### PR TITLE
[Eager] Make sure test case work under eager mode

### DIFF
--- a/framework/api/incubate/test_Hessian.py
+++ b/framework/api/incubate/test_Hessian.py
@@ -137,6 +137,7 @@ def test_Hessian4():
     x: 2-d tensor
     single_input
     """
+    paddle.fluid.set_flags({"FLAGS_retain_grad_for_all_tensor": True})
     x = np.random.rand(4, 3)
     paddle.disable_static()
     res = ans.numerical_hessian(func2, paddle.to_tensor(x, dtype="float64"), is_batched=True)
@@ -144,3 +145,4 @@ def test_Hessian4():
     obj.static = False
     obj.enable_backward = False
     obj.run(res=res, func=func2, inputs=x, is_batched=True)
+    paddle.fluid.set_flags({"FLAGS_retain_grad_for_all_tensor": False})

--- a/framework/api/incubate/test_jvp.py
+++ b/framework/api/incubate/test_jvp.py
@@ -79,10 +79,12 @@ def test_jvp_base():
     x: 1-d tensor
     single_input and single_output
     """
+    paddle.fluid.set_flags({"FLAGS_retain_grad_for_all_tensor": True})
     x = np.random.rand(2)
     paddle.disable_static()
     res = ans.jvp_with_jac(func0, paddle.to_tensor(x))
     obj.base(res=res.numpy(), func=func0, xs=x)
+    paddle.fluid.set_flags({"FLAGS_retain_grad_for_all_tensor": False})
 
 
 @pytest.mark.api_incubate_jvp_parameters
@@ -91,10 +93,12 @@ def test_jvp1():
     x: 2-d tensor
     single_input and single_output
     """
+    paddle.fluid.set_flags({"FLAGS_retain_grad_for_all_tensor": True})
     x = np.array([[1.0, 2.0], [3.0, 4.0]])
     paddle.disable_static()
     res = ans.jvp_with_jac(func0, paddle.to_tensor(x))
     obj.run(res=res.numpy(), func=func0, xs=x)
+    paddle.fluid.set_flags({"FLAGS_retain_grad_for_all_tensor": False})
 
 
 @pytest.mark.api_incubate_jvp_parameters
@@ -104,11 +108,13 @@ def test_jvp2():
     single_input and single_output
     set v
     """
+    paddle.fluid.set_flags({"FLAGS_retain_grad_for_all_tensor": True})
     x = np.array([[1.0, 2.0], [3.0, 4.0]])
     v = np.random.rand(2, 2)
     paddle.disable_static()
     res = ans.jvp_with_jac(func0, paddle.to_tensor(x), v=paddle.to_tensor(v))
     obj.run(res=res.numpy(), func=func0, xs=x, v=v)
+    paddle.fluid.set_flags({"FLAGS_retain_grad_for_all_tensor": False})
 
 
 @pytest.mark.api_incubate_jvp_parameters
@@ -160,10 +166,12 @@ def test_jvp6():
     x: 2-d tensor
     single_input and multi_output
     """
+    paddle.fluid.set_flags({"FLAGS_retain_grad_for_all_tensor": True})
     x = np.random.rand(3, 3)
     paddle.disable_static()
     res = ans.jvp_with_jac(func2, paddle.to_tensor(x))
     obj.run(res=res.numpy(), func=func2, xs=x)
+    paddle.fluid.set_flags({"FLAGS_retain_grad_for_all_tensor": False})
 
 
 @pytest.mark.api_incubate_jvp_parameters
@@ -173,11 +181,13 @@ def test_jvp7():
     single_input and multi_output
     set v
     """
+    paddle.fluid.set_flags({"FLAGS_retain_grad_for_all_tensor": True})
     x = np.random.rand(3, 3)
     v = np.random.rand(3, 3)
     paddle.disable_static()
     res = ans.jvp_with_jac(func2, paddle.to_tensor(x), v=paddle.to_tensor(v))
     obj.run(res=res.numpy(), func=func2, xs=x, v=v)
+    paddle.fluid.set_flags({"FLAGS_retain_grad_for_all_tensor": False})
 
 
 @pytest.mark.api_incubate_jvp_parameters
@@ -186,11 +196,13 @@ def test_jvp8():
     x: 2-d tensor
     multi_input and multi_output
     """
+    paddle.fluid.set_flags({"FLAGS_retain_grad_for_all_tensor": True})
     x = np.random.rand(3, 3)
     y = np.random.rand(3, 3)
     paddle.disable_static()
     res = ans.jvp_with_jac(func3, [paddle.to_tensor(x), paddle.to_tensor(y)])
     obj.run(res=res.numpy(), func=func3, xs=[x, y])
+    paddle.fluid.set_flags({"FLAGS_retain_grad_for_all_tensor": False})
 
 
 @pytest.mark.api_incubate_jvp_parameters
@@ -200,6 +212,7 @@ def test_jvp9():
     multi_input and multi_output
     set v
     """
+    paddle.fluid.set_flags({"FLAGS_retain_grad_for_all_tensor": True})
     x = np.random.rand(4, 4)
     v1 = np.random.rand(4, 4)
     paddle.disable_static()
@@ -207,3 +220,4 @@ def test_jvp9():
         func3, [paddle.to_tensor(x), paddle.to_tensor(x)], v=[paddle.to_tensor(v1), paddle.to_tensor(v1)]
     )
     obj.run(res=res.numpy(), func=func3, xs=[x, x], v=[v1, v1])
+    paddle.fluid.set_flags({"FLAGS_retain_grad_for_all_tensor": False})

