### PR TITLE
fix the pytest mark error, test=model

### DIFF
--- a/inference/python_api_test/test_class_model/test_vgg11_trt_fp16.py
+++ b/inference/python_api_test/test_class_model/test_vgg11_trt_fp16.py
@@ -45,7 +45,7 @@ def test_config():
 @pytest.mark.win
 @pytest.mark.server
 @pytest.mark.trt_fp16
-def test_trtfp16_more_bz():
+def test_trt_fp16_more_bz():
     """
     compared trt fp16 batch_size=1-10 vgg11 outputs with true val
     """
@@ -81,7 +81,7 @@ def test_trtfp16_more_bz():
 
 @pytest.mark.jetson
 @pytest.mark.trt_fp16
-def test_trtfp16_more_bz():
+def test_jetson_trt_fp16_more_bz():
     """
     compared trt fp16 batch_size=1-10 vgg11 outputs with true val
     """
@@ -116,7 +116,7 @@ def test_trtfp16_more_bz():
 
 
 @pytest.mark.trt_fp16_multi_thread
-def test_trtfp16_bz1_multi_thread():
+def test_trt_fp16_bz1_multi_thread():
     """
     compared trt fp16 batch_size=1 vgg11 multi_thread outputs with true val
     """

--- a/inference/python_api_test/test_class_model/test_vgg11_trt_fp32.py
+++ b/inference/python_api_test/test_class_model/test_vgg11_trt_fp32.py
@@ -71,7 +71,6 @@ def test_trt_fp32_more_bz():
         del test_suite2  # destroy class to save memory
 
 
-@pytest.mark.server
 @pytest.mark.jetson
 @pytest.mark.trt_fp32
 def test_jetson_trt_fp32_more_bz():


### PR DESCRIPTION
fix the skip error of vgg11_trt_fp16 and remove the vgg_trt_fp32's jetson case in Linux