### PR TITLE
update the version of paddlenlp

### DIFF
--- a/inference/python_api_test/requirements.txt
+++ b/inference/python_api_test/requirements.txt
@@ -3,6 +3,6 @@ psutil
 pytest
 pynvml==11.0.0
 opencv-python==4.6.0.66
-paddlenlp==2.5.0
+paddlenlp==2.5.2
 dataclasses ; python_version == "3.6"
 sentencepiece==0.1.96


### PR DESCRIPTION
Update the version of paddlenlp to 2.5.2 to fix the impact of 'remove fluid.dygraph.parallel to distributed.parallel'.