### PR TITLE
[Eager] Add -sv for pytest to print msg

### DIFF
--- a/framework/api/multithreading_case.py
+++ b/framework/api/multithreading_case.py
@@ -68,11 +68,11 @@ def runCETest(params):
     path = params[0]
     case = params[1]
     print("case: %s" % case)
-    val = os.system("export FLAGS_call_stack_level= && cd %s && python3.7 -m pytest %s" % (path, case))
+    val = os.system("export FLAGS_call_stack_level= && cd %s && python3.7 -m pytest -sv %s" % (path, case))
     retry_count = 0
     final_result = ""
     while val != 0:
-        val = os.system("export FLAGS_call_stack_level=2 && cd %s && python3.7 -m pytest %s" % (path, case))
+        val = os.system("export FLAGS_call_stack_level=2 && cd %s && python3.7 -m pytest -sv %s" % (path, case))
         retry_count = retry_count + 1
         if retry_count > 2:
             val = 0


### PR DESCRIPTION
临时对 pytest 增加 -sv 配置，打印单测中 print() 的信息，用于验证新增的 CE-Framework-ci-test 流水线在切换 eager 后是否生效，验证完毕后，再提个 PR 去除 -sv 配置。