### PR TITLE
Remove delete_pass_list of ViT cases

### DIFF
--- a/inference/python_api_test/test_class_model/test_ViT_base_patch16_224_trt_fp16.py
+++ b/inference/python_api_test/test_class_model/test_ViT_base_patch16_224_trt_fp16.py
@@ -32,7 +32,8 @@ def check_model_exist():
         tar.extractall()
         tar.close()
         clip_model_extra_op(
-            path_prefix="./ViT_base_patch16_224/inference", output_model_path="./ViT_base_patch16_224/inference"
+            path_prefix="./ViT_base_patch16_224/inference",
+            output_model_path="./ViT_base_patch16_224/inference",
         )
 
 
@@ -43,7 +44,8 @@ def test_config():
     check_model_exist()
     test_suite = InferenceTest()
     test_suite.load_config(
-        model_file="./ViT_base_patch16_224/inference.pdmodel", params_file="./ViT_base_patch16_224/inference.pdiparams"
+        model_file="./ViT_base_patch16_224/inference.pdmodel",
+        params_file="./ViT_base_patch16_224/inference.pdiparams",
     )
     test_suite.config_test()
 
@@ -85,7 +87,6 @@ def test_trt_fp16_more_bz():
             delta=2e-4,
             max_batch_size=max_batch_size,
             precision="trt_fp16",
-            delete_pass_list=["preln_residual_bias_fuse_pass"],
             dynamic=True,
             tuned=True,
         )
@@ -103,7 +104,6 @@ def test_trt_fp16_more_bz():
             delta=2e-4,
             max_batch_size=max_batch_size,
             precision="trt_fp16",
-            delete_pass_list=["preln_residual_bias_fuse_pass"],
             dynamic=True,
         )
 
@@ -146,7 +146,6 @@ def test_jetson_trt_fp16_more_bz():
             delta=2e-4,
             max_batch_size=max_batch_size,
             precision="trt_fp16",
-            delete_pass_list=["preln_residual_bias_fuse_pass"],
             dynamic=True,
             tuned=True,
         )
@@ -164,7 +163,6 @@ def test_jetson_trt_fp16_more_bz():
             delta=2e-4,
             max_batch_size=max_batch_size,
             precision="trt_fp16",
-            delete_pass_list=["preln_residual_bias_fuse_pass"],
             dynamic=True,
         )
 
@@ -183,7 +181,8 @@ def test_trt_fp16_bz1_multi_thread():
     batch_size = 1
     test_suite = InferenceTest()
     test_suite.load_config(
-        model_file="./ViT_base_patch16_224/inference.pdmodel", params_file="./ViT_base_patch16_224/inference.pdiparams"
+        model_file="./ViT_base_patch16_224/inference.pdmodel",
+        params_file="./ViT_base_patch16_224/inference.pdiparams",
     )
     images_list, npy_list = test_suite.get_images_npy(file_path, images_size)
     fake_input = np.array(images_list[0:batch_size]).astype("float32")
@@ -194,14 +193,14 @@ def test_trt_fp16_bz1_multi_thread():
 
     test_suite2 = InferenceTest()
     test_suite2.load_config(
-        model_file="./ViT_base_patch16_224/inference.pdmodel", params_file="./ViT_base_patch16_224/inference.pdiparams"
+        model_file="./ViT_base_patch16_224/inference.pdmodel",
+        params_file="./ViT_base_patch16_224/inference.pdiparams",
     )
     test_suite2.trt_bz1_multi_thread_test(
         input_data_dict,
         output_data_dict,
         delta=2e-4,
         precision="trt_fp16",
-        delete_pass_list=["preln_residual_bias_fuse_pass"],
     )
 
     del test_suite2  # destroy class to save memory

--- a/inference/python_api_test/test_class_model/test_ViT_base_patch16_224_trt_fp32.py
+++ b/inference/python_api_test/test_class_model/test_ViT_base_patch16_224_trt_fp32.py
@@ -31,7 +31,8 @@ def check_model_exist():
         tar.extractall()
         tar.close()
         clip_model_extra_op(
-            path_prefix="./ViT_base_patch16_224/inference", output_model_path="./ViT_base_patch16_224/inference"
+            path_prefix="./ViT_base_patch16_224/inference",
+            output_model_path="./ViT_base_patch16_224/inference",
         )
 
 
@@ -42,7 +43,8 @@ def test_config():
     check_model_exist()
     test_suite = InferenceTest()
     test_suite.load_config(
-        model_file="./ViT_base_patch16_224/inference.pdmodel", params_file="./ViT_base_patch16_224/inference.pdiparams"
+        model_file="./ViT_base_patch16_224/inference.pdmodel",
+        params_file="./ViT_base_patch16_224/inference.pdiparams",
     )
     test_suite.config_test()
 
@@ -83,7 +85,6 @@ def test_trt_fp32_more_bz():
             output_data_dict,
             max_batch_size=max_batch_size,
             precision="trt_fp32",
