### PR TITLE
remove -sv, recover pytest command

### DIFF
--- a/framework/api/multithreading_case.py
+++ b/framework/api/multithreading_case.py
@@ -68,11 +68,11 @@ def runCETest(params):
     path = params[0]
     case = params[1]
     print("case: %s" % case)
-    val = os.system("export FLAGS_call_stack_level= && cd %s && python3.7 -m pytest -sv %s" % (path, case))
+    val = os.system("export FLAGS_call_stack_level= && cd %s && python3.7 -m pytest %s" % (path, case))
     retry_count = 0
     final_result = ""
     while val != 0:
-        val = os.system("export FLAGS_call_stack_level=2 && cd %s && python3.7 -m pytest -sv %s" % (path, case))
+        val = os.system("export FLAGS_call_stack_level=2 && cd %s && python3.7 -m pytest %s" % (path, case))
         retry_count = retry_count + 1
         if retry_count > 2:
             val = 0


### PR DESCRIPTION
上一个 [PR1086](https://github.com/PaddlePaddle/PaddleTest/pull/1086) 临时对 pytest 增加 -sv 配置，打印单测中 print() 的信息，用于验证新增的 CE-Framework-ci-test 流水线在切换 eager 后是否生效。

现已验证完毕，本 PR 去除 -sv 配置，还原初始脚本。