--- a/framework/api/incubate/test_vjp.py
+++ b/framework/api/incubate/test_vjp.py
@@ -169,11 +169,13 @@ def test_vjp7():
     x: 2-d tensor
     multi_input and multi_output
     """
+    paddle.fluid.set_flags({"FLAGS_retain_grad_for_all_tensor": True})
     x = np.random.rand(3, 3)
     y = np.random.rand(3, 3)
     paddle.disable_static()
     res = ans.vjp_with_jac(func3, [paddle.to_tensor(x), paddle.to_tensor(y)])
     obj.run(res=res, func=func3, xs=[x, y])
+    paddle.fluid.set_flags({"FLAGS_retain_grad_for_all_tensor": False})
 
 
 @pytest.mark.api_incubate_vjp_parameters
@@ -183,6 +185,7 @@ def test_vjp8():
     multi_input and multi_output
     set v
     """
+    paddle.fluid.set_flags({"FLAGS_retain_grad_for_all_tensor": True})
     x = np.random.rand(4, 4)
     v1 = np.random.rand(4, 4)
     paddle.disable_static()
@@ -190,3 +193,4 @@ def test_vjp8():
         func3, [paddle.to_tensor(x), paddle.to_tensor(x)], v=[paddle.to_tensor(v1), paddle.to_tensor(v1)]
     )
     obj.run(res=res, func=func3, xs=[x, x], v=[v1, v1])
+    paddle.fluid.set_flags({"FLAGS_retain_grad_for_all_tensor": False})

--- a/framework/api/nn/test_GRU.py
+++ b/framework/api/nn/test_GRU.py
@@ -17,7 +17,7 @@ def test_gru_base0():
     """
     Sigmoid_base
     """
-
+    paddle.fluid.set_flags({"FLAGS_retain_grad_for_all_tensor": True})
     obj0 = RnnBase(paddle.nn.GRU)
     np.random.seed(22)
     x = np.random.rand(1, 2, 4)
@@ -41,6 +41,7 @@ def test_gru_base0():
         bias_ih_attr=initializer.Constant(2),
         bias_hh_attr=initializer.Constant(2),
     )
+    paddle.fluid.set_flags({"FLAGS_retain_grad_for_all_tensor": False})
 
 
 @pytest.mark.api_nn_GRU_vartype
@@ -48,6 +49,7 @@ def test_gru_base1():
     """
     Sigmoid_base
     """
+    paddle.fluid.set_flags({"FLAGS_retain_grad_for_all_tensor": True})
     obj1 = RnnBase(paddle.nn.GRU)
     obj1.dtype = "float64"
     obj1.enable_static = False
@@ -73,6 +75,7 @@ def test_gru_base1():
         bias_ih_attr=initializer.Constant(2),
         bias_hh_attr=initializer.Constant(2),
     )
+    paddle.fluid.set_flags({"FLAGS_retain_grad_for_all_tensor": False})
 
 
 @pytest.mark.api_nn_GRU_parameters
@@ -80,6 +83,7 @@ def test_gru0():
     """
     default
     """
+    paddle.fluid.set_flags({"FLAGS_retain_grad_for_all_tensor": True})
     obj2 = RnnBase(paddle.nn.GRU)
     obj2.enable_static = False
     np.random.seed(22)
@@ -104,6 +108,7 @@ def test_gru0():
         bias_ih_attr=initializer.Constant(2),
         bias_hh_attr=initializer.Constant(2),
     )
+    paddle.fluid.set_flags({"FLAGS_retain_grad_for_all_tensor": False})
 
 
 @pytest.mark.api_nn_GRU_parameters
@@ -111,6 +116,7 @@ def test_gru1():
     """
     num_layers = 3
     """
+    paddle.fluid.set_flags({"FLAGS_retain_grad_for_all_tensor": True})
     obj3 = RnnBase(paddle.nn.GRU)
     obj3.enable_static = False
     np.random.seed(22)
@@ -136,6 +142,7 @@ def test_gru1():
         bias_ih_attr=initializer.Constant(2),
         bias_hh_attr=initializer.Constant(2),
     )
+    paddle.fluid.set_flags({"FLAGS_retain_grad_for_all_tensor": False})
 
 
 @pytest.mark.api_nn_GRU_parameters
@@ -144,6 +151,7 @@ def test_gru2():
     num_layers = 3
     direction='bidirect'
     """
+    paddle.fluid.set_flags({"FLAGS_retain_grad_for_all_tensor": True})
     obj4 = RnnBase(paddle.nn.GRU)
     obj4.enable_static = False
     np.random.seed(22)
@@ -192,6 +200,7 @@ def test_gru2():
         bias_ih_attr=initializer.Constant(2),
         bias_hh_attr=initializer.Constant(2),
     )
+    paddle.fluid.set_flags({"FLAGS_retain_grad_for_all_tensor": False})
 
 
 @pytest.mark.api_nn_GRU_parameters
@@ -200,6 +209,7 @@ def test_gru3():
     num_layers = 3
     direction='bidirectional'
     """
+    paddle.fluid.set_flags({"FLAGS_retain_grad_for_all_tensor": True})
     obj5 = RnnBase(paddle.nn.GRU)
     obj5.enable_static = False
     np.random.seed(22)
@@ -248,6 +258,7 @@ def test_gru3():
         bias_ih_attr=initializer.Constant(2),
         bias_hh_attr=initializer.Constant(2),
     )
+    paddle.fluid.set_flags({"FLAGS_retain_grad_for_all_tensor": False})
 
 
 @pytest.mark.api_nn_GRU_parameters
