### PR TITLE
add det infer case top bbox check

### DIFF
--- a/inference/python_api_test/test_case/image_preprocess.py
+++ b/inference/python_api_test/test_case/image_preprocess.py
@@ -153,7 +153,7 @@ def normalize(num):
         return num
 
 
-def sig_fig_compare(array1, array2, delta=5):
+def sig_fig_compare(array1, array2, delta=5, det_top_bbox=False, det_top_bbox_threshold=0.75):
     """
     compare significant figure
     Args:
@@ -164,6 +164,12 @@ def sig_fig_compare(array1, array2, delta=5):
     """
     # start = time.time()
     assert not np.all(np.isnan(array1)), f"output value all nan! \n{array1}"
+    if det_top_bbox and len(array1.shape) == 2:
+        # 适配部分fp16检测模型case,只对比超过置信度阈值的检测框
+        if array1.shape[1] == 6:
+            top_count = sum(array1[:, 1] >= det_top_bbox_threshold)
+            array1 = array1[:top_count, :]
+            array2 = array2[:top_count, :]
     if np.any(abs(array2) > 100):
         normalize_func = np.vectorize(normalize)
         array1_normal = normalize_func(array1)

--- a/inference/python_api_test/test_case/infer_test.py
+++ b/inference/python_api_test/test_case/infer_test.py
@@ -599,7 +599,8 @@ class InferenceTest(object):
         dynamic=False,
         shape_range_file="shape_range.pbtxt",
         tuned=False,
-        result_sort=False,
+        det_top_bbox=False,
+        det_top_bbox_threshold=0.75,
         delete_pass_list=None,
     ):
         """
@@ -672,7 +673,7 @@ class InferenceTest(object):
             output_data_truth_val = output_data_dict[output_data_name]
             print("output_data_shape:", output_data.shape)
             print("truth_value_shape:", output_data_truth_val.shape)
-            diff = sig_fig_compare(output_data, output_data_truth_val, delta)
+            diff = sig_fig_compare(output_data, output_data_truth_val, delta, det_top_bbox, det_top_bbox_threshold)
 
     def trt_more_bz_dynamic_test(
         self,

--- a/inference/python_api_test/test_det_model/test_fast_rcnn_trt_fp16.py
+++ b/inference/python_api_test/test_det_model/test_fast_rcnn_trt_fp16.py
@@ -96,5 +96,4 @@ def test_trt_fp16_more_bz():
             precision="trt_fp16",
             dynamic=True,
             tuned=False,
-            result_sort=True,
         )

--- a/inference/python_api_test/test_det_model/test_mask_rcnn_trt_fp16.py
+++ b/inference/python_api_test/test_det_model/test_mask_rcnn_trt_fp16.py
@@ -95,6 +95,5 @@ def test_trt_fp16_more_bz():
             precision="trt_fp16",
             dynamic=True,
             tuned=False,
-            result_sort=True,
             min_subgraph_size=35,
         )

--- a/inference/python_api_test/test_det_model/test_ppyolo_trt_fp16.py
+++ b/inference/python_api_test/test_det_model/test_ppyolo_trt_fp16.py
@@ -102,7 +102,6 @@ def test_trt_fp16_more_bz():
             repeat=1,
             delta=1,
             precision="trt_fp16",
-            result_sort=True,
             dynamic=True,
             shape_range_file="./ppyolo/shape_range.pbtxt",
         )

--- a/inference/python_api_test/test_det_model/test_ppyolov2_trt_fp16.py
+++ b/inference/python_api_test/test_det_model/test_ppyolov2_trt_fp16.py
@@ -99,5 +99,6 @@ def test_trt_fp16_more_bz():
             repeat=1,
             delta=2.4,
             precision="trt_fp16",
-            result_sort=True,
+            det_top_bbox=True,
+            det_top_bbox_threshold=0.75,
         )

--- a/inference/python_api_test/test_det_model/test_yolov3_trt_fp16.py
+++ b/inference/python_api_test/test_det_model/test_yolov3_trt_fp16.py
@@ -145,9 +145,7 @@ def test_trt_fp16_more_bz():
         # output_data_dict = {"save_infer_model/scale_0.tmp_1": scale_0, "save_infer_model/scale_1.tmp_1": scale_1}
         output_data_dict = test_suite.get_truth_val(input_data_dict, device="gpu")
         test_suite.load_config(model_file="./yolov3/model.pdmodel", params_file="./yolov3/model.pdiparams")
-        test_suite.trt_more_bz_test(
-            input_data_dict, output_data_dict, repeat=1, delta=6e-2, precision="trt_fp16"
-        )
+        test_suite.trt_more_bz_test(input_data_dict, output_data_dict, repeat=1, delta=6e-2, precision="trt_fp16")
 
         del test_suite  # destroy class to save memory
 

--- a/inference/python_api_test/test_det_model/test_yolov3_trt_fp16.py
+++ b/inference/python_api_test/test_det_model/test_yolov3_trt_fp16.py
@@ -146,7 +146,7 @@ def test_trt_fp16_more_bz():
         output_data_dict = test_suite.get_truth_val(input_data_dict, device="gpu")
         test_suite.load_config(model_file="./yolov3/model.pdmodel", params_file="./yolov3/model.pdiparams")
         test_suite.trt_more_bz_test(
-            input_data_dict, output_data_dict, repeat=1, delta=6e-2, precision="trt_fp16", result_sort=True
+            input_data_dict, output_data_dict, repeat=1, delta=6e-2, precision="trt_fp16"
         )
 
         del test_suite  # destroy class to save memory
@@ -207,7 +207,6 @@ def test_jetson_trt_fp16_more_bz():
             max_batch_size=10,
             delta=6e-2,
             precision="trt_fp16",
-            result_sort=True,
         )
 
         del test_suite  # destroy class to save memory


### PR DESCRIPTION
1. 检测模型TRT FP16 case存在低置信度检测框diff较大的问题，但不影响模型最终检测效果，对这部分case做兼容
2. 增加参数bbox置信度阈值，筛选高于阈值的检测框结果做精度校验，ppyolov2_trt_fp16验证通过