### PR TITLE
添加推理库竞品性能case

### DIFF
--- a/inference/benchmark/python/torch/clas_benchmark.py
+++ b/inference/benchmark/python/torch/clas_benchmark.py
@@ -1,3 +1,7 @@
+"""
+# -*- coding: utf-8 -*-
+# encoding=utf-8 vi:ts=4:sw=4:expandtab:ft=python
+"""
 import argparse
 import logging
 import os
@@ -6,62 +10,77 @@ import time
 
 import cv2
 import torch
-import torchvision
 import trtorch
-import torch.nn as nn
 import torchvision.models as models
 
-FORMAT = '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+FORMAT = "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
 logging.basicConfig(level=logging.INFO, format=FORMAT)
 logger = logging.getLogger(__name__)
 
-class Predictor(nn.Module):
+
+class Predictor(torch.nn.Module):
+    """
+    python inference model
+    """
+
     def __init__(self):
+        """
+        model name
+        """
         super().__init__()
 
         args = parse_args()
-        if args.model_name == 'resnet50':
+        if args.model_name == "resnet50":
             self.model = models.alexnet(pretrained=True).eval()
-        elif args.model_name == 'resnet101':
+        elif args.model_name == "resnet101":
             self.model = models.resnet101(pretrained=True).eval()
-        elif args.model_name == 'alexnet':
+        elif args.model_name == "alexnet":
             self.model = models.alexnet(pretrained=True).eval()
-        elif args.model_name == 'vgg16':
+        elif args.model_name == "vgg16":
             self.model = models.vgg16(pretrained=True).eval()
-        elif args.model_name == 'squeezenet1_0':
+        elif args.model_name == "squeezenet1_0":
             self.model = models.squeezenet1_0(pretrained=True).eval()
-        elif args.model_name == 'inception_v3':
+        elif args.model_name == "inception_v3":
             self.model = models.inception_v3(pretrained=True).eval()
-        elif args.model_name == 'mobilenet_v2':
+        elif args.model_name == "mobilenet_v2":
             self.model = models.mobilenet_v2(pretrained=True).eval()
         else:
-            raise Exception('net type [%s] invalid! \
-                        \n please specify corret model_name' % args.model_name)
+            raise Exception(
+                "net type [%s] invalid! \
+                        \n please specify corret model_name"
+                % args.model_name
+            )
 
     def forward(self, x):
+        """
+        model forward inference
+        Args:
+            x: input
+        Returns:
+            y_pred: output
+        """
         with torch.no_grad():
             y_pred = self.model(x)
             return y_pred
 
 
 def parse_args():
-    """[summary]
-    Returns:
-        [type]: [description]
+    """
+    Args input
+    Returns: Args
     """
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         "--model_name",
         type=str,
         default="resnet50",
-        choices = ['resnet50', 'resnet101', 'alexnet', 'vgg16', 'squeezenet1_0','inception_v3', 'mobilenet_v2'])
+        choices=["resnet50", "resnet101", "alexnet", "vgg16", "squeezenet1_0", "inception_v3", "mobilenet_v2"],
+    )
     parser.add_argument(
-        "--trt_precision",
-        type=str,
-        default="fp32",
-        help="trt precision, choice = ['fp32', 'fp16', 'int8']")
-    parser.add_argument("--device", default="gpu" ,type=str, choices = ['gpu', 'cpu'])
-    parser.add_argument("--use_trt", dest="use_trt", action='store_true')
+        "--trt_precision", type=str, default="fp32", help="trt precision, choice = ['fp32', 'fp16', 'int8']"
+    )
+    parser.add_argument("--device", default="gpu", type=str, choices=["gpu", "cpu"])
+    parser.add_argument("--use_trt", dest="use_trt", action="store_true")
     parser.add_argument("--batch_size", type=int, default=1, help="batch size")
     parser.add_argument("--warmup_times", type=int, default=5, help="warmup")
     parser.add_argument("--repeats", type=int, default=1000, help="repeats")
@@ -69,6 +88,13 @@ def parse_args():
 
 
 def forward_benchmark(args):
+    """
+    forward inference
+    Args:
+        args
+    Returns:
+        infernce benchmark time
+    """
 
     image_tensor = torch.randn((1, 3, 224, 224)).to("cuda")
     logger.info("input image tensor shape : {}".format(image_tensor.shape))
@@ -90,10 +116,18 @@ def forward_benchmark(args):
             output = predictor(image_tensor)
         time2 = time.time()
         total_inference_cost = (time2 - time1) * 1000  # total latency, ms
-    return total_inference_cost
+    return total_inference_cost, output
 
 
 def trt_benchmark(args):
+    """
+    trt forward inference
+    Args:
+        args
+    Returns:
+        infernce trt benchmark time
+    """
+
     # Compile module
     predictor = Predictor()
     device = torch.device("cuda:0")
@@ -102,10 +136,9 @@ def trt_benchmark(args):
     traced_model = torch.jit.trace(predictor.to(device), [image_tensor]).to(device)
 
     # Compile module
-    compiled_trt_model = trtorch.compile(traced_model, {
-        "input_shapes": [image_tensor.shape],
-        "op_precision": torch.half, # Run in FP16
-    })
+    compiled_trt_model = trtorch.compile(
+        traced_model, {"input_shapes": [image_tensor.shape], "op_precision": torch.half}  # Run in FP16
+    )
     for i in range(args.warmup_times):
         results = compiled_trt_model(image_tensor.half())
     time1 = time.time()
@@ -113,7 +146,7 @@ def trt_benchmark(args):
         results = compiled_trt_model(image_tensor.half())
     time2 = time.time()
     total_inference_cost = (time2 - time1) * 1000  # total latency, ms
-    return total_inference_cost
+    return total_inference_cost, results
 
 
 def summary_config(args, infer_time: float):
@@ -123,20 +156,21 @@ def summary_config(args, infer_time: float):
         infer_time : inference time
     """
     logger.info("----------------------- Model info ----------------------")