@@ -257,6 +268,7 @@ def test_gru4():
     direction='bidirectional'
     time_major = True
     """
+    paddle.fluid.set_flags({"FLAGS_retain_grad_for_all_tensor": True})
     obj6 = RnnBase(paddle.nn.GRU)
     obj6.enable_static = False
     np.random.seed(22)
@@ -308,6 +320,7 @@ def test_gru4():
         bias_ih_attr=initializer.Constant(2),
         bias_hh_attr=initializer.Constant(2),
     )
+    paddle.fluid.set_flags({"FLAGS_retain_grad_for_all_tensor": False})
 
 
 @pytest.mark.api_nn_GRU_parameters
@@ -318,6 +331,7 @@ def test_gru5():
     time_major = True
     dropout = 0
     """
+    paddle.fluid.set_flags({"FLAGS_retain_grad_for_all_tensor": True})
     obj7 = RnnBase(paddle.nn.GRU)
     obj7.enable_static = False
     np.random.seed(22)
@@ -371,6 +385,7 @@ def test_gru5():
         bias_ih_attr=initializer.Constant(2),
         bias_hh_attr=initializer.Constant(2),
     )
+    paddle.fluid.set_flags({"FLAGS_retain_grad_for_all_tensor": False})
 
 
 @pytest.mark.api_nn_GRU_parameters
@@ -381,6 +396,7 @@ def test_gru6():
     time_major = True
     dropout = 0
     """
+    paddle.fluid.set_flags({"FLAGS_retain_grad_for_all_tensor": True})
     obj8 = RnnBase(paddle.nn.GRU)
     obj8.enable_static = False
     np.random.seed(22)
@@ -434,6 +450,7 @@ def test_gru6():
         bias_ih_attr=initializer.Constant(2),
         bias_hh_attr=initializer.Constant(2),
     )
+    paddle.fluid.set_flags({"FLAGS_retain_grad_for_all_tensor": False})
 
 
 # @pytest.mark.api_nn_GRU_parameters

--- a/framework/api/nn/test_GRUCell.py
+++ b/framework/api/nn/test_GRUCell.py
@@ -17,6 +17,7 @@ def test_grucell_base0():
     """
     test_grucell_base
     """
+    paddle.fluid.set_flags({"FLAGS_retain_grad_for_all_tensor": True})
     obj0 = RnnBase(paddle.nn.GRUCell)
     np.random.seed(22)
     x = np.random.rand(1, 2)
@@ -33,6 +34,7 @@ def test_grucell_base0():
         bias_ih_attr=initializer.Constant(2),
         bias_hh_attr=initializer.Constant(2),
     )
+    paddle.fluid.set_flags({"FLAGS_retain_grad_for_all_tensor": False})
 
 
 @pytest.mark.api_nn_GRUCell_vartype
@@ -40,6 +42,7 @@ def test_grucell_base1():
     """
     test_grucell_base
     """
+    paddle.fluid.set_flags({"FLAGS_retain_grad_for_all_tensor": True})
     obj1 = RnnBase(paddle.nn.GRUCell)
     obj1.dtype = "float64"
     obj1.enable_static = False
@@ -58,6 +61,7 @@ def test_grucell_base1():
         bias_ih_attr=initializer.Constant(2),
         bias_hh_attr=initializer.Constant(2),
     )
+    paddle.fluid.set_flags({"FLAGS_retain_grad_for_all_tensor": False})
 
 
 @pytest.mark.api_nn_GRUCell_parameters
@@ -65,6 +69,7 @@ def test_grucell0():
     """
     test_grucell0
     """
+    paddle.fluid.set_flags({"FLAGS_retain_grad_for_all_tensor": True})
     obj2 = RnnBase(paddle.nn.GRUCell)
     obj2.enable_static = False
     np.random.seed(22)
@@ -157,3 +162,4 @@ def test_grucell0():
         bias_ih_attr=initializer.Constant(4),
         bias_hh_attr=initializer.Constant(4),
     )
+    paddle.fluid.set_flags({"FLAGS_retain_grad_for_all_tensor": False})

--- a/framework/api/nn/test_LSTM.py
+++ b/framework/api/nn/test_LSTM.py
@@ -17,6 +17,7 @@ def test_lstm_base0():
     """
     test_lstm_base
     """
+    paddle.fluid.set_flags({"FLAGS_retain_grad_for_all_tensor": True})
     obj0 = RnnBase(paddle.nn.LSTM)
     np.random.seed(22)
     x = np.random.rand(1, 2, 4)
@@ -32,6 +33,7 @@ def test_lstm_base0():
         bias_ih_attr=initializer.Constant(2),
         bias_hh_attr=initializer.Constant(2),
     )
+    paddle.fluid.set_flags({"FLAGS_retain_grad_for_all_tensor": False})
 
 
 @pytest.mark.api_nn_LSTM_vartype
@@ -39,6 +41,7 @@ def test_lstm_base1():
     """
     test_lstm_base
     """
+    paddle.fluid.set_flags({"FLAGS_retain_grad_for_all_tensor": True})
     obj1 = RnnBase(paddle.nn.LSTM)
     obj1.dtype = "float64"
     obj1.enable_static = False
@@ -56,6 +59,7 @@ def test_lstm_base1():
         bias_ih_attr=initializer.Constant(2),
         bias_hh_attr=initializer.Constant(2),
     )
+    paddle.fluid.set_flags({"FLAGS_retain_grad_for_all_tensor": False})
 
 
 @pytest.mark.api_nn_LSTM_parameters
@@ -63,6 +67,7 @@ def test_lstm0():
     """
     default
     """
+    paddle.fluid.set_flags({"FLAGS_retain_grad_for_all_tensor": True})
     obj2 = RnnBase(paddle.nn.LSTM)
     obj2.enable_static = False
     np.random.seed(22)
@@ -79,6 +84,7 @@ def test_lstm0():
         bias_ih_attr=initializer.Constant(2),
         bias_hh_attr=initializer.Constant(2),
     )
+    paddle.fluid.set_flags({"FLAGS_retain_grad_for_all_tensor": False})
 
 
 @pytest.mark.api_nn_LSTM_parameters
@@ -86,6 +92,7 @@ def test_lstm1():
     """
     set (h,c)
     """
+    paddle.fluid.set_flags({"FLAGS_retain_grad_for_all_tensor": True})
     obj3 = RnnBase(paddle.nn.LSTM)
     obj3.enable_static = False
     np.random.seed(22)
@@ -104,6 +111,7 @@ def test_lstm1():
         bias_ih_attr=initializer.Constant(2),
         bias_hh_attr=initializer.Constant(2),
     )
+    paddle.fluid.set_flags({"FLAGS_retain_grad_for_all_tensor": False})
 
 
 @pytest.mark.api_nn_LSTM_parameters
@@ -111,6 +119,7 @@ def test_lstm2():
     """
     direction='bidirect'
     """
+    paddle.fluid.set_flags({"FLAGS_retain_grad_for_all_tensor": True})
     obj4 = RnnBase(paddle.nn.LSTM)
     obj4.enable_static = False
     obj4.atol = 1e-4
@@ -128,6 +137,7 @@ def test_lstm2():
         bias_ih_attr=initializer.Constant(2),
         bias_hh_attr=initializer.Constant(2),
     )
+    paddle.fluid.set_flags({"FLAGS_retain_grad_for_all_tensor": False})
 
 
 @pytest.mark.api_nn_LSTM_parameters
@@ -135,6 +145,7 @@ def test_lstm3():
     """
     direction='bidirectional'
     """
+    paddle.fluid.set_flags({"FLAGS_retain_grad_for_all_tensor": True})
     obj5 = RnnBase(paddle.nn.LSTM)
     obj5.enable_static = False
     obj5.atol = 1e-4
@@ -152,6 +163,7 @@ def test_lstm3():
         bias_ih_attr=initializer.Constant(2),
         bias_hh_attr=initializer.Constant(2),
     )
+    paddle.fluid.set_flags({"FLAGS_retain_grad_for_all_tensor": False})
 
 
 @pytest.mark.api_nn_LSTM_parameters
@@ -160,6 +172,7 @@ def test_lstm4():
     set (h,c)
     num_layers=4
     """
