### PR TITLE
add bf16 precision to humansegv2 model

### DIFF
--- a/inference/python_api_test/test_int8_model/test_segmentation_infer.py
+++ b/inference/python_api_test/test_int8_model/test_segmentation_infer.py
@@ -60,7 +60,7 @@ def load_predictor(args):
             pred_cfg.enable_mkldnn()
             if args.precision == "int8":
                 pred_cfg.enable_mkldnn_int8({"conv2d", "depthwise_conv2d", "pool2d", "elementwise_mul"})
-            
+
             if args.precision == "bf16":
                 pred_cfg.enable_mkldnn_bfloat16()
 
@@ -258,7 +258,10 @@ if __name__ == "__main__":
         type=str,
         default="fp32",
         choices=["fp32", "fp16", "int8", "bf16"],
-        help="The precision of inference. It can be 'fp32', 'fp16' or 'int8'. 'bf16' is available when using mkldnn. Default is 'fp16'.",
+        help=(
+            "The precision of inference. It can be 'fp32', 'fp16' or 'int8'."
+            "'bf16' is available when using mkldnn. Default is 'fp16'."
+        ),
     )
     parser.add_argument("--use_mkldnn", type=bool, default=False, help="Whether use mkldnn or not.")
     parser.add_argument("--cpu_threads", type=int, default=1, help="Num of cpu threads.")

--- a/inference/python_api_test/test_int8_model/test_segmentation_infer.py
+++ b/inference/python_api_test/test_int8_model/test_segmentation_infer.py
@@ -66,7 +66,6 @@ def load_predictor(args):
 
     if args.use_trt:
         if args.precision == "bf16":
-            pred_cfg.enable_mkldnn_bfloat16()
             print("trt does not support bf16, switching to fp16")
             args.precision = "fp16"
         # To collect the dynamic shapes of inputs for TensorRT engine

--- a/inference/python_api_test/test_int8_model/test_segmentation_infer.py
+++ b/inference/python_api_test/test_int8_model/test_segmentation_infer.py
@@ -60,8 +60,15 @@ def load_predictor(args):
             pred_cfg.enable_mkldnn()
             if args.precision == "int8":
                 pred_cfg.enable_mkldnn_int8({"conv2d", "depthwise_conv2d", "pool2d", "elementwise_mul"})
+            
+            if args.precision == "bf16":
+                pred_cfg.enable_mkldnn_bfloat16()
 
     if args.use_trt:
+        if args.precision == "bf16":
+            pred_cfg.enable_mkldnn_bfloat16()
+            print("trt does not support bf16, switching to fp16")
+            args.precision = "fp16"
         # To collect the dynamic shapes of inputs for TensorRT engine
         dynamic_shape_file = os.path.join(args.model_path, "dynamic_shape.txt")
         if os.path.exists(dynamic_shape_file):
@@ -250,8 +257,8 @@ if __name__ == "__main__":
         "--precision",
         type=str,
         default="fp32",
-        choices=["fp32", "fp16", "int8"],
-        help="The precision of inference. It can be 'fp32', 'fp16' or 'int8'. Default is 'fp16'.",
+        choices=["fp32", "fp16", "int8", "bf16"],
+        help="The precision of inference. It can be 'fp32', 'fp16' or 'int8'. 'bf16' is available when using mkldnn. Default is 'fp16'.",
     )
     parser.add_argument("--use_mkldnn", type=bool, default=False, help="Whether use mkldnn or not.")
     parser.add_argument("--cpu_threads", type=int, default=1, help="Num of cpu threads.")


### PR DESCRIPTION
This change lets us optimize the model for the bfloat16 data type when running with oneDNN.