### PR TITLE
修复gpu返回str问题

### DIFF
--- a/inference/python_api_test/run.sh
+++ b/inference/python_api_test/run.sh
@@ -1,6 +1,5 @@
 home=$PWD
 # base
-python -m pip install -r requirements.txt
 cd test_class_model
 rm -rf ./result.txt
 echo "[class model inference cases result]" >> result.txt

--- a/inference/python_api_test/test_case/infer_test.py
+++ b/inference/python_api_test/test_case/infer_test.py
@@ -114,7 +114,7 @@ class InferenceTest(object):
 
         cuda_visible_devices = os.environ.get("CUDA_VISIBLE_DEVICES")
         if cuda_visible_devices:
-            cuda_visible_device = cuda_visible_devices.split(",")[0]
+            cuda_visible_device = int(cuda_visible_devices.split(",")[0])
         else:
             cuda_visible_device = 0
 

--- a/inference/python_api_test/test_class_model/run.sh
+++ b/inference/python_api_test/test_class_model/run.sh
@@ -1,4 +1,3 @@
-python -m pip install pytest
 export FLAGS_call_stack_level=2
 cases=`find . -name "test*.py" | sort`
 ignore=""
@@ -11,7 +10,7 @@ do
     if [[ ${ignore} =~ ${file##*/} ]]; then
         echo "跳过"
     else
-        python3.7 -m pytest ${file}
+        python -m pytest ${file}
         if [ $? -ne 0 ]; then
             echo ${file} >> result.txt
             bug=`expr ${bug} + 1`


### PR DESCRIPTION
- 调用系统GPU号返回值为str，如果更改默认选项卡则会触发问题，现修改为int类型