### PR TITLE
fix lac_trt_fp32/16.py 

### DIFF
--- a/inference/python_api_test/test_case/infer_test.py
+++ b/inference/python_api_test/test_case/infer_test.py
@@ -604,6 +604,7 @@ class InferenceTest(object):
         need_sort=False,
         det_top_bbox_threshold=0.75,
         delete_pass_list=None,
+        delete_op_list=None,
     ):
         """
         test enable_tensorrt_engine()
@@ -653,7 +654,8 @@ class InferenceTest(object):
         if delete_pass_list:
             for ir_pass in delete_pass_list:
                 self.pd_config.delete_pass(ir_pass)
-
+        if delete_op_list:
+            self.pd_config.exp_disable_tensorrt_ops(delete_op_list)
         predictor = paddle_infer.create_predictor(self.pd_config)
 
         input_names = predictor.get_input_names()

--- a/inference/python_api_test/test_nlp_model/test_lac_trt_fp16.py
+++ b/inference/python_api_test/test_nlp_model/test_lac_trt_fp16.py
@@ -79,7 +79,7 @@ def test_lac_trt_fp16():
         dynamic=True,
         tuned=True,
         min_subgraph_size=2,
-        # see comments test_lac_trt_fp32.py
+        # see comments in test_lac_trt_fp32.py
         delete_op_list=["transpose_2.tmp_0_slice_0"],
     )
 
@@ -98,6 +98,6 @@ def test_lac_trt_fp16():
         dynamic=True,
         tuned=False,
         min_subgraph_size=2,
-        # see comments test_lac_trt_fp32.py
+        # see comments in test_lac_trt_fp32.py
         delete_op_list=["transpose_2.tmp_0_slice_0"],
     )

--- a/inference/python_api_test/test_nlp_model/test_lac_trt_fp16.py
+++ b/inference/python_api_test/test_nlp_model/test_lac_trt_fp16.py
@@ -79,6 +79,8 @@ def test_lac_trt_fp16():
         dynamic=True,
         tuned=True,
         min_subgraph_size=2,
+        # see comments test_lac_trt_fp32.py
+        delete_op_list=["transpose_2.tmp_0_slice_0"],
     )
 
     del test_suite1  # destroy class to save memory
@@ -96,4 +98,6 @@ def test_lac_trt_fp16():
         dynamic=True,
         tuned=False,
         min_subgraph_size=2,
+        # see comments test_lac_trt_fp32.py
+        delete_op_list=["transpose_2.tmp_0_slice_0"],
     )

--- a/inference/python_api_test/test_nlp_model/test_lac_trt_fp32.py
+++ b/inference/python_api_test/test_nlp_model/test_lac_trt_fp32.py
@@ -79,6 +79,10 @@ def test_lac_trt_fp32():
         dynamic=True,
         tuned=True,
         min_subgraph_size=2,
+        # transpose_2.tmp_0_slice_0 is a slice op's output name, forbid this slice op into paddle-trt
+        # because it's EndsTensorList is max_0.tmp_0, there is
+        # another tensorrt_engine who has a input called max_0.tmp_0 too.
+        delete_op_list=["transpose_2.tmp_0_slice_0"],
     )
 
     del test_suite1  # destroy class to save memory
@@ -96,6 +100,8 @@ def test_lac_trt_fp32():
         dynamic=True,
         tuned=False,
         min_subgraph_size=2,
+        # see below comments
+        delete_op_list=["transpose_2.tmp_0_slice_0"],
     )
 
     del test_suite2  # destroy class to save memory


### PR DESCRIPTION
- 这个模型比较奇怪，有两个tensor的名字一样，并且他们又是两个trt engine的输入，因此收集shape的时候会覆盖。
- 没办法，只能禁止一个进入TRT了。


<img width="1011" alt="image" src="https://github.com/PaddlePaddle/PaddleTest/assets/39978853/04ef8e60-8685-4854-8006-f58b76d2f64a">