-            delete_pass_list=["preln_residual_bias_fuse_pass"],
             dynamic=True,
             tuned=True,
         )
@@ -100,7 +101,6 @@ def test_trt_fp32_more_bz():
             output_data_dict,
             max_batch_size=max_batch_size,
             precision="trt_fp32",
-            delete_pass_list=["preln_residual_bias_fuse_pass"],
             dynamic=True,
         )
 
@@ -142,7 +142,6 @@ def test_jetson_trt_fp32_more_bz():
             output_data_dict,
             max_batch_size=max_batch_size,
             precision="trt_fp32",
-            delete_pass_list=["preln_residual_bias_fuse_pass"],
             dynamic=True,
             tuned=True,
         )
@@ -159,7 +158,6 @@ def test_jetson_trt_fp32_more_bz():
             output_data_dict,
             max_batch_size=max_batch_size,
             precision="trt_fp32",
-            delete_pass_list=["preln_residual_bias_fuse_pass"],
             dynamic=True,
         )
 
@@ -178,7 +176,8 @@ def test_trt_fp32_bz1_multi_thread():
     batch_size = 1
     test_suite = InferenceTest()
     test_suite.load_config(
-        model_file="./ViT_base_patch16_224/inference.pdmodel", params_file="./ViT_base_patch16_224/inference.pdiparams"
+        model_file="./ViT_base_patch16_224/inference.pdmodel",
+        params_file="./ViT_base_patch16_224/inference.pdiparams",
     )
     images_list, npy_list = test_suite.get_images_npy(file_path, images_size)
     fake_input = np.array(images_list[0:batch_size]).astype("float32")
@@ -189,10 +188,13 @@ def test_trt_fp32_bz1_multi_thread():
 
     test_suite2 = InferenceTest()
     test_suite2.load_config(
-        model_file="./ViT_base_patch16_224/inference.pdmodel", params_file="./ViT_base_patch16_224/inference.pdiparams"
+        model_file="./ViT_base_patch16_224/inference.pdmodel",
+        params_file="./ViT_base_patch16_224/inference.pdiparams",
     )
     test_suite2.trt_bz1_multi_thread_test(
-        input_data_dict, output_data_dict, precision="trt_fp32", delete_pass_list=["preln_residual_bias_fuse_pass"]
+        input_data_dict,
+        output_data_dict,
+        precision="trt_fp32",
     )
 
     del test_suite2  # destroy class to save memory

--- a/inference/python_api_test/test_class_model/test_ViT_base_patch16_384_trt_fp16.py
+++ b/inference/python_api_test/test_class_model/test_ViT_base_patch16_384_trt_fp16.py
@@ -32,7 +32,8 @@ def check_model_exist():
         tar.extractall()
         tar.close()
         clip_model_extra_op(
-            path_prefix="./ViT_base_patch16_384/inference", output_model_path="./ViT_base_patch16_384/inference"
+            path_prefix="./ViT_base_patch16_384/inference",
+            output_model_path="./ViT_base_patch16_384/inference",
         )
 
 
@@ -43,7 +44,8 @@ def test_config():
     check_model_exist()
     test_suite = InferenceTest()
     test_suite.load_config(
-        model_file="./ViT_base_patch16_384/inference.pdmodel", params_file="./ViT_base_patch16_384/inference.pdiparams"
+        model_file="./ViT_base_patch16_384/inference.pdmodel",
+        params_file="./ViT_base_patch16_384/inference.pdiparams",
     )
     test_suite.config_test()
 
@@ -85,7 +87,6 @@ def test_trt_fp16_more_bz():
             max_batch_size=max_batch_size,
             precision="trt_fp16",
             delta=0.005,
-            delete_pass_list=["preln_residual_bias_fuse_pass"],
             dynamic=True,
             tuned=True,
         )
@@ -103,7 +104,6 @@ def test_trt_fp16_more_bz():
             max_batch_size=max_batch_size,
             precision="trt_fp16",
             delta=0.005,
-            delete_pass_list=["preln_residual_bias_fuse_pass"],
             dynamic=True,
         )
 
@@ -146,7 +146,6 @@ def test_jetson_trt_fp16_more_bz():
             max_batch_size=max_batch_size,
             precision="trt_fp16",
             delta=0.005,
-            delete_pass_list=["preln_residual_bias_fuse_pass"],
             dynamic=True,
             tuned=True,
         )
@@ -164,7 +163,6 @@ def test_jetson_trt_fp16_more_bz():
             max_batch_size=max_batch_size,
             precision="trt_fp16",
             delta=0.005,
-            delete_pass_list=["preln_residual_bias_fuse_pass"],
             dynamic=True,
         )
 