+    paddle.fluid.set_flags({"FLAGS_retain_grad_for_all_tensor": True})
     obj6 = RnnBase(paddle.nn.LSTM)
     obj6.enable_static = False
     np.random.seed(22)
@@ -179,6 +192,7 @@ def test_lstm4():
         bias_ih_attr=initializer.Constant(2),
         bias_hh_attr=initializer.Constant(2),
     )
+    paddle.fluid.set_flags({"FLAGS_retain_grad_for_all_tensor": False})
 
 
 @pytest.mark.api_nn_LSTM_parameters
@@ -188,6 +202,7 @@ def test_lstm5():
     num_layers=4
     time_major=True
     """
+    paddle.fluid.set_flags({"FLAGS_retain_grad_for_all_tensor": True})
     obj7 = RnnBase(paddle.nn.LSTM)
     obj7.enable_static = False
     np.random.seed(22)
@@ -213,3 +228,4 @@ def test_lstm5():
         bias_ih_attr=initializer.Constant(2),
         bias_hh_attr=initializer.Constant(2),
     )
+    paddle.fluid.set_flags({"FLAGS_retain_grad_for_all_tensor": False})

--- a/framework/api/nn/test_LSTMCell.py
+++ b/framework/api/nn/test_LSTMCell.py
@@ -17,6 +17,7 @@ def test_lstmcell_base0():
     """
     test_grucell_base
     """
+    paddle.fluid.set_flags({"FLAGS_retain_grad_for_all_tensor": True})
     obj0 = RnnBase(paddle.nn.LSTMCell)
     np.random.seed(22)
     x = np.random.rand(1, 2)
@@ -32,6 +33,7 @@ def test_lstmcell_base0():
         bias_ih_attr=initializer.Constant(2),
         bias_hh_attr=initializer.Constant(2),
     )
+    paddle.fluid.set_flags({"FLAGS_retain_grad_for_all_tensor": False})
 
 
 @pytest.mark.api_nn_LSTMCell_vartype
@@ -39,6 +41,7 @@ def test_lstmcell_base1():
     """
     test_grucell_base
     """
+    paddle.fluid.set_flags({"FLAGS_retain_grad_for_all_tensor": True})
     obj1 = RnnBase(paddle.nn.LSTMCell)
     obj1.dtype = "float64"
     np.random.seed(22)
@@ -55,6 +58,7 @@ def test_lstmcell_base1():
         bias_ih_attr=initializer.Constant(2),
         bias_hh_attr=initializer.Constant(2),
     )
+    paddle.fluid.set_flags({"FLAGS_retain_grad_for_all_tensor": False})
 
 
 @pytest.mark.api_nn_LSTMCell_parameters
@@ -62,6 +66,7 @@ def test_lstmcell0():
     """
     test_grucell0
     """
+    paddle.fluid.set_flags({"FLAGS_retain_grad_for_all_tensor": True})
     obj2 = RnnBase(paddle.nn.LSTMCell)
     obj2.enable_static = False
     obj2.atol = 1e-4
@@ -154,6 +159,7 @@ def test_lstmcell0():
         bias_ih_attr=initializer.Constant(2),
         bias_hh_attr=initializer.Constant(2),
     )
+    paddle.fluid.set_flags({"FLAGS_retain_grad_for_all_tensor": False})
 
 
 @pytest.mark.api_nn_LSTMCell_parameters
@@ -161,6 +167,7 @@ def test_lstmcell1():
     """
     set states
     """
+    paddle.fluid.set_flags({"FLAGS_retain_grad_for_all_tensor": True})
     obj3 = RnnBase(paddle.nn.LSTMCell)
     obj3.enable_static = False
     np.random.seed(22)
@@ -179,3 +186,4 @@ def test_lstmcell1():
         bias_ih_attr=initializer.Constant(4),
         bias_hh_attr=initializer.Constant(4),
     )
+    paddle.fluid.set_flags({"FLAGS_retain_grad_for_all_tensor": False})

--- a/framework/api/nn/test_SimpleRNN.py
+++ b/framework/api/nn/test_SimpleRNN.py
@@ -19,6 +19,7 @@ def test_simplernn_base0():
     """
     test_grucell_base
     """
+    paddle.fluid.set_flags({"FLAGS_retain_grad_for_all_tensor": True})
     obj0 = RnnBase(paddle.nn.SimpleRNN)
     np.random.seed(22)
     x = np.random.rand(1, 2, 3)
@@ -33,6 +34,7 @@ def test_simplernn_base0():
         bias_ih_attr=initializer.Constant(2),
         bias_hh_attr=initializer.Constant(2),
     )
+    paddle.fluid.set_flags({"FLAGS_retain_grad_for_all_tensor": False})
 
 
 @pytest.mark.api_nn_SimpleRNN_vartype
@@ -40,6 +42,7 @@ def test_simplernn_base1():
     """
     test_grucell_base
     """
+    paddle.fluid.set_flags({"FLAGS_retain_grad_for_all_tensor": True})
     obj1 = RnnBase(paddle.nn.SimpleRNN)
     obj1.dtype = "float64"
     obj1.enable_static = False
@@ -56,6 +59,7 @@ def test_simplernn_base1():
         bias_ih_attr=initializer.Constant(2),
         bias_hh_attr=initializer.Constant(2),
     )
+    paddle.fluid.set_flags({"FLAGS_retain_grad_for_all_tensor": False})
 
 
 @pytest.mark.api_nn_SimpleRNN_parameters
@@ -63,6 +67,7 @@ def test_simplernn0():
     """
     default
     """
+    paddle.fluid.set_flags({"FLAGS_retain_grad_for_all_tensor": True})
     obj2 = RnnBase(paddle.nn.SimpleRNN)
     obj2.enable_static = False
     np.random.seed(22)
@@ -80,6 +85,7 @@ def test_simplernn0():
         bias_ih_attr=initializer.Constant(2),
         bias_hh_attr=initializer.Constant(2),
     )
+    paddle.fluid.set_flags({"FLAGS_retain_grad_for_all_tensor": False})
 
 
 @pytest.mark.api_nn_SimpleRNN_parameters
@@ -87,6 +93,7 @@ def test_simplernn1():
     """
     num_layer=2
     """
+    paddle.fluid.set_flags({"FLAGS_retain_grad_for_all_tensor": True})
     obj3 = RnnBase(paddle.nn.SimpleRNN)
     obj3.enable_static = False
     np.random.seed(22)
@@ -105,6 +112,7 @@ def test_simplernn1():
         bias_ih_attr=initializer.Constant(2),
         bias_hh_attr=initializer.Constant(2),
     )
+    paddle.fluid.set_flags({"FLAGS_retain_grad_for_all_tensor": False})
 
 
 @pytest.mark.api_nn_SimpleRNN_parameters
@@ -113,6 +121,7 @@ def test_simplernn2():
     num_layer=2
     activation='relu'
     """