-    logger.info("Model name: {0}, Model type: {1}".format("alexnet",
-                                                          "torch_model"))
+    logger.info("Model name: {0}, Model type: {1}".format("alexnet", "torch_model"))
     logger.info("----------------------- Data info -----------------------")
-    logger.info("Batch size: {0}, Num of samples: {1}".format(args.batch_size,
-                                                              args.repeats))
+    logger.info("Batch size: {0}, Num of samples: {1}".format(args.batch_size, args.repeats))
     logger.info("----------------------- Conf info -----------------------")
     logger.info("device: {0}".format(args.device))
-    if (args.use_trt):
+    if args.use_trt:
         logger.info("enable_tensorrt: {0}".format(args.use_trt))
         logger.info("trt_precision: {0}".format(args.trt_precision))
     logger.info("----------------------- Perf info -----------------------")
-    logger.info("Average latency(ms): {0}, QPS: {1}".format(
-        infer_time / args.repeats, (args.repeats * args.batch_size) / (
-            infer_time / 1000)))
+    logger.info(
+        "Average latency(ms): {0}, QPS: {1}".format(
+            infer_time / args.repeats, (args.repeats * args.batch_size) / (infer_time / 1000)
+        )
+    )
+
 
 def run_demo():
     """
@@ -144,10 +178,11 @@ def run_demo():
     """
     args = parse_args()
     if args.use_trt:
-        total_time = trt_benchmark(args)
+        total_time = trt_benchmark(args)[0]
     else:
-        total_time = forward_benchmark(args)
+        total_time = forward_benchmark(args)[0]
     summary_config(args, total_time)
+
 
 if __name__ == "__main__":
     run_demo()

