### PR TITLE
fix beamsearchdecoder test case

### DIFF
--- a/framework/api/nn/test_beamsearchdecoder.py
+++ b/framework/api/nn/test_beamsearchdecoder.py
@@ -577,6 +577,7 @@ def test_beamsearchdecoder8():
     Exception to the type of start_id
     """
     paddle.seed(33)
+    paddle.enable_static()
     trg_embeder = Embedding(100, 16)
     output_layer = Linear(16, 16)
     decoder_cell = GRUCell(input_size=16, hidden_size=16)
@@ -592,6 +593,7 @@ def test_beamsearchdecoder8():
             pass
         else:
             raise Exception
+    paddle.disable_static()
 
 
 @pytest.mark.api_nn_BeamSearchDecoder_exception


### PR DESCRIPTION
这个单测捕捉主框架中接口的异常行为，而该异常行为发生的地方只应该在静态图模式下。

详见PR：https://github.com/PaddlePaddle/Paddle/pull/49473 的改动：
python/paddle/fluid/layers/tensor.py