### PR TITLE
移除run.sh中pip安装命令

### DIFF
--- a/inference/python_api_test/run.sh
+++ b/inference/python_api_test/run.sh
@@ -1,6 +1,5 @@
 home=$PWD
 # base
-python -m pip install -r requirements.txt
 cd test_class_model
 rm -rf ./result.txt
 echo "[class model inference cases result]" >> result.txt


### PR DESCRIPTION
- 移除run.sh中的pip安装命令，迁移至ci脚本中安装，提升兼容性