@@ -183,7 +181,8 @@ def test_trt_fp16_bz1_multi_thread():
     batch_size = 1
     test_suite = InferenceTest()
     test_suite.load_config(
-        model_file="./ViT_base_patch16_384/inference.pdmodel", params_file="./ViT_base_patch16_384/inference.pdiparams"
+        model_file="./ViT_base_patch16_384/inference.pdmodel",
+        params_file="./ViT_base_patch16_384/inference.pdiparams",
     )
     images_list, npy_list = test_suite.get_images_npy(file_path, images_size)
     fake_input = np.array(images_list[0:batch_size]).astype("float32")
@@ -193,14 +192,14 @@ def test_trt_fp16_bz1_multi_thread():
     del test_suite  # destroy class to save memory
     test_suite2 = InferenceTest()
     test_suite2.load_config(
-        model_file="./ViT_base_patch16_384/inference.pdmodel", params_file="./ViT_base_patch16_384/inference.pdiparams"
+        model_file="./ViT_base_patch16_384/inference.pdmodel",
+        params_file="./ViT_base_patch16_384/inference.pdiparams",
     )
     test_suite2.trt_bz1_multi_thread_test(
         input_data_dict,
         output_data_dict,
         delta=0.005,
         precision="trt_fp16",
-        delete_pass_list=["preln_residual_bias_fuse_pass"],
     )
 
     del test_suite2  # destroy class to save memory

--- a/inference/python_api_test/test_class_model/test_ViT_base_patch16_384_trt_fp32.py
+++ b/inference/python_api_test/test_class_model/test_ViT_base_patch16_384_trt_fp32.py
@@ -32,7 +32,8 @@ def check_model_exist():
         tar.extractall()
         tar.close()
         clip_model_extra_op(
-            path_prefix="./ViT_base_patch16_384/inference", output_model_path="./ViT_base_patch16_384/inference"
+            path_prefix="./ViT_base_patch16_384/inference",
+            output_model_path="./ViT_base_patch16_384/inference",
         )
 
 
@@ -43,7 +44,8 @@ def test_config():
     check_model_exist()
     test_suite = InferenceTest()
     test_suite.load_config(
-        model_file="./ViT_base_patch16_384/inference.pdmodel", params_file="./ViT_base_patch16_384/inference.pdiparams"
+        model_file="./ViT_base_patch16_384/inference.pdmodel",
+        params_file="./ViT_base_patch16_384/inference.pdiparams",
     )
     test_suite.config_test()
 
@@ -84,7 +86,6 @@ def test_trt_fp32_more_bz():
             output_data_dict,
             max_batch_size=max_batch_size,
             precision="trt_fp32",
-            delete_pass_list=["preln_residual_bias_fuse_pass"],
             dynamic=True,
             tuned=True,
         )
@@ -101,7 +102,6 @@ def test_trt_fp32_more_bz():
             output_data_dict,
             max_batch_size=max_batch_size,
             precision="trt_fp32",
-            delete_pass_list=["preln_residual_bias_fuse_pass"],
             dynamic=True,
         )
 
@@ -143,7 +143,6 @@ def test_jetson_trt_fp32_more_bz():
             output_data_dict,
             max_batch_size=max_batch_size,
             precision="trt_fp32",
-            delete_pass_list=["preln_residual_bias_fuse_pass"],
             dynamic=True,
             tuned=True,
         )
@@ -160,7 +159,6 @@ def test_jetson_trt_fp32_more_bz():
             output_data_dict,
             max_batch_size=max_batch_size,
             precision="trt_fp32",
-            delete_pass_list=["preln_residual_bias_fuse_pass"],
             dynamic=True,
         )
 
@@ -179,7 +177,8 @@ def test_trt_fp32_bz1_multi_thread():
     batch_size = 1
     test_suite = InferenceTest()
     test_suite.load_config(
-        model_file="./ViT_base_patch16_384/inference.pdmodel", params_file="./ViT_base_patch16_384/inference.pdiparams"
+        model_file="./ViT_base_patch16_384/inference.pdmodel",
+        params_file="./ViT_base_patch16_384/inference.pdiparams",
     )
     images_list, npy_list = test_suite.get_images_npy(file_path, images_size)
     fake_input = np.array(images_list[0:batch_size]).astype("float32")
@@ -190,10 +189,13 @@ def test_trt_fp32_bz1_multi_thread():
 
     test_suite2 = InferenceTest()
     test_suite2.load_config(
-        model_file="./ViT_base_patch16_384/inference.pdmodel", params_file="./ViT_base_patch16_384/inference.pdiparams"
+        model_file="./ViT_base_patch16_384/inference.pdmodel",
+        params_file="./ViT_base_patch16_384/inference.pdiparams",
     )
     test_suite2.trt_bz1_multi_thread_test(
-        input_data_dict, output_data_dict, precision="trt_fp32", delete_pass_list=["preln_residual_bias_fuse_pass"]
+        input_data_dict,
+        output_data_dict,
+        precision="trt_fp32",
     )
 
     del test_suite2  # destroy class to save memory

