### PR TITLE
rm legacy dygraph test

### DIFF
--- a/framework/api/incubate/test_FusedFeedForward.py
+++ b/framework/api/incubate/test_FusedFeedForward.py
@@ -9,9 +9,6 @@ from apibase import APIBase
 import paddle
 import pytest
 import numpy as np
-from paddle.fluid.framework import _enable_legacy_dygraph
-
-_enable_legacy_dygraph()
 
 sys.path.append("../../utils/")
 from interceptor import skip_not_compile_gpu

--- a/framework/api/incubate/test_fused_feedforward.py
+++ b/framework/api/incubate/test_fused_feedforward.py
@@ -10,9 +10,6 @@ from apibase import APIBase
 import paddle
 import pytest
 import numpy as np
-from paddle.fluid.framework import _enable_legacy_dygraph
-
-_enable_legacy_dygraph()
 
 sys.path.append("../../utils/")
 from interceptor import skip_not_compile_gpu


### PR DESCRIPTION
动态图改造完毕，现在Paddle已经不再支持老动态图功能,见[PR](https://github.com/PaddlePaddle/Paddle/pull/49036)，所以需要删除`_enable_legacy_dygraph()`