--- a/inference/benchmark/python/torch/clas_benchmark.py
+++ b/inference/benchmark/python/torch/clas_benchmark.py
@@ -1,0 +1,153 @@
+import argparse
+import logging
+import os
+import sys
+import time
+
+import cv2
+import torch
+import torchvision
+import trtorch
+import torch.nn as nn
+import torchvision.models as models
+
+FORMAT = '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+logging.basicConfig(level=logging.INFO, format=FORMAT)
+logger = logging.getLogger(__name__)
+
+class Predictor(nn.Module):
+    def __init__(self):
+        super().__init__()
+
+        args = parse_args()
+        if args.model_name == 'resnet50':
+            self.model = models.alexnet(pretrained=True).eval()
+        elif args.model_name == 'resnet101':
+            self.model = models.resnet101(pretrained=True).eval()
+        elif args.model_name == 'alexnet':
+            self.model = models.alexnet(pretrained=True).eval()
+        elif args.model_name == 'vgg16':
+            self.model = models.vgg16(pretrained=True).eval()
+        elif args.model_name == 'squeezenet1_0':
+            self.model = models.squeezenet1_0(pretrained=True).eval()
+        elif args.model_name == 'inception_v3':
+            self.model = models.inception_v3(pretrained=True).eval()
+        elif args.model_name == 'mobilenet_v2':
+            self.model = models.mobilenet_v2(pretrained=True).eval()
+        else:
+            raise Exception('net type [%s] invalid! \
+                        \n please specify corret model_name' % args.model_name)
+
+    def forward(self, x):
+        with torch.no_grad():
+            y_pred = self.model(x)
+            return y_pred
+
+
+def parse_args():
+    """[summary]
+    Returns:
+        [type]: [description]
+    """
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--model_name",
+        type=str,
+        default="resnet50",
+        choices = ['resnet50', 'resnet101', 'alexnet', 'vgg16', 'squeezenet1_0','inception_v3', 'mobilenet_v2'])
+    parser.add_argument(
+        "--trt_precision",
+        type=str,
+        default="fp32",
+        help="trt precision, choice = ['fp32', 'fp16', 'int8']")
+    parser.add_argument("--device", default="gpu" ,type=str, choices = ['gpu', 'cpu'])
+    parser.add_argument("--use_trt", dest="use_trt", action='store_true')
+    parser.add_argument("--batch_size", type=int, default=1, help="batch size")
+    parser.add_argument("--warmup_times", type=int, default=5, help="warmup")
+    parser.add_argument("--repeats", type=int, default=1000, help="repeats")
+    return parser.parse_args()
+
+
+def forward_benchmark(args):
+
+    image_tensor = torch.randn((1, 3, 224, 224)).to("cuda")
+    logger.info("input image tensor shape : {}".format(image_tensor.shape))
+    # set running device on
+    predictor = Predictor()
+    if args.device == "gpu":
+        device = torch.device("cuda:0")
+    else:
+        device = torch.device("cpu")
+    image_tensor = image_tensor.to(device)
+    predictor = torch.jit.script(predictor).to(device)
+    with torch.no_grad():
+        # warm up
+        for i in range(args.warmup_times):
+            output = predictor(image_tensor)
+
+        time1 = time.time()
+        for i in range(args.repeats):
+            output = predictor(image_tensor)
+        time2 = time.time()
+        total_inference_cost = (time2 - time1) * 1000  # total latency, ms
+    return total_inference_cost
+
+
+def trt_benchmark(args):
+    # Compile module
+    predictor = Predictor()
+    device = torch.device("cuda:0")
+    image_tensor = torch.randn((1, 3, 224, 224)).to(device)
+    # Trace the module with example data
+    traced_model = torch.jit.trace(predictor.to(device), [image_tensor]).to(device)
+
+    # Compile module
+    compiled_trt_model = trtorch.compile(traced_model, {
+        "input_shapes": [image_tensor.shape],
+        "op_precision": torch.half, # Run in FP16
+    })
+    for i in range(args.warmup_times):
+        results = compiled_trt_model(image_tensor.half())
+    time1 = time.time()
+    for i in range(args.repeats):
+        results = compiled_trt_model(image_tensor.half())
+    time2 = time.time()
+    total_inference_cost = (time2 - time1) * 1000  # total latency, ms
+    return total_inference_cost
+
+
+def summary_config(args, infer_time: float):
+    """
+    Args:
+        args : input args
+        infer_time : inference time
+    """
+    logger.info("----------------------- Model info ----------------------")
+    logger.info("Model name: {0}, Model type: {1}".format("alexnet",
+                                                          "torch_model"))
+    logger.info("----------------------- Data info -----------------------")
+    logger.info("Batch size: {0}, Num of samples: {1}".format(args.batch_size,
+                                                              args.repeats))
+    logger.info("----------------------- Conf info -----------------------")
+    logger.info("device: {0}".format(args.device))
+    if (args.use_trt):
+        logger.info("enable_tensorrt: {0}".format(args.use_trt))
+        logger.info("trt_precision: {0}".format(args.trt_precision))
+    logger.info("----------------------- Perf info -----------------------")
+    logger.info("Average latency(ms): {0}, QPS: {1}".format(
+        infer_time / args.repeats, (args.repeats * args.batch_size) / (
+            infer_time / 1000)))
+
+def run_demo():
+    """
+    run_demo
+    """
+    args = parse_args()
+    if args.use_trt:
+        total_time = trt_benchmark(args)
+    else:
+        total_time = forward_benchmark(args)
+    summary_config(args, total_time)
+
+if __name__ == "__main__":
+    run_demo()