+    paddle.fluid.set_flags({"FLAGS_retain_grad_for_all_tensor": True})
     obj4 = RnnBase(paddle.nn.SimpleRNN)
     obj4.enable_static = False
     np.random.seed(22)
@@ -140,6 +149,7 @@ def test_simplernn2():
         bias_ih_attr=initializer.Constant(2),
         bias_hh_attr=initializer.Constant(2),
     )
+    paddle.fluid.set_flags({"FLAGS_retain_grad_for_all_tensor": False})
 
 
 @pytest.mark.api_nn_SimpleRNN_parameters
@@ -147,6 +157,7 @@ def test_simplernn3():
     """
     time_major=True
     """
+    paddle.fluid.set_flags({"FLAGS_retain_grad_for_all_tensor": True})
     obj5 = RnnBase(paddle.nn.SimpleRNN)
     obj5.enable_static = False
     np.random.seed(22)
@@ -165,6 +176,7 @@ def test_simplernn3():
         bias_ih_attr=initializer.Constant(2),
         bias_hh_attr=initializer.Constant(2),
     )
+    paddle.fluid.set_flags({"FLAGS_retain_grad_for_all_tensor": False})
 
 
 @pytest.mark.api_nn_SimpleRNN_parameters
@@ -172,6 +184,7 @@ def test_simplernn4():
     """
     dropout=0.8
     """
+    paddle.fluid.set_flags({"FLAGS_retain_grad_for_all_tensor": True})
     obj6 = RnnBase(paddle.nn.SimpleRNN)
     obj6.enable_static = False
     np.random.seed(22)
