### PR TITLE
exp_disable_tensorrt_ops(["roll"])

### DIFF
--- a/inference/python_api_test/test_class_model/test_swin_transformer_trt_fp16.py
+++ b/inference/python_api_test/test_class_model/test_swin_transformer_trt_fp16.py
@@ -12,6 +12,7 @@ import six
 import wget
 import pytest
 import numpy as np
+import paddle.inference as paddle_infer
 
 # pylint: disable=wrong-import-position
 sys.path.append("..")
@@ -89,6 +90,11 @@ def test_trt_fp16_more_bz():
             model_file="./swin_transformer/inference.pdmodel",
             params_file="./swin_transformer/inference.pdiparams",
         )
+
+        # fix the error of DLTP-70788 temporarily
+        ver = paddle_infer.get_trt_compile_version()
+        if ver[0] * 1000 + ver[1] * 100 + ver[2] * 10 > 8500:
+            test_suite2.pd_config.exp_disable_tensorrt_ops(["roll"])
 
         test_suite2.trt_more_bz_test(
             input_data_dict,

--- a/inference/python_api_test/test_class_model/test_swin_transformer_trt_fp32.py
+++ b/inference/python_api_test/test_class_model/test_swin_transformer_trt_fp32.py
@@ -12,6 +12,7 @@ import six
 import wget
 import pytest
 import numpy as np
+import paddle.inference as paddle_infer
 
 # pylint: disable=wrong-import-position
 sys.path.append("..")
@@ -88,6 +89,12 @@ def test_trt_fp32_more_bz():
             model_file="./swin_transformer/inference.pdmodel",
             params_file="./swin_transformer/inference.pdiparams",
         )
+
+        # fix the error of DLTP-70788 temporarily
+        ver = paddle_infer.get_trt_compile_version()
+        if ver[0] * 1000 + ver[1] * 100 + ver[2] * 10 > 8500:
+            test_suite2.pd_config.exp_disable_tensorrt_ops(["roll"])
+
         test_suite2.trt_more_bz_test(
             input_data_dict,
             output_data_dict,


### PR DESCRIPTION
set test_suite2.pd_config.exp_disable_tensorrt_ops(["roll"]) when trt_compile_version > 8.5 to fix the error of DLTP-70788 temporarily