--- a/inference/benchmark/python/torch/seg_benchmark.py
+++ b/inference/benchmark/python/torch/seg_benchmark.py
@@ -1,3 +1,7 @@
+"""
+# -*- coding: utf-8 -*-
+# encoding=utf-8 vi:ts=4:sw=4:expandtab:ft=python
+"""
 import argparse
 import logging
 import os
@@ -6,52 +10,62 @@ import time
 
 import cv2
 import torch
-import torchvision
 import trtorch
-import torch.nn as nn
 import torchvision.models as models
 
-FORMAT = '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+FORMAT = "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
 logging.basicConfig(level=logging.INFO, format=FORMAT)
 logger = logging.getLogger(__name__)
 
-class Predictor(nn.Module):
+
+class Predictor(torch.nn.Module):
+    """
+    python inference model
+    """
+
     def __init__(self):
+        """
+        model name
+        """
         super().__init__()
 
         args = parse_args()
-        if args.model_name == 'deeplabv3_resnet50':
+        if args.model_name == "deeplabv3_resnet50":
             self.model = models.segmentation.deeplabv3_resnet50(pretrained=True).eval()
-        elif args.model_name == 'unet':
+        elif args.model_name == "unet":
             self.model = models.segmentation.unet(pretrained=True).eval()
         else:
-            raise Exception('net type [%s] invalid! \
-                        \n please specify corret model_name' % args.model_name)
+            raise Exception(
+                "net type [%s] invalid! \
+                        \n please specify corret model_name"
+                % args.model_name
+            )
 
     def forward(self, x):
+        """
+        model forward inference
+        Args:
+            x: input
+        Returns:
+            y_pred: output
+        """
         with torch.no_grad():
             y_pred = self.model(x)
             return y_pred
 
 
 def parse_args():
-    """[summary]
-    Returns:
-        [type]: [description]
+    """
+    Args input
+    Returns: Args
     """
     parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--model_name", type=str, default="deeplabv3_resnet50", choices=["deeplabv3_resnet50", "unet"])
     parser.add_argument(
-        "--model_name",
-        type=str,
-        default="deeplabv3_resnet50",
-        choices = ['deeplabv3_resnet50', 'unet'])
-    parser.add_argument(
-        "--trt_precision",
-        type=str,
-        default="fp32",
-        help="trt precision, choice = ['fp32', 'fp16', 'int8']")
-    parser.add_argument("--device", default="gpu" ,type=str, choices = ['gpu', 'cpu'])
-    parser.add_argument("--use_trt", dest="use_trt", action='store_true')
+        "--trt_precision", type=str, default="fp32", help="trt precision, choice = ['fp32', 'fp16', 'int8']"
+    )
+    parser.add_argument("--device", default="gpu", type=str, choices=["gpu", "cpu"])
+    parser.add_argument("--use_trt", dest="use_trt", action="store_true")
     parser.add_argument("--batch_size", type=int, default=1, help="batch size")
     parser.add_argument("--warmup_times", type=int, default=5, help="warmup")
     parser.add_argument("--repeats", type=int, default=1000, help="repeats")
@@ -59,6 +73,13 @@ def parse_args():
 
 
 def forward_benchmark(args):
+    """
+    forward inference
+    Args:
+        args
+    Returns:
+        infernce benchmark time
+    """
 
     image_tensor = torch.randn((1, 3, 224, 224)).to("cuda")
     logger.info("input image tensor shape : {}".format(image_tensor.shape))
@@ -80,10 +101,17 @@ def forward_benchmark(args):
             output = predictor(image_tensor)
         time2 = time.time()
         total_inference_cost = (time2 - time1) * 1000  # total latency, ms
-    return total_inference_cost
+    return total_inference_cost, output
 
 
 def trt_benchmark(args):
+    """
+    trt forward inference
+    Args:
+        args
+    Returns:
+        infernce trt benchmark time
+    """
     # Compile module
     predictor = Predictor()
     device = torch.device("cuda:0")
@@ -92,10 +120,9 @@ def trt_benchmark(args):
     traced_model = torch.jit.trace(predictor.to(device), [image_tensor]).to(device)
 
     # Compile module
-    compiled_trt_model = trtorch.compile(traced_model, {
-        "input_shapes": [image_tensor.shape],
-        "op_precision": torch.half, # Run in FP16
-    })
+    compiled_trt_model = trtorch.compile(
+        traced_model, {"input_shapes": [image_tensor.shape], "op_precision": torch.half}  # Run in FP16
+    )
     for i in range(args.warmup_times):
         results = compiled_trt_model(image_tensor.half())
     time1 = time.time()
@@ -103,7 +130,7 @@ def trt_benchmark(args):
         results = compiled_trt_model(image_tensor.half())
     time2 = time.time()
     total_inference_cost = (time2 - time1) * 1000  # total latency, ms
-    return total_inference_cost
+    return total_inference_cost, results
 
 
 def summary_config(args, infer_time: float):
@@ -113,20 +140,21 @@ def summary_config(args, infer_time: float):
         infer_time : inference time
     """
     logger.info("----------------------- Model info ----------------------")