@@ -190,6 +203,7 @@ def test_simplernn4():
         bias_ih_attr=initializer.Constant(2),
         bias_hh_attr=initializer.Constant(2),
     )
+    paddle.fluid.set_flags({"FLAGS_retain_grad_for_all_tensor": False})
 
 
 @pytest.mark.api_nn_SimpleRNN_parameters
@@ -197,6 +211,7 @@ def test_simplernn5():
     """
     dropout=0.8
     """
+    paddle.fluid.set_flags({"FLAGS_retain_grad_for_all_tensor": True})
     obj7 = RnnBase(paddle.nn.SimpleRNN)
     obj7.enable_static = False
     np.random.seed(22)
@@ -217,3 +232,4 @@ def test_simplernn5():
         bias_ih_attr=initializer.Constant(2),
         bias_hh_attr=initializer.Constant(2),
     )
+    paddle.fluid.set_flags({"FLAGS_retain_grad_for_all_tensor": False})

--- a/framework/api/nn/test_SimpleRNNCell.py
+++ b/framework/api/nn/test_SimpleRNNCell.py
@@ -17,6 +17,7 @@ def test_simplernncell_base0():
     """
     test_grucell_base
     """
+    paddle.fluid.set_flags({"FLAGS_retain_grad_for_all_tensor": True})
     obj0 = RnnBase(paddle.nn.SimpleRNNCell)
     np.random.seed(22)
     x = np.random.rand(1, 4)
@@ -33,6 +34,7 @@ def test_simplernncell_base0():
         bias_ih_attr=initializer.Constant(2),
         bias_hh_attr=initializer.Constant(2),
     )
+    paddle.fluid.set_flags({"FLAGS_retain_grad_for_all_tensor": False})
 
 
 @pytest.mark.api_nn_SimpleRNNCell_vartype
@@ -40,6 +42,7 @@ def test_simplernncell_base1():
     """
     test_grucell_base
     """
+    paddle.fluid.set_flags({"FLAGS_retain_grad_for_all_tensor": True})
     obj1 = RnnBase(paddle.nn.SimpleRNNCell)
     obj1.dtype = "float64"
     obj1.enable_static = False
@@ -58,6 +61,7 @@ def test_simplernncell_base1():
         bias_ih_attr=initializer.Constant(2),
         bias_hh_attr=initializer.Constant(2),
     )
+    paddle.fluid.set_flags({"FLAGS_retain_grad_for_all_tensor": False})
 
 
 @pytest.mark.api_nn_GRUCell_parameters
@@ -65,6 +69,7 @@ def test_grucell0():
     """
     default
     """
+    paddle.fluid.set_flags({"FLAGS_retain_grad_for_all_tensor": True})
     obj2 = RnnBase(paddle.nn.SimpleRNNCell)
     obj2.enable_static = False
     np.random.seed(22)
@@ -80,6 +85,7 @@ def test_grucell0():
         bias_ih_attr=initializer.Constant(4),
         bias_hh_attr=initializer.Constant(4),
     )
+    paddle.fluid.set_flags({"FLAGS_retain_grad_for_all_tensor": False})
 
 
 @pytest.mark.api_nn_GRUCell_parameters
@@ -87,6 +93,7 @@ def test_grucell1():
     """
     set states
     """
+    paddle.fluid.set_flags({"FLAGS_retain_grad_for_all_tensor": True})
     obj3 = RnnBase(paddle.nn.SimpleRNNCell)
     obj3.enable_static = False
     np.random.seed(22)
@@ -104,6 +111,7 @@ def test_grucell1():
         bias_ih_attr=initializer.Constant(4),
         bias_hh_attr=initializer.Constant(4),
     )
+    paddle.fluid.set_flags({"FLAGS_retain_grad_for_all_tensor": False})
 
 
 @pytest.mark.api_nn_GRUCell_parameters
@@ -112,6 +120,7 @@ def test_grucell2():
     set states
     activation=relu
     """
+    paddle.fluid.set_flags({"FLAGS_retain_grad_for_all_tensor": True})
     obj4 = RnnBase(paddle.nn.SimpleRNNCell)
     obj4.enable_static = False
     np.random.seed(22)
@@ -136,3 +145,4 @@ def test_grucell2():
         bias_ih_attr=initializer.Constant(4),
         bias_hh_attr=initializer.Constant(4),
     )
+    paddle.fluid.set_flags({"FLAGS_retain_grad_for_all_tensor": False})

--- a/framework/api/nn/test_birnn.py
+++ b/framework/api/nn/test_birnn.py
@@ -152,6 +152,7 @@ def test_birnn3():
     obj5.run(res, x_data, (h_data, h1_data), cell_fw=cell_fw, cell_bw=cell_bw)
     paddle.fluid.set_flags({"FLAGS_retain_grad_for_all_tensor": False})
 
+
 @pytest.mark.api_nn_BiRNN_parameters
 def test_birnn4():
     """

--- a/framework/api/nn/test_birnn.py
+++ b/framework/api/nn/test_birnn.py
@@ -17,6 +17,7 @@ def test_birnn0():
     """
     time_major = True
     """
+    paddle.fluid.set_flags({"FLAGS_retain_grad_for_all_tensor": True})
     obj2 = RnnBase(paddle.nn.BiRNN)
     obj2.enable_static = False
     np.random.seed(22)
@@ -45,6 +46,7 @@ def test_birnn0():
     )
     obj2.atol = 1e-5
     obj2.run(res, x, cell_fw=cell_fw, cell_bw=cell_bw, time_major=True)