--- a/inference/python_api_test/test_class_model/test_ViT_base_patch32_384_trt_fp16.py
+++ b/inference/python_api_test/test_class_model/test_ViT_base_patch32_384_trt_fp16.py
@@ -32,7 +32,8 @@ def check_model_exist():
         tar.extractall()
         tar.close()
         clip_model_extra_op(
-            path_prefix="./ViT_base_patch32_384/inference", output_model_path="./ViT_base_patch32_384/inference"
+            path_prefix="./ViT_base_patch32_384/inference",
+            output_model_path="./ViT_base_patch32_384/inference",
         )
 
 
@@ -43,7 +44,8 @@ def test_config():
     check_model_exist()
     test_suite = InferenceTest()
     test_suite.load_config(
-        model_file="./ViT_base_patch32_384/inference.pdmodel", params_file="./ViT_base_patch32_384/inference.pdiparams"
+        model_file="./ViT_base_patch32_384/inference.pdmodel",
+        params_file="./ViT_base_patch32_384/inference.pdiparams",
     )
     test_suite.config_test()
 
@@ -85,7 +87,6 @@ def test_trt_fp16_more_bz():
             delta=0.005,
             max_batch_size=max_batch_size,
             precision="trt_fp16",
-            delete_pass_list=["preln_residual_bias_fuse_pass"],
             dynamic=True,
             tuned=True,
         )
@@ -103,7 +104,6 @@ def test_trt_fp16_more_bz():
             delta=0.005,
             max_batch_size=max_batch_size,
             precision="trt_fp16",
-            delete_pass_list=["preln_residual_bias_fuse_pass"],
             dynamic=True,
         )
 
@@ -146,7 +146,6 @@ def test_jetson_trt_fp16_more_bz():
             delta=0.005,
             max_batch_size=max_batch_size,
             precision="trt_fp16",
-            delete_pass_list=["preln_residual_bias_fuse_pass"],
             dynamic=True,
             tuned=True,
         )
@@ -164,7 +163,6 @@ def test_jetson_trt_fp16_more_bz():
             delta=0.005,
             max_batch_size=max_batch_size,
             precision="trt_fp16",
-            delete_pass_list=["preln_residual_bias_fuse_pass"],
             dynamic=True,
         )
 
@@ -183,7 +181,8 @@ def test_trt_fp16_bz1_multi_thread():
     batch_size = 1
     test_suite = InferenceTest()
     test_suite.load_config(
-        model_file="./ViT_base_patch32_384/inference.pdmodel", params_file="./ViT_base_patch32_384/inference.pdiparams"
+        model_file="./ViT_base_patch32_384/inference.pdmodel",
+        params_file="./ViT_base_patch32_384/inference.pdiparams",
     )
     images_list, npy_list = test_suite.get_images_npy(file_path, images_size)
     fake_input = np.array(images_list[0:batch_size]).astype("float32")
@@ -193,14 +192,14 @@ def test_trt_fp16_bz1_multi_thread():
     del test_suite  # destroy class to save memory
     test_suite2 = InferenceTest()
     test_suite2.load_config(
-        model_file="./ViT_base_patch32_384/inference.pdmodel", params_file="./ViT_base_patch32_384/inference.pdiparams"
+        model_file="./ViT_base_patch32_384/inference.pdmodel",
+        params_file="./ViT_base_patch32_384/inference.pdiparams",
     )
     test_suite2.trt_bz1_multi_thread_test(
         input_data_dict,
         output_data_dict,
         delta=0.005,
         precision="trt_fp16",
-        delete_pass_list=["preln_residual_bias_fuse_pass"],
     )
 
     del test_suite2  # destroy class to save memory

--- a/inference/python_api_test/test_class_model/test_ViT_base_patch32_384_trt_fp32.py
+++ b/inference/python_api_test/test_class_model/test_ViT_base_patch32_384_trt_fp32.py
@@ -32,7 +32,8 @@ def check_model_exist():
         tar.extractall()
         tar.close()
         clip_model_extra_op(
-            path_prefix="./ViT_base_patch32_384/inference", output_model_path="./ViT_base_patch32_384/inference"
+            path_prefix="./ViT_base_patch32_384/inference",
+            output_model_path="./ViT_base_patch32_384/inference",
         )
 
 
@@ -43,7 +44,8 @@ def test_config():
     check_model_exist()
     test_suite = InferenceTest()
     test_suite.load_config(
-        model_file="./ViT_base_patch32_384/inference.pdmodel", params_file="./ViT_base_patch32_384/inference.pdiparams"
+        model_file="./ViT_base_patch32_384/inference.pdmodel",
+        params_file="./ViT_base_patch32_384/inference.pdiparams",
     )
     test_suite.config_test()
 
@@ -84,7 +86,6 @@ def test_trt_fp32_more_bz():
             output_data_dict,
             max_batch_size=max_batch_size,
             precision="trt_fp32",
-            delete_pass_list=["preln_residual_bias_fuse_pass"],
             dynamic=True,
             tuned=True,
         )