-    logger.info("Model name: {0}, Model type: {1}".format("alexnet",
-                                                          "torch_model"))
+    logger.info("Model name: {0}, Model type: {1}".format("alexnet", "torch_model"))
     logger.info("----------------------- Data info -----------------------")
-    logger.info("Batch size: {0}, Num of samples: {1}".format(args.batch_size,
-                                                              args.repeats))
+    logger.info("Batch size: {0}, Num of samples: {1}".format(args.batch_size, args.repeats))
     logger.info("----------------------- Conf info -----------------------")
     logger.info("device: {0}".format(args.device))
-    if (args.use_trt):
+    if args.use_trt:
         logger.info("enable_tensorrt: {0}".format(args.use_trt))
         logger.info("trt_precision: {0}".format(args.trt_precision))
     logger.info("----------------------- Perf info -----------------------")
-    logger.info("Average latency(ms): {0}, QPS: {1}".format(
-        infer_time / args.repeats, (args.repeats * args.batch_size) / (
-            infer_time / 1000)))
+    logger.info(
+        "Average latency(ms): {0}, QPS: {1}".format(
+            infer_time / args.repeats, (args.repeats * args.batch_size) / (infer_time / 1000)
+        )
+    )
+
 
 def run_demo():
     """
@@ -134,10 +162,11 @@ def run_demo():
     """
     args = parse_args()
     if args.use_trt:
-        total_time = trt_benchmark(args)
+        total_time = trt_benchmark(args)[0]
     else:
-        total_time = forward_benchmark(args)
+        total_time = forward_benchmark(args)[0]
     summary_config(args, total_time)
+
 
 if __name__ == "__main__":
     run_demo()

