### PR TITLE
[Zero-Dim] Support output 0D for to_tensor

### DIFF
--- a/framework/api/paddlebase/test_prod.py
+++ b/framework/api/paddlebase/test_prod.py
@@ -157,7 +157,7 @@ def test_prod10():
     x = np.array([[-0.8, -0.4], [0.7, 0.9]])
     axis = 1
     res = np.prod(x, axis=axis)
-    exp = paddle.prod(paddle.to_tensor(x), axis=paddle.to_tensor(axis))
+    exp = paddle.prod(paddle.to_tensor(x), axis=paddle.to_tensor([axis]))
     assert np.allclose(exp.numpy(), res)
 
 


### PR DESCRIPTION
For https://github.com/PaddlePaddle/Paddle/pull/52775 to pass CE-Framework