@@ -101,7 +102,6 @@ def test_trt_fp32_more_bz():
             output_data_dict,
             max_batch_size=max_batch_size,
             precision="trt_fp32",
-            delete_pass_list=["preln_residual_bias_fuse_pass"],
             dynamic=True,
         )
 
@@ -143,7 +143,6 @@ def test_jetson_trt_fp32_more_bz():
             output_data_dict,
             max_batch_size=max_batch_size,
             precision="trt_fp32",
-            delete_pass_list=["preln_residual_bias_fuse_pass"],
             dynamic=True,
             tuned=True,
         )
@@ -160,7 +159,6 @@ def test_jetson_trt_fp32_more_bz():
             output_data_dict,
             max_batch_size=max_batch_size,
             precision="trt_fp32",
-            delete_pass_list=["preln_residual_bias_fuse_pass"],
             dynamic=True,
         )
 
@@ -179,7 +177,8 @@ def test_trt_fp32_bz1_multi_thread():
     batch_size = 1
     test_suite = InferenceTest()
     test_suite.load_config(
-        model_file="./ViT_base_patch32_384/inference.pdmodel", params_file="./ViT_base_patch32_384/inference.pdiparams"
+        model_file="./ViT_base_patch32_384/inference.pdmodel",
+        params_file="./ViT_base_patch32_384/inference.pdiparams",
     )
     images_list, npy_list = test_suite.get_images_npy(file_path, images_size)
     fake_input = np.array(images_list[0:batch_size]).astype("float32")
@@ -190,10 +189,13 @@ def test_trt_fp32_bz1_multi_thread():
 
     test_suite2 = InferenceTest()
     test_suite2.load_config(
-        model_file="./ViT_base_patch32_384/inference.pdmodel", params_file="./ViT_base_patch32_384/inference.pdiparams"
+        model_file="./ViT_base_patch32_384/inference.pdmodel",
+        params_file="./ViT_base_patch32_384/inference.pdiparams",
     )
     test_suite2.trt_bz1_multi_thread_test(
-        input_data_dict, output_data_dict, precision="trt_fp32", delete_pass_list=["preln_residual_bias_fuse_pass"]
+        input_data_dict,
+        output_data_dict,
+        precision="trt_fp32",
     )
 
     del test_suite2  # destroy class to save memory

--- a/inference/python_api_test/test_class_model/test_ViT_large_patch16_224_trt_fp16.py
+++ b/inference/python_api_test/test_class_model/test_ViT_large_patch16_224_trt_fp16.py
@@ -32,7 +32,8 @@ def check_model_exist():
         tar.extractall()
         tar.close()
         clip_model_extra_op(
-            path_prefix="./ViT_large_patch16_224/inference", output_model_path="./ViT_large_patch16_224/inference"
+            path_prefix="./ViT_large_patch16_224/inference",
+            output_model_path="./ViT_large_patch16_224/inference",
         )
 
 
@@ -86,7 +87,6 @@ def test_trt_fp16_more_bz():
             delta=0.003,
             max_batch_size=max_batch_size,
             precision="trt_fp16",
-            delete_pass_list=["preln_residual_bias_fuse_pass"],
             dynamic=True,
             tuned=True,
         )
@@ -104,7 +104,6 @@ def test_trt_fp16_more_bz():
             delta=0.003,
             max_batch_size=max_batch_size,
             precision="trt_fp16",
-            delete_pass_list=["preln_residual_bias_fuse_pass"],
             dynamic=True,
         )
 
@@ -147,7 +146,6 @@ def test_jetson_trt_fp16_more_bz():
             delta=0.003,
             max_batch_size=max_batch_size,
             precision="trt_fp16",
-            delete_pass_list=["preln_residual_bias_fuse_pass"],
             dynamic=True,
             tuned=True,
         )
@@ -165,7 +163,6 @@ def test_jetson_trt_fp16_more_bz():
             delta=0.003,
             max_batch_size=max_batch_size,
             precision="trt_fp16",
-            delete_pass_list=["preln_residual_bias_fuse_pass"],
             dynamic=True,
         )
 
@@ -204,7 +201,6 @@ def test_trt_fp16_bz1_multi_thread():
         output_data_dict,
         delta=0.003,
         precision="trt_fp16",
-        delete_pass_list=["preln_residual_bias_fuse_pass"],
     )
 
     del test_suite2  # destroy class to save memory

--- a/inference/python_api_test/test_class_model/test_ViT_large_patch16_224_trt_fp32.py
+++ b/inference/python_api_test/test_class_model/test_ViT_large_patch16_224_trt_fp32.py
@@ -32,7 +32,8 @@ def check_model_exist():
         tar.extractall()
         tar.close()
         clip_model_extra_op(
-            path_prefix="./ViT_large_patch16_224/inference", output_model_path="./ViT_large_patch16_224/inference"
+            path_prefix="./ViT_large_patch16_224/inference",
+            output_model_path="./ViT_large_patch16_224/inference",
         )
 
 
