### PR TITLE
移除pytest安装脚本

### DIFF
--- a/inference/python_api_test/test_class_model/run.sh
+++ b/inference/python_api_test/test_class_model/run.sh
@@ -1,4 +1,3 @@
-python -m pip install pytest
 export FLAGS_call_stack_level=2
 cases=`find . -name "test*.py" | sort`
 ignore=""


### PR DESCRIPTION
- 移除inference/python_api_test/test_class_model下run.sh中的pytest安装指令