### PR TITLE
Add separate requirements.txt without pycuda

### DIFF
--- a/inference/python_api_test/test_int8_model/requirements_no_cuda.txt
+++ b/inference/python_api_test/test_int8_model/requirements_no_cuda.txt
@@ -1,0 +1,9 @@
+paddledet>=2.4.0
+paddleseg==2.5.0
+paddlenlp>=2.3.0
+tensorrt
+onnx
+GPUtil
+psutil
+pynvml
+tensorrt


### PR DESCRIPTION
Installing the pycuda library requires CUDA. Intel does not need CUDA to test oneDNN and most of our validation machines don't use GPU's so forcing the installation of pycuda makes it impossible to test some models. This PR creates a second requirements.txt file without pycuda.