### PR TITLE
temporarily disable test_det.py, test_dist.py, test_trace.py

### DIFF
--- a/framework/api/multithreading_case.py
+++ b/framework/api/multithreading_case.py
@@ -30,7 +30,7 @@ ignore_case_dir = {
     "device": [],
     "fft": [],
     "incubate": [],
-    "linalg": ["test_cond.py", "test_norm.py", "test_matrix_rank.py", "test_multi_dot.py"],
+    "linalg": ["test_cond.py", "test_norm.py", "test_matrix_rank.py", "test_multi_dot.py", "test_det.py"],
     "loss": [],
     "nn": [
         "test_functional_celu.py",
@@ -50,6 +50,8 @@ ignore_case_dir = {
         "test_dot.py",
         "test_inner.py",
         "test_tensordot.py",
+        "test_dist.py",
+        "test_trace.py"
     ],
     "optimizer": [],
     "distribution": [],

--- a/framework/api/multithreading_case.py
+++ b/framework/api/multithreading_case.py
@@ -51,7 +51,7 @@ ignore_case_dir = {
         "test_inner.py",
         "test_tensordot.py",
         "test_dist.py",
-        "test_trace.py"
+        "test_trace.py",
     ],
     "optimizer": [],
     "distribution": [],


### PR DESCRIPTION
to support the following api 0D output

    paddle.dist
    paddle.linalg.cond
    paddle.trace
    paddle.linalg.cov
    paddle.linalg.det
    paddle.linalg.norm
temporarily disable test_det.py, test_dist.py, test_trace.py
see https://github.com/PaddlePaddle/Paddle/pull/52857
