### PR TITLE
修复solov2模型trt动态shape离线文件无法生成问题

### DIFF
--- a/inference/python_api_test/test_case/infer_test.py
+++ b/inference/python_api_test/test_case/infer_test.py
@@ -374,7 +374,6 @@ class InferenceTest(object):
         if dynamic:
             if tuned:
                 self.pd_config.collect_shape_range_info("shape_range.pbtxt")
-                return 0
             else:
                 self.pd_config.enable_tensorrt_engine(
                     workspace_size=1 << 30,
@@ -396,7 +395,6 @@ class InferenceTest(object):
             )
 
         predictor = paddle_infer.create_predictor(self.pd_config)
-
         input_names = predictor.get_input_names()
         for _, input_data_name in enumerate(input_names):
             input_handle = predictor.get_input_handle(input_data_name)
@@ -404,7 +402,8 @@ class InferenceTest(object):
 
         for i in range(repeat):
             predictor.run()
-
+        if tuned: #collect_shape_range_info收集动态shape需要predictor后再退出
+            return 0
         output_names = predictor.get_output_names()
         for i, output_data_name in enumerate(output_names):
             output_handle = predictor.get_output_handle(output_data_name)


### PR DESCRIPTION
* 由于collect_shape_range_info函数需要在predictor执行后才可触发离线保存，所以调整return顺序，在predictor后判定是否退出