### PR TITLE
fix mkldnn  test_image_classification_infer.py failure

### DIFF
--- a/inference/python_api_test/test_int8_model/test_image_classification_infer.py
+++ b/inference/python_api_test/test_int8_model/test_image_classification_infer.py
@@ -236,6 +236,11 @@ def main(FLAGS):
     main func
     """
     predictor = None
+
+    if FLAGS.use_mkldnn:
+        pass
+        # FLAGS.device = 'CPU'
+
     if FLAGS.deploy_backend == "paddle_inference":
         predictor = PaddleInferenceEngine(
             model_dir=FLAGS.model_path,

--- a/inference/python_api_test/test_int8_model/test_image_classification_infer.py
+++ b/inference/python_api_test/test_int8_model/test_image_classification_infer.py
@@ -238,7 +238,7 @@ def main(FLAGS):
     predictor = None
 
     if FLAGS.use_mkldnn:
-        FLAGS.device = 'CPU'
+        FLAGS.device = "CPU"
 
     if FLAGS.deploy_backend == "paddle_inference":
         predictor = PaddleInferenceEngine(

--- a/inference/python_api_test/test_int8_model/test_image_classification_infer.py
+++ b/inference/python_api_test/test_int8_model/test_image_classification_infer.py
@@ -238,8 +238,7 @@ def main(FLAGS):
     predictor = None
 
     if FLAGS.use_mkldnn:
-        pass
-        # FLAGS.device = 'CPU'
+        FLAGS.device = 'CPU'
 
     if FLAGS.deploy_backend == "paddle_inference":
         predictor = PaddleInferenceEngine(


### PR DESCRIPTION
- 当跑mlkdnn时候，必须指定--device=CPU