### PR TITLE
修复paddlenlp多线程触发bug,test=linux_inference_ci

### DIFF
--- a/inference/python_api_test/test_case/text_preprocess.py
+++ b/inference/python_api_test/test_case/text_preprocess.py
@@ -3,8 +3,6 @@
 """
 text preprocess
 """
-import paddlenlp as ppnlp
-
 
 def ernie_data(data_path):
     """
@@ -14,6 +12,7 @@ def ernie_data(data_path):
     Returns:
        examples(list): array in list
     """
+    import paddlenlp as ppnlp # 仅nlp case会触发载入
     max_seq_length = 128
     examples = []
     with open(data_path, "r", encoding="utf-8") as f:

--- a/inference/python_api_test/test_case/text_preprocess.py
+++ b/inference/python_api_test/test_case/text_preprocess.py
@@ -4,6 +4,7 @@
 text preprocess
 """
 
+
 def ernie_data(data_path):
     """
     ernie data text to list(array).
@@ -13,6 +14,7 @@ def ernie_data(data_path):
        examples(list): array in list
     """
     import paddlenlp as ppnlp  # 仅nlp case会触发载入
+    
     max_seq_length = 128
     examples = []
     with open(data_path, "r", encoding="utf-8") as f:

--- a/inference/python_api_test/test_case/text_preprocess.py
+++ b/inference/python_api_test/test_case/text_preprocess.py
@@ -12,7 +12,7 @@ def ernie_data(data_path):
     Returns:
        examples(list): array in list
     """
-    import paddlenlp as ppnlp # 仅nlp case会触发载入
+    import paddlenlp as ppnlp  # 仅nlp case会触发载入
     max_seq_length = 128
     examples = []
     with open(data_path, "r", encoding="utf-8") as f:

--- a/inference/python_api_test/test_case/text_preprocess.py
+++ b/inference/python_api_test/test_case/text_preprocess.py
@@ -14,7 +14,6 @@ def ernie_data(data_path):
        examples(list): array in list
     """
     import paddlenlp as ppnlp  # 仅nlp case会触发载入
-    
     max_seq_length = 128
     examples = []
     with open(data_path, "r", encoding="utf-8") as f:


### PR DESCRIPTION
* paddlenlp依赖库载入迁移至函数中，确保非nlp载入paddlenlp库而导致多线程问题