### PR TITLE
skip TransformedDistribution tests for fix event shape bug.

### DIFF
--- a/framework/api/distribution/test_TransformedDistribution.py
+++ b/framework/api/distribution/test_TransformedDistribution.py
@@ -31,6 +31,7 @@ def test_TransformedDistribution0():
     assert np.allclose(log_prob_value.numpy(), np.array([-1.64333570]))
 
 
+@pytest.mark.skip(reason="Skip TransformedDistribution for fix event shape bug.")
 @pytest.mark.api_distribution_TransformedDistribution_parameters
 def test_TransformedDistribution1():
     """
@@ -50,6 +51,7 @@ def test_TransformedDistribution1():
     assert np.allclose(log_prob_value.numpy(), np.array([-0.69314718]))
 
 
+@pytest.mark.skip(reason="Skip TransformedDistribution for fix event shape bug.")
 @pytest.mark.api_distribution_TransformedDistribution_parameters
 def test_TransformedDistribution2():
     """
@@ -72,6 +74,7 @@ def test_TransformedDistribution2():
     assert np.allclose(log_prob_value.numpy(), np.array([-1.17594624]))
 
 
+@pytest.mark.skip(reason="Skip TransformedDistribution for fix event shape bug.")
 @pytest.mark.api_distribution_TransformedDistribution_parameters
 def test_TransformedDistribution3():
     """
@@ -94,6 +97,7 @@ def test_TransformedDistribution3():
     assert np.allclose(log_prob_value.numpy(), np.array([-0.27615857]))
 
 
+@pytest.mark.skip(reason="Skip TransformedDistribution for fix event shape bug.")
 @pytest.mark.api_distribution_TransformedDistribution_parameters
 def test_TransformedDistribution4():
     """


### PR DESCRIPTION
Skip `TransformedDistribution`  tests temporarily for fix even_shape bug https://github.com/PaddlePaddle/Paddle/pull/46035