### PR TITLE
remove np matrix_rank and multi_dot trick

### DIFF
--- a/framework/api/linalg/test_matrix_rank.py
+++ b/framework/api/linalg/test_matrix_rank.py
@@ -38,7 +38,7 @@ def test_matrix_rank_base():
     x = np.array(
         [[-2.0, 2.0, 1.0, 2.0, 2.0], [-2.0, 2.0, 1.0, 2.0, 2.0], [1.0, 3.0, 4.0, 1.0, 7.0], [-4.0, 4.0, 2.0, 4.0, 4.0]]
     )
-    res = [np.linalg.matrix_rank(x, tol=tol, hermitian=hermitian)]
+    res = np.linalg.matrix_rank(x, tol=tol, hermitian=hermitian)
     obj.base(res=res, x=x, tol=tol, hermitian=hermitian)
 
 
@@ -54,7 +54,7 @@ def test_matrix_rank_1():
     x = np.array(
         [[-2.0, 2.0, 1.0, 2.0, 2.0], [-2.0, 2.0, 1.0, 2.0, 2.0], [1.0, 3.0, 4.0, 1.0, 7.0], [-4.0, 4.0, 2.0, 4.0, 4.0]]
     )
-    res = [np.linalg.matrix_rank(x, tol=tol, hermitian=hermitian)]
+    res = np.linalg.matrix_rank(x, tol=tol, hermitian=hermitian)
     obj.run(res=res, x=x, tol=tol, hermitian=hermitian)
 
 
@@ -68,7 +68,7 @@ def test_matrix_rank_2():
     tol = 4.4
     hermitian = True
     x = np.array([[-2.0, 2.0, 1.0, 2.0], [-2.0, 2.0, 1.0, 2.0], [1.0, 3.0, 4.0, 1.0], [-4.0, 4.0, 2.0, 4.0]])
-    res = [np.linalg.matrix_rank(x, tol=tol, hermitian=hermitian)]
+    res = np.linalg.matrix_rank(x, tol=tol, hermitian=hermitian)
     obj.run(res=res, x=x, tol=tol, hermitian=hermitian)
 
 

--- a/framework/api/linalg/test_multi_dot.py
+++ b/framework/api/linalg/test_multi_dot.py
@@ -169,7 +169,7 @@ def test_multi_dot2():
     types = ["float32", "float64"]
     x1 = np.random.rand(4)
     x2 = np.random.rand(4)
-    res = np.dot(x1, x2).reshape([1])
+    res = np.dot(x1, x2)
     for d in types:
         api_res, api_grad = cal_multi_dot(d, x1=x1, x2=x2)
         assert api_res.shape == res.shape
@@ -189,7 +189,7 @@ def test_multi_dot3():
     x2 = np.random.rand(4, 5)
     x3 = np.random.rand(5, 2)
     x4 = np.random.rand(2)
-    res = np.dot(np.dot(x1, x2), np.dot(x3, x4)).reshape([1])
+    res = np.dot(np.dot(x1, x2), np.dot(x3, x4))
     for d in types:
         api_res, api_grad = cal_multi_dot(d, x1=x1, x2=x2, x3=x3, x4=x4)
         assert api_res.shape == res.shape


### PR DESCRIPTION
matrix_rank and multi_dot did not support zero-dimensional output before, and now this [pr](https://github.com/PaddlePaddle/Paddle/pull/52861) will enable them to support zero-dimensional output, so remove the dimension operation on numpy output