@@ -85,7 +86,6 @@ def test_trt_fp32_more_bz():
             output_data_dict,
             max_batch_size=max_batch_size,
             precision="trt_fp32",
-            delete_pass_list=["preln_residual_bias_fuse_pass"],
             dynamic=True,
             tuned=True,
         )
@@ -102,7 +102,6 @@ def test_trt_fp32_more_bz():
             output_data_dict,
             max_batch_size=max_batch_size,
             precision="trt_fp32",
-            delete_pass_list=["preln_residual_bias_fuse_pass"],
             dynamic=True,
         )
 
@@ -144,7 +143,6 @@ def test_jetson_trt_fp32_more_bz():
             output_data_dict,
             max_batch_size=max_batch_size,
             precision="trt_fp32",
-            delete_pass_list=["preln_residual_bias_fuse_pass"],
             dynamic=True,
             tuned=True,
         )
@@ -161,7 +159,6 @@ def test_jetson_trt_fp32_more_bz():
             output_data_dict,
             max_batch_size=max_batch_size,
             precision="trt_fp32",
-            delete_pass_list=["preln_residual_bias_fuse_pass"],
             dynamic=True,
         )
 
@@ -196,7 +193,9 @@ def test_trt_fp32_bz1_multi_thread():
         params_file="./ViT_large_patch16_224/inference.pdiparams",
     )
     test_suite2.trt_bz1_multi_thread_test(
-        input_data_dict, output_data_dict, precision="trt_fp32", delete_pass_list=["preln_residual_bias_fuse_pass"]
+        input_data_dict,
+        output_data_dict,
+        precision="trt_fp32",
     )
 
     del test_suite2  # destroy class to save memory

--- a/inference/python_api_test/test_class_model/test_ViT_large_patch16_384_trt_fp16.py
+++ b/inference/python_api_test/test_class_model/test_ViT_large_patch16_384_trt_fp16.py
@@ -32,7 +32,8 @@ def check_model_exist():
         tar.extractall()
         tar.close()
         clip_model_extra_op(
-            path_prefix="./ViT_large_patch16_384/inference", output_model_path="./ViT_large_patch16_384/inference"
+            path_prefix="./ViT_large_patch16_384/inference",
+            output_model_path="./ViT_large_patch16_384/inference",
         )
 
 
@@ -86,7 +87,6 @@ def test_trt_fp16_more_bz():
             delta=0.0003,
             max_batch_size=max_batch_size,
             precision="trt_fp16",
-            delete_pass_list=["preln_residual_bias_fuse_pass"],
             dynamic=True,
             tuned=True,
         )
@@ -104,7 +104,6 @@ def test_trt_fp16_more_bz():
             delta=0.0003,
             max_batch_size=max_batch_size,
             precision="trt_fp16",
-            delete_pass_list=["preln_residual_bias_fuse_pass"],
             dynamic=True,
         )
 
@@ -147,7 +146,6 @@ def test_jetson_trt_fp16_more_bz():
             delta=0.0003,
             max_batch_size=max_batch_size,
             precision="trt_fp16",
-            delete_pass_list=["preln_residual_bias_fuse_pass"],
             dynamic=True,
             tuned=True,
         )
@@ -165,7 +163,6 @@ def test_jetson_trt_fp16_more_bz():
             delta=0.0003,
             max_batch_size=max_batch_size,
             precision="trt_fp16",
-            delete_pass_list=["preln_residual_bias_fuse_pass"],
             dynamic=True,
         )
 
@@ -203,7 +200,6 @@ def test_trt_fp16_bz1_multi_thread():
         output_data_dict,
         delta=0.0003,
         precision="trt_fp16",
-        delete_pass_list=["preln_residual_bias_fuse_pass"],
     )
 
     del test_suite2  # destroy class to save memory

--- a/inference/python_api_test/test_class_model/test_ViT_large_patch16_384_trt_fp32.py
+++ b/inference/python_api_test/test_class_model/test_ViT_large_patch16_384_trt_fp32.py
@@ -32,7 +32,8 @@ def check_model_exist():
         tar.extractall()
         tar.close()
         clip_model_extra_op(
-            path_prefix="./ViT_large_patch16_384/inference", output_model_path="./ViT_large_patch16_384/inference"
+            path_prefix="./ViT_large_patch16_384/inference",
+            output_model_path="./ViT_large_patch16_384/inference",
         )
 
 
@@ -85,7 +86,6 @@ def test_trt_fp32_more_bz():
             output_data_dict,
             max_batch_size=max_batch_size,
             precision="trt_fp32",
-            delete_pass_list=["preln_residual_bias_fuse_pass"],
             dynamic=True,
             tuned=True,
         )
@@ -102,7 +102,6 @@ def test_trt_fp32_more_bz():
             output_data_dict,
             max_batch_size=max_batch_size,
             precision="trt_fp32",
-            delete_pass_list=["preln_residual_bias_fuse_pass"],
             dynamic=True,
         )
 