+    paddle.fluid.set_flags({"FLAGS_retain_grad_for_all_tensor": False})
 
 
 @pytest.mark.api_nn_BiRNN_parameters
@@ -52,6 +54,7 @@ def test_birnn1():
     """
     set initial_states
     """
+    paddle.fluid.set_flags({"FLAGS_retain_grad_for_all_tensor": True})
     obj3 = RnnBase(paddle.nn.BiRNN)
     obj3.enable_static = False
     np.random.seed(22)
@@ -78,6 +81,7 @@ def test_birnn1():
         bias_hh_attr=initializer.Constant(4),
     )
     obj3.run(res, x_data, ((h_data, c_data), (h1_data, c1_data)), cell_fw=cell_fw, cell_bw=cell_bw)
+    paddle.fluid.set_flags({"FLAGS_retain_grad_for_all_tensor": False})
 
 
 @pytest.mark.api_nn_BiRNN_parameters
@@ -86,6 +90,7 @@ def test_birnn2():
     cell: GRUCell
     set initial_states
     """
+    paddle.fluid.set_flags({"FLAGS_retain_grad_for_all_tensor": True})
     obj4 = RnnBase(paddle.nn.BiRNN)
     obj4.enable_static = False
     np.random.seed(22)
@@ -111,6 +116,7 @@ def test_birnn2():
     )
     obj4.atol = 1e-4
     obj4.run(res, x_data, cell_fw=cell_fw, cell_bw=cell_bw)
+    paddle.fluid.set_flags({"FLAGS_retain_grad_for_all_tensor": False})
 
 
 @pytest.mark.api_nn_BiRNN_parameters
@@ -119,6 +125,7 @@ def test_birnn3():
     cell: SimpleRNNCell
     set initial_states
     """
+    paddle.fluid.set_flags({"FLAGS_retain_grad_for_all_tensor": True})
     obj5 = RnnBase(paddle.nn.BiRNN)
     obj5.enable_static = False
     np.random.seed(22)
@@ -143,7 +150,7 @@ def test_birnn3():
         bias_hh_attr=initializer.Constant(4),
     )
     obj5.run(res, x_data, (h_data, h1_data), cell_fw=cell_fw, cell_bw=cell_bw)
-
+    paddle.fluid.set_flags({"FLAGS_retain_grad_for_all_tensor": False})
 
 @pytest.mark.api_nn_BiRNN_parameters
 def test_birnn4():
@@ -151,6 +158,7 @@ def test_birnn4():
     cell: fw -> GRUCell; bw -> SimpleRNNCell
     set initial_states
     """
+    paddle.fluid.set_flags({"FLAGS_retain_grad_for_all_tensor": True})
     obj6 = RnnBase(paddle.nn.BiRNN)
     obj6.enable_static = False
     np.random.seed(22)
@@ -175,3 +183,4 @@ def test_birnn4():
         bias_hh_attr=initializer.Constant(4),
     )
     obj6.run(res, x_data, (h_data, h1_data), cell_fw=cell_fw, cell_bw=cell_bw)
+    paddle.fluid.set_flags({"FLAGS_retain_grad_for_all_tensor": False})

--- a/framework/api/nn/test_rnn.py
+++ b/framework/api/nn/test_rnn.py
@@ -17,6 +17,7 @@ def test_birnn_base():
     """
     default
     """
+    paddle.fluid.set_flags({"FLAGS_retain_grad_for_all_tensor": True})
     obj0 = RnnBase(paddle.nn.RNN)
     obj0.enable_static = False
     np.random.seed(22)
@@ -32,6 +33,7 @@ def test_birnn_base():
     )
     obj0.atol = 1e-4
     obj0.run(res, x, cell=cell)
+    paddle.fluid.set_flags({"FLAGS_retain_grad_for_all_tensor": False})
 
 
 @pytest.mark.api_nn_BiRNN_parameters
@@ -39,6 +41,7 @@ def test_birnn0():
     """
     time_major = True
     """
+    paddle.fluid.set_flags({"FLAGS_retain_grad_for_all_tensor": True})
     obj2 = RnnBase(paddle.nn.RNN)
     obj2.enable_static = False
     np.random.seed(22)
@@ -56,6 +59,7 @@ def test_birnn0():
     )
     obj2.atol = 1e-4
     obj2.run(res, x, cell=cell, time_major=True)
+    paddle.fluid.set_flags({"FLAGS_retain_grad_for_all_tensor": False})
 
 
 @pytest.mark.api_nn_BiRNN_parameters
@@ -63,6 +67,7 @@ def test_birnn1():
     """
     time_major = True
     """
+    paddle.fluid.set_flags({"FLAGS_retain_grad_for_all_tensor": True})
     obj3 = RnnBase(paddle.nn.RNN)
     obj3.enable_static = False
     np.random.seed(22)
@@ -80,6 +85,7 @@ def test_birnn1():
     )
 
     obj3.run(res, x, cell=cell, is_reverse=True, time_major=True)
+    paddle.fluid.set_flags({"FLAGS_retain_grad_for_all_tensor": False})
 
 
 @pytest.mark.api_nn_BiRNN_parameters
@@ -87,6 +93,7 @@ def test_birnn2():
     """
     set initial_states
     """
+    paddle.fluid.set_flags({"FLAGS_retain_grad_for_all_tensor": True})
     obj4 = RnnBase(paddle.nn.RNN)
     obj4.enable_static = False
     np.random.seed(22)
@@ -105,6 +112,7 @@ def test_birnn2():
     )
     obj4.atol = 1e-5
     obj4.run(res, x_data, (h_data, c_data), cell=cell)
+    paddle.fluid.set_flags({"FLAGS_retain_grad_for_all_tensor": False})
 
 
 @pytest.mark.api_nn_BiRNN_parameters
@@ -113,6 +121,7 @@ def test_birnn3():
     cell: GRUCell
     set initial_states
     """
