### PR TITLE
skip the tnt_gpu_mixed case in CI, run_mode=model

### DIFF
--- a/inference/python_api_test/test_class_model/test_tnt_small_gpu.py
+++ b/inference/python_api_test/test_class_model/test_tnt_small_gpu.py
@@ -95,6 +95,7 @@ def test_gpu_more_bz():
 @pytest.mark.win
 @pytest.mark.server
 @pytest.mark.gpu
+@pytest.mark.skip(reason="Precision reduction caused by PR 49753 fc kernel fuse")
 def test_gpu_mixed_precision_bz1():
     """
     compared gpu batch_size=1 TNT_small mixed_precision outputs with true val


### PR DESCRIPTION
The precision reduction caused by PR 49753 fc kernel fuse can't be further repaired.