### PR TITLE
修改test_jvp.py以适配组合机制

### DIFF
--- a/framework/api/incubate/test_jvp.py
+++ b/framework/api/incubate/test_jvp.py
@@ -28,6 +28,22 @@ class TestJvp(APIBase):
         # self.enable_backward = False
         # self.delta = 1e-3
 
+class TestJvpNoStatc(APIBase):
+    """
+    test
+    """
+
+    def hook(self):
+        """
+        implement
+        """
+        self.types = [np.float32, np.float64]
+        # self.debug = True
+        self.static = False
+        # enable check grad
+        # self.enable_backward = False
+        # self.delta = 1e-3
+
 
 def cal_jvp(func, xs, v=None):
     """
@@ -69,6 +85,7 @@ def func3(x, y):
 
 
 obj = TestJvp(cal_jvp)
+obj_nostatic = TestJvpNoStatc(cal_jvp)
 ans = FiniteDifferenceUtils()
 
 
@@ -189,8 +206,12 @@ def test_jvp8():
     x = np.random.rand(3, 3)
     y = np.random.rand(3, 3)
     paddle.disable_static()
+    from paddle.fluid import core
+    core._set_prim_backward_enabled(True)
     res = ans.jvp_with_jac(func3, [paddle.to_tensor(x), paddle.to_tensor(y)])
     obj.run(res=res.numpy(), func=func3, xs=[x, y])
+    core._set_prim_backward_enabled(False)
+
 
 
 @pytest.mark.api_incubate_jvp_parameters
@@ -206,4 +227,4 @@ def test_jvp9():
     res = ans.jvp_with_jac(
         func3, [paddle.to_tensor(x), paddle.to_tensor(x)], v=[paddle.to_tensor(v1), paddle.to_tensor(v1)]
     )
-    obj.run(res=res.numpy(), func=func3, xs=[x, x], v=[v1, v1])
+    obj_nostatic.run(res=res.numpy(), func=func3, xs=[x, x], v=[v1, v1])

--- a/framework/api/incubate/test_jvp.py
+++ b/framework/api/incubate/test_jvp.py
@@ -28,6 +28,7 @@ class TestJvp(APIBase):
         # self.enable_backward = False
         # self.delta = 1e-3
 
+
 class TestJvpNoStatc(APIBase):
     """
     test
@@ -207,11 +208,11 @@ def test_jvp8():
     y = np.random.rand(3, 3)
     paddle.disable_static()
     from paddle.fluid import core
+
     core._set_prim_backward_enabled(True)
     res = ans.jvp_with_jac(func3, [paddle.to_tensor(x), paddle.to_tensor(y)])
     obj.run(res=res.numpy(), func=func3, xs=[x, y])
     core._set_prim_backward_enabled(False)
-
 
 
 @pytest.mark.api_incubate_jvp_parameters


### PR DESCRIPTION
test_jvp8 添加开启组合静态图反向flag 以实现高阶计算；
test_jvp9 禁掉静态图测试，由于静态图开启组合后，对聚合节点sm(add_n)的输入名称无法通过compositeOpMaker进行映射，导致找不到输入。sum算子在组合机制下应该拆解前向，通过动转静中to_prim 策略进行高阶拆解，jvp 系列测试接口逐步废弃，在静态图下不再使用，测试可暂时关闭，最终需要通过动转静实现静态图逻辑