+    paddle.fluid.set_flags({"FLAGS_retain_grad_for_all_tensor": True})
     obj5 = RnnBase(paddle.nn.RNN)
     obj5.enable_static = False
     np.random.seed(22)
@@ -128,6 +137,7 @@ def test_birnn3():
         bias_hh_attr=initializer.Constant(4),
     )
     obj5.run(res, x_data, h_data, cell=cell)
+    paddle.fluid.set_flags({"FLAGS_retain_grad_for_all_tensor": False})
 
 
 @pytest.mark.api_nn_BiRNN_parameters
@@ -136,6 +146,7 @@ def test_birnn4():
     cell:  -> SimpleRNNCell
     set initial_states
     """
+    paddle.fluid.set_flags({"FLAGS_retain_grad_for_all_tensor": True})
     obj6 = RnnBase(paddle.nn.RNN)
     obj6.enable_static = False
     np.random.seed(22)
@@ -151,3 +162,4 @@ def test_birnn4():
         bias_hh_attr=initializer.Constant(4),
     )
     obj6.run(res, x_data, h_data, cell=cell)
+    paddle.fluid.set_flags({"FLAGS_retain_grad_for_all_tensor": False})

--- a/framework/api/paddlebase/test_clone.py
+++ b/framework/api/paddlebase/test_clone.py
@@ -15,6 +15,7 @@ def test_clone0():
     """
     x: 1d-tensor
     """
+    paddle.fluid.set_flags({"FLAGS_retain_grad_for_all_tensor": True})
     xp = np.ones((3,))
     x = paddle.to_tensor(xp)
     x.stop_gradient = False
@@ -23,6 +24,7 @@ def test_clone0():
     y.backward()
     assert np.allclose(x.numpy(), clone_x.numpy())
     assert np.allclose(x.grad.numpy(), clone_x.grad.numpy())
+    paddle.fluid.set_flags({"FLAGS_retain_grad_for_all_tensor": False})
 
 
 @pytest.mark.api_base_clone_parameters
@@ -30,6 +32,7 @@ def test_clone1():
     """
     x: 2d-tensor
     """
+    paddle.fluid.set_flags({"FLAGS_retain_grad_for_all_tensor": True})
     xp = np.ones((3, 3))
     x = paddle.to_tensor(xp)
     x.stop_gradient = False
@@ -38,6 +41,7 @@ def test_clone1():
     y.backward()
     assert np.allclose(x.numpy(), clone_x.numpy())
     assert np.allclose(x.grad.numpy(), clone_x.grad.numpy())
+    paddle.fluid.set_flags({"FLAGS_retain_grad_for_all_tensor": False})
 
 
 @pytest.mark.api_base_clone_parameters
@@ -45,6 +49,7 @@ def test_clone2():
     """
     x: 3d-tensor
     """
+    paddle.fluid.set_flags({"FLAGS_retain_grad_for_all_tensor": True})
     xp = np.ones((3, 3, 4))
     x = paddle.to_tensor(xp)
     x.stop_gradient = False
@@ -53,6 +58,7 @@ def test_clone2():
     y.backward()
     assert np.allclose(x.numpy(), clone_x.numpy())
     assert np.allclose(x.grad.numpy(), clone_x.grad.numpy())
+    paddle.fluid.set_flags({"FLAGS_retain_grad_for_all_tensor": False})
 
 
 @pytest.mark.api_base_clone_parameters
@@ -60,6 +66,7 @@ def test_clone3():
     """
     x: 4d-tensor
     """
+    paddle.fluid.set_flags({"FLAGS_retain_grad_for_all_tensor": True})
     xp = np.ones((3, 3, 4, 4))
     x = paddle.to_tensor(xp)
     x.stop_gradient = False
@@ -68,3 +75,4 @@ def test_clone3():
     y.backward()
     assert np.allclose(x.numpy(), clone_x.numpy())
     assert np.allclose(x.grad.numpy(), clone_x.grad.numpy())
+    paddle.fluid.set_flags({"FLAGS_retain_grad_for_all_tensor": False})

--- a/framework/api/paddlebase/test_fill_diagonal_.py
+++ b/framework/api/paddlebase/test_fill_diagonal_.py
@@ -23,6 +23,7 @@ def fill_diagonal_base(x, value, offset=0, warp=False):
     """
     api calculate
     """
+    paddle.fluid.set_flags({"FLAGS_retain_grad_for_all_tensor": True})
     outputs, gradients = [], []
     for place in places:
         for t in types:
@@ -37,6 +38,7 @@ def fill_diagonal_base(x, value, offset=0, warp=False):
             loss = paddle.sum(out)
             loss.backward()
             gradients.append(y.grad.numpy())
+    paddle.fluid.set_flags({"FLAGS_retain_grad_for_all_tensor": True})
     return outputs, gradients
 
 


### PR DESCRIPTION
FLAGS_retain_grad_for_all_tensor 仅对新动态图生效，原本默认值为 True，即保留所有 tensor 的梯度信息。后因模型中保留所有 tensor 的梯度将会大量占用显存，于是将其默认值改成 False [PR43142](https://github.com/PaddlePaddle/Paddle/pull/43142)，因此相关单测在切换到新动态时，需要手动设置为 True。

ps: 目前 PR-CE-Framework 流水线已经切换到 新动态图模式。