@@ -144,7 +143,6 @@ def test_jetson_trt_fp32_more_bz():
             output_data_dict,
             max_batch_size=max_batch_size,
             precision="trt_fp32",
-            delete_pass_list=["preln_residual_bias_fuse_pass"],
             dynamic=True,
             tuned=True,
         )
@@ -161,7 +159,6 @@ def test_jetson_trt_fp32_more_bz():
             output_data_dict,
             max_batch_size=max_batch_size,
             precision="trt_fp32",
-            delete_pass_list=["preln_residual_bias_fuse_pass"],
             dynamic=True,
         )
 
@@ -196,7 +193,9 @@ def test_trt_fp32_bz1_multi_thread():
         params_file="./ViT_large_patch16_384/inference.pdiparams",
     )
     test_suite2.trt_bz1_multi_thread_test(
-        input_data_dict, output_data_dict, precision="trt_fp32", delete_pass_list=["preln_residual_bias_fuse_pass"]
+        input_data_dict,
+        output_data_dict,
+        precision="trt_fp32",
     )
 
     del test_suite2  # destroy class to save memory

--- a/inference/python_api_test/test_class_model/test_ViT_large_patch32_384_trt_fp16.py
+++ b/inference/python_api_test/test_class_model/test_ViT_large_patch32_384_trt_fp16.py
@@ -32,7 +32,8 @@ def check_model_exist():
         tar.extractall()
         tar.close()
         clip_model_extra_op(
-            path_prefix="./ViT_large_patch32_384/inference", output_model_path="./ViT_large_patch32_384/inference"
+            path_prefix="./ViT_large_patch32_384/inference",
+            output_model_path="./ViT_large_patch32_384/inference",
         )
 
 
@@ -86,7 +87,6 @@ def test_trt_fp16_more_bz():
             delta=0.0005,
             max_batch_size=max_batch_size,
             precision="trt_fp16",
-            delete_pass_list=["preln_residual_bias_fuse_pass"],
             dynamic=True,
             tuned=True,
         )
@@ -104,7 +104,6 @@ def test_trt_fp16_more_bz():
             delta=0.0005,
             max_batch_size=max_batch_size,
             precision="trt_fp16",
-            delete_pass_list=["preln_residual_bias_fuse_pass"],
             dynamic=True,
         )
 
@@ -147,7 +146,6 @@ def test_jetson_trt_fp16_more_bz():
             delta=0.0005,
             max_batch_size=max_batch_size,
             precision="trt_fp16",
-            delete_pass_list=["preln_residual_bias_fuse_pass"],
             dynamic=True,
             tuned=True,
         )
@@ -165,7 +163,6 @@ def test_jetson_trt_fp16_more_bz():
             delta=0.0005,
             max_batch_size=max_batch_size,
             precision="trt_fp16",
-            delete_pass_list=["preln_residual_bias_fuse_pass"],
             dynamic=True,
         )
 
@@ -203,7 +200,6 @@ def test_trt_fp16_bz1_multi_thread():
         output_data_dict,
         delta=0.0005,
         precision="trt_fp16",
-        delete_pass_list=["preln_residual_bias_fuse_pass"],
     )
 
     del test_suite2  # destroy class to save memory

--- a/inference/python_api_test/test_class_model/test_ViT_large_patch32_384_trt_fp32.py
+++ b/inference/python_api_test/test_class_model/test_ViT_large_patch32_384_trt_fp32.py
@@ -32,7 +32,8 @@ def check_model_exist():
         tar.extractall()
         tar.close()
         clip_model_extra_op(
-            path_prefix="./ViT_large_patch32_384/inference", output_model_path="./ViT_large_patch32_384/inference"
+            path_prefix="./ViT_large_patch32_384/inference",
+            output_model_path="./ViT_large_patch32_384/inference",
         )
 
 
@@ -85,7 +86,6 @@ def test_trt_fp32_more_bz():
             output_data_dict,
             max_batch_size=max_batch_size,
             precision="trt_fp32",
-            delete_pass_list=["preln_residual_bias_fuse_pass"],
             dynamic=True,
             tuned=True,
         )
@@ -102,7 +102,6 @@ def test_trt_fp32_more_bz():
             output_data_dict,
             max_batch_size=max_batch_size,
             precision="trt_fp32",
-            delete_pass_list=["preln_residual_bias_fuse_pass"],
             dynamic=True,
         )
 
@@ -144,7 +143,6 @@ def test_jetson_trt_fp32_more_bz():
             output_data_dict,
             max_batch_size=max_batch_size,
             precision="trt_fp32",
-            delete_pass_list=["preln_residual_bias_fuse_pass"],
             dynamic=True,
             tuned=True,
         )
@@ -161,7 +159,6 @@ def test_jetson_trt_fp32_more_bz():
             output_data_dict,
             max_batch_size=max_batch_size,
             precision="trt_fp32",
