### PR TITLE
[Eager] Roll back legacy for fused_feedforward

### DIFF
--- a/framework/api/incubate/test_FusedFeedForward.py
+++ b/framework/api/incubate/test_FusedFeedForward.py
@@ -10,6 +10,7 @@ import paddle
 import pytest
 import numpy as np
 from paddle.fluid.framework import _enable_legacy_dygraph
+
 _enable_legacy_dygraph()
 
 sys.path.append("../../utils/")

--- a/framework/api/incubate/test_FusedFeedForward.py
+++ b/framework/api/incubate/test_FusedFeedForward.py
@@ -9,6 +9,8 @@ from apibase import APIBase
 import paddle
 import pytest
 import numpy as np
+from paddle.fluid.framework import _enable_legacy_dygraph
+_enable_legacy_dygraph()
 
 sys.path.append("../../utils/")
 from interceptor import skip_not_compile_gpu

--- a/framework/api/incubate/test_fused_feedforward.py
+++ b/framework/api/incubate/test_fused_feedforward.py
@@ -10,6 +10,8 @@ from apibase import APIBase
 import paddle
 import pytest
 import numpy as np
+from paddle.fluid.framework import _enable_legacy_dygraph
+_enable_legacy_dygraph()
 
 sys.path.append("../../utils/")
 from interceptor import skip_not_compile_gpu

--- a/framework/api/incubate/test_fused_feedforward.py
+++ b/framework/api/incubate/test_fused_feedforward.py
@@ -11,6 +11,7 @@ import paddle
 import pytest
 import numpy as np
 from paddle.fluid.framework import _enable_legacy_dygraph
+
 _enable_legacy_dygraph()
 
 sys.path.append("../../utils/")


### PR DESCRIPTION
Make sure fused_feedforward related tests run in legacy dygraph.