--- a/inference/benchmark/python/torch/seg_benchmark.py
+++ b/inference/benchmark/python/torch/seg_benchmark.py
@@ -1,0 +1,143 @@
+import argparse
+import logging
+import os
+import sys
+import time
+
+import cv2
+import torch
+import torchvision
+import trtorch
+import torch.nn as nn
+import torchvision.models as models
+
+FORMAT = '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+logging.basicConfig(level=logging.INFO, format=FORMAT)
+logger = logging.getLogger(__name__)
+
+class Predictor(nn.Module):
+    def __init__(self):
+        super().__init__()
+
+        args = parse_args()
+        if args.model_name == 'deeplabv3_resnet50':
+            self.model = models.segmentation.deeplabv3_resnet50(pretrained=True).eval()
+        elif args.model_name == 'unet':
+            self.model = models.segmentation.unet(pretrained=True).eval()
+        else:
+            raise Exception('net type [%s] invalid! \
+                        \n please specify corret model_name' % args.model_name)
+
+    def forward(self, x):
+        with torch.no_grad():
+            y_pred = self.model(x)
+            return y_pred
+
+
+def parse_args():
+    """[summary]
+    Returns:
+        [type]: [description]
+    """
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--model_name",
+        type=str,
+        default="deeplabv3_resnet50",
+        choices = ['deeplabv3_resnet50', 'unet'])
+    parser.add_argument(
+        "--trt_precision",
+        type=str,
+        default="fp32",
+        help="trt precision, choice = ['fp32', 'fp16', 'int8']")
+    parser.add_argument("--device", default="gpu" ,type=str, choices = ['gpu', 'cpu'])
+    parser.add_argument("--use_trt", dest="use_trt", action='store_true')
+    parser.add_argument("--batch_size", type=int, default=1, help="batch size")
+    parser.add_argument("--warmup_times", type=int, default=5, help="warmup")
+    parser.add_argument("--repeats", type=int, default=1000, help="repeats")
+    return parser.parse_args()
+
+
+def forward_benchmark(args):
+
+    image_tensor = torch.randn((1, 3, 224, 224)).to("cuda")
+    logger.info("input image tensor shape : {}".format(image_tensor.shape))
+    # set running device on
+    predictor = Predictor()
+    if args.device == "gpu":
+        device = torch.device("cuda:0")
+    else:
+        device = torch.device("cpu")
+    image_tensor = image_tensor.to(device)
+    predictor = torch.jit.script(predictor).to(device)
+    with torch.no_grad():
+        # warm up
+        for i in range(args.warmup_times):
+            output = predictor(image_tensor)
+
+        time1 = time.time()
+        for i in range(args.repeats):
+            output = predictor(image_tensor)
+        time2 = time.time()
+        total_inference_cost = (time2 - time1) * 1000  # total latency, ms
+    return total_inference_cost
+
+
+def trt_benchmark(args):
+    # Compile module
+    predictor = Predictor()
+    device = torch.device("cuda:0")
+    image_tensor = torch.randn((1, 3, 224, 224)).to(device)
+    # Trace the module with example data
+    traced_model = torch.jit.trace(predictor.to(device), [image_tensor]).to(device)
+
+    # Compile module
+    compiled_trt_model = trtorch.compile(traced_model, {
+        "input_shapes": [image_tensor.shape],
+        "op_precision": torch.half, # Run in FP16
+    })
+    for i in range(args.warmup_times):
+        results = compiled_trt_model(image_tensor.half())
+    time1 = time.time()
+    for i in range(args.repeats):
+        results = compiled_trt_model(image_tensor.half())
+    time2 = time.time()
+    total_inference_cost = (time2 - time1) * 1000  # total latency, ms
+    return total_inference_cost
+
+
+def summary_config(args, infer_time: float):
+    """
+    Args:
+        args : input args
+        infer_time : inference time
+    """
+    logger.info("----------------------- Model info ----------------------")
+    logger.info("Model name: {0}, Model type: {1}".format("alexnet",
+                                                          "torch_model"))
+    logger.info("----------------------- Data info -----------------------")
+    logger.info("Batch size: {0}, Num of samples: {1}".format(args.batch_size,
+                                                              args.repeats))
+    logger.info("----------------------- Conf info -----------------------")
+    logger.info("device: {0}".format(args.device))
+    if (args.use_trt):
+        logger.info("enable_tensorrt: {0}".format(args.use_trt))
+        logger.info("trt_precision: {0}".format(args.trt_precision))
+    logger.info("----------------------- Perf info -----------------------")
+    logger.info("Average latency(ms): {0}, QPS: {1}".format(
+        infer_time / args.repeats, (args.repeats * args.batch_size) / (
+            infer_time / 1000)))
+
+def run_demo():
+    """
+    run_demo
+    """
+    args = parse_args()
+    if args.use_trt:
+        total_time = trt_benchmark(args)
+    else:
+        total_time = forward_benchmark(args)
+    summary_config(args, total_time)
+
+if __name__ == "__main__":
+    run_demo()

--- a/inference/python_api_test/test_det_model/run.sh
+++ b/inference/python_api_test/test_det_model/run.sh
@@ -1,10 +1,8 @@
 export FLAGS_call_stack_level=2
 cases="test_yolov3_gpu.py \
        test_yolov3_mkldnn.py \
-       test_ppyolov2_trt_fp32.py \
        test_ppyolo_gpu.py \
        test_ppyolo_mkldnn.py \
-       test_ppyolov2_gpu.py \
        test_ppyolov2_mkldnn.py \
        test_solov2_gpu.py \
        test_solov2_mkldnn.py"


### PR DESCRIPTION
* 添加torch分类模型，覆盖resnet50，resnet101，alexnet，vgg16，squeezenet1_0，inception_v3，mobilenet_v2 模型
* 添加torch分割模型，覆盖 deeplabv3p，unet模型
* 支持torch-tensorrt和原生性能推理