### PR TITLE
ban test slogdet

### DIFF
--- a/framework/api/multithreading_case.py
+++ b/framework/api/multithreading_case.py
@@ -30,7 +30,7 @@ ignore_case_dir = {
     "device": [],
     "fft": [],
     "incubate": [],
-    "linalg": ["test_cond.py", "test_norm.py"],
+    "linalg": ["test_cond.py", "test_norm.py", "test_slogdet.py"],
     "loss": [],
     "nn": [
         "test_functional_celu.py",


### PR DESCRIPTION
To support 0D output for linagle.slogdet, this pr https://github.com/PaddlePaddle/Paddle/pull/52891, temporarily disabled test_slogdet