-            delete_pass_list=["preln_residual_bias_fuse_pass"],
             dynamic=True,
         )
 
@@ -196,7 +193,9 @@ def test_trt_fp32_bz1_multi_thread():
         params_file="./ViT_large_patch32_384/inference.pdiparams",
     )
     test_suite2.trt_bz1_multi_thread_test(
-        input_data_dict, output_data_dict, precision="trt_fp32", delete_pass_list=["preln_residual_bias_fuse_pass"]
+        input_data_dict,
+        output_data_dict,
+        precision="trt_fp32",
     )
 
     del test_suite2  # destroy class to save memory

--- a/inference/python_api_test/test_class_model/test_ViT_small_patch16_224_trt_fp16.py
+++ b/inference/python_api_test/test_class_model/test_ViT_small_patch16_224_trt_fp16.py
@@ -32,7 +32,8 @@ def check_model_exist():
         tar.extractall()
         tar.close()
         clip_model_extra_op(
-            path_prefix="./ViT_small_patch16_224/inference", output_model_path="./ViT_small_patch16_224/inference"
+            path_prefix="./ViT_small_patch16_224/inference",
+            output_model_path="./ViT_small_patch16_224/inference",
         )
 
 
@@ -142,7 +143,7 @@ def test_jetson_trt_fp16_more_bz():
         test_suite1.trt_more_bz_test(
             input_data_dict,
             output_data_dict,
-            delta=0.003,
+            delta=0.007,
             max_batch_size=max_batch_size,
             precision="trt_fp16",
             dynamic=True,
@@ -159,7 +160,7 @@ def test_jetson_trt_fp16_more_bz():
         test_suite2.trt_more_bz_test(
             input_data_dict,
             output_data_dict,
-            delta=0.003,
+            delta=0.007,
             max_batch_size=max_batch_size,
             precision="trt_fp16",
             dynamic=True,
@@ -195,6 +196,11 @@ def test_trt_fp16_bz1_multi_thread():
         model_file="./ViT_small_patch16_224/inference.pdmodel",
         params_file="./ViT_small_patch16_224/inference.pdiparams",
     )
-    test_suite2.trt_bz1_multi_thread_test(input_data_dict, output_data_dict, delta=0.003, precision="trt_fp16")
+    test_suite2.trt_bz1_multi_thread_test(
+        input_data_dict,
+        output_data_dict,
+        delta=0.003,
+        precision="trt_fp16",
+    )
 
     del test_suite2  # destroy class to save memory

--- a/inference/python_api_test/test_class_model/test_ViT_small_patch16_224_trt_fp32.py
+++ b/inference/python_api_test/test_class_model/test_ViT_small_patch16_224_trt_fp32.py
@@ -32,7 +32,8 @@ def check_model_exist():
         tar.extractall()
         tar.close()
         clip_model_extra_op(
-            path_prefix="./ViT_small_patch16_224/inference", output_model_path="./ViT_small_patch16_224/inference"
+            path_prefix="./ViT_small_patch16_224/inference",
+            output_model_path="./ViT_small_patch16_224/inference",
         )
 
 
@@ -85,7 +86,6 @@ def test_trt_fp32_more_bz():
             output_data_dict,
             max_batch_size=max_batch_size,
             precision="trt_fp32",
-            delete_pass_list=["preln_residual_bias_fuse_pass"],
             dynamic=True,
             tuned=True,
         )
@@ -102,7 +102,6 @@ def test_trt_fp32_more_bz():
             output_data_dict,
             max_batch_size=max_batch_size,
             precision="trt_fp32",
-            delete_pass_list=["preln_residual_bias_fuse_pass"],
             dynamic=True,
         )
 
@@ -144,7 +143,6 @@ def test_jetson_trt_fp32_more_bz():
             output_data_dict,
             max_batch_size=max_batch_size,
             precision="trt_fp32",
-            delete_pass_list=["preln_residual_bias_fuse_pass"],
             dynamic=True,
             tuned=True,
         )
@@ -161,7 +159,6 @@ def test_jetson_trt_fp32_more_bz():
             output_data_dict,
             max_batch_size=max_batch_size,
             precision="trt_fp32",
-            delete_pass_list=["preln_residual_bias_fuse_pass"],
             dynamic=True,
         )
 
@@ -196,7 +193,9 @@ def test_trt_fp32_bz1_multi_thread():
         params_file="./ViT_small_patch16_224/inference.pdiparams",
     )
     test_suite2.trt_bz1_multi_thread_test(
-        input_data_dict, output_data_dict, precision="trt_fp32", delete_pass_list=["preln_residual_bias_fuse_pass"]
+        input_data_dict,
+        output_data_dict,
+        precision="trt_fp32",
     )
 
     del test_suite2  # destroy class to save memory


### PR DESCRIPTION
Remove delete_pass_list=["preln_residual_bias_fuse_pass"] of ViT cases because of the Bug_fix [PR](https://github.com/PaddlePaddle/Paddle/pull/50381) in release