### PR TITLE
Revert "update ViT_small_trt_fp32 temporarily (#2222)"

### DIFF
--- a/inference/python_api_test/test_class_model/test_ViT_small_patch16_224_trt_fp32.py
+++ b/inference/python_api_test/test_class_model/test_ViT_small_patch16_224_trt_fp32.py
@@ -84,7 +84,6 @@ def test_trt_fp32_more_bz():
             output_data_dict,
             max_batch_size=max_batch_size,
             precision="trt_fp32",
-            delete_pass_list=["preln_residual_bias_fuse_pass"],
             dynamic=True,
             tuned=True,
         )
@@ -101,7 +100,6 @@ def test_trt_fp32_more_bz():
             output_data_dict,
             max_batch_size=max_batch_size,
             precision="trt_fp32",
-            delete_pass_list=["preln_residual_bias_fuse_pass"],
             dynamic=True,
         )
 
@@ -143,7 +141,6 @@ def test_jetson_trt_fp32_more_bz():
             output_data_dict,
             max_batch_size=max_batch_size,
             precision="trt_fp32",
-            delete_pass_list=["preln_residual_bias_fuse_pass"],
             dynamic=True,
             tuned=True,
         )
@@ -160,7 +157,6 @@ def test_jetson_trt_fp32_more_bz():
             output_data_dict,
             max_batch_size=max_batch_size,
             precision="trt_fp32",
-            delete_pass_list=["preln_residual_bias_fuse_pass"],
             dynamic=True,
         )
 
@@ -198,7 +194,6 @@ def test_trt_fp32_bz1_multi_thread():
         input_data_dict,
         output_data_dict,
         precision="trt_fp32",
-        delete_pass_list=["preln_residual_bias_fuse_pass"],
     )
 
     del test_suite2  # destroy class to save memory


### PR DESCRIPTION
This reverts commit 86d705fa970164ce641c7e843a85b27946a746f1.  It's not the impact of the preln_residual_bias_fuse_pass and the problem of diff is solved. 