### PR TITLE
fix the error in DLTP-69329 temporarily

### DIFF
--- a/inference/python_api_test/test_class_model/test_tnt_small_trt_fp16.py
+++ b/inference/python_api_test/test_class_model/test_tnt_small_trt_fp16.py
@@ -13,6 +13,7 @@ import six
 import wget
 import pytest
 import numpy as np
+import paddle.inference as paddle_infer
 
 # pylint: disable=wrong-import-position
 sys.path.append("..")
@@ -96,6 +97,11 @@ def test_trt_fp16_more_bz():
             params_file="./TNT_small/inference.pdiparams",
         )
 
+        # fix the error in DLTP-69329 temporarily
+        ver = paddle_infer.get_trt_compile_version()
+        if ver[0] * 1000 + ver[1] * 100 + ver[2] * 10 > 8200:
+            test_suite2.pd_config.exp_disable_tensorrt_ops(["set_value"])
+
         test_suite2.trt_more_bz_test(
             input_data_dict,
             output_data_dict,
@@ -153,6 +159,11 @@ def test_jetson_trt_fp16_more_bz():
             params_file="./TNT_small/inference.pdiparams",
         )
 
+        # fix the error in DLTP-69329 temporarily
+        ver = paddle_infer.get_trt_compile_version()
+        if ver[0] * 1000 + ver[1] * 100 + ver[2] * 10 > 8200:
+            test_suite2.pd_config.exp_disable_tensorrt_ops(["set_value"])
+
         test_suite2.trt_more_bz_test(
             input_data_dict,
             output_data_dict,
@@ -209,6 +220,11 @@ def test_trt_fp16_bz1_multi_thread():
         model_file="./TNT_small/inference.pdmodel",
         params_file="./TNT_small/inference.pdiparams",
     )
+
+    # fix the error in DLTP-69329 temporarily
+    ver = paddle_infer.get_trt_compile_version()
+    if ver[0] * 1000 + ver[1] * 100 + ver[2] * 10 > 8200:
+        test_suite2.pd_config.exp_disable_tensorrt_ops(["set_value"])
 
     test_suite2.trt_bz1_multi_thread_test(
         input_data_dict,


### PR DESCRIPTION
disable the "set_value" op to fix the [error](https://console.cloud.baidu-int.com/devops/icafe/issue/DLTP-69329/show) of declined precision when trt_version > 8.2 temporarily