### PR TITLE
remove the dependency on paddlenlp

### DIFF
--- a/inference/python_api_test/requirements.txt
+++ b/inference/python_api_test/requirements.txt
@@ -3,7 +3,5 @@ psutil
 pytest
 pynvml==11.0.0
 opencv-python==4.6.0.66
-paddlenlp==2.5.2 ; python_version < "3.11"
-pydantic==1.10.6 ; python_version == "3.7"
 dataclasses ; python_version == "3.6"
 sentencepiece==0.1.96

--- a/inference/python_api_test/test_nlp_model/test_bert_gpu.py
+++ b/inference/python_api_test/test_nlp_model/test_bert_gpu.py
@@ -80,13 +80,10 @@ def test_gpu_bz1():
         model_file="./bert/inference.pdmodel",
         params_file="./bert/inference.pdiparams",
     )
-    data_path = "./bert/data.txt"
-    images_list = test_suite.get_text_npy(data_path)
+    input_ids = np.load("./bert/input_ids.npy").astype("int64")
+    token_type_ids = np.load("./bert/token_type_ids.npy").astype("int64")
 
-    input_data_dict = {
-        "input_ids": np.array([images_list[0][0]]).astype("int64"),
-        "token_type_ids": np.array([images_list[0][1]]).astype("int64"),
-    }
+    input_data_dict = {"input_ids": np.array([input_ids]), "token_type_ids": np.array([token_type_ids])}
     output_data_dict = test_suite.get_truth_val(input_data_dict, device="gpu")
 
     del test_suite  # destroy class to save memory
@@ -123,13 +120,10 @@ def test_gpu_mixed_precision_bz1():
         model_file="./bert/inference.pdmodel",
         params_file="./bert/inference.pdiparams",
     )
-    data_path = "./bert/data.txt"
-    images_list = test_suite.get_text_npy(data_path)
+    input_ids = np.load("./bert/input_ids.npy").astype("int64")
+    token_type_ids = np.load("./bert/token_type_ids.npy").astype("int64")
 
-    input_data_dict = {
-        "input_ids": np.array([images_list[0][0]]).astype("int64"),
-        "token_type_ids": np.array([images_list[0][1]]).astype("int64"),
-    }
+    input_data_dict = {"input_ids": np.array([input_ids]), "token_type_ids": np.array([token_type_ids])}
     output_data_dict = test_suite.get_truth_val(input_data_dict, device="gpu")
 
     del test_suite  # destroy class to save memory

--- a/inference/python_api_test/test_nlp_model/test_bert_mkldnn.py
+++ b/inference/python_api_test/test_nlp_model/test_bert_mkldnn.py
@@ -59,13 +59,10 @@ def test_mkldnn():
         model_file="./bert/inference.pdmodel",
         params_file="./bert/inference.pdiparams",
     )
-    data_path = "./bert/data.txt"
-    images_list = test_suite.get_text_npy(data_path)
+    input_ids = np.load("./bert/input_ids.npy").astype("int64")
+    token_type_ids = np.load("./bert/token_type_ids.npy").astype("int64")
 
-    input_data_dict = {
-        "input_ids": np.array([images_list[0][0]]).astype("int64"),
-        "token_type_ids": np.array([images_list[0][1]]).astype("int64"),
-    }
+    input_data_dict = {"input_ids": np.array([input_ids]), "token_type_ids": np.array([token_type_ids])}
     output_data_dict = test_suite.get_truth_val(input_data_dict, device="cpu")
 
     del test_suite  # destroy class to save memory

--- a/inference/python_api_test/test_nlp_model/test_bert_mkldnn_int8.py
+++ b/inference/python_api_test/test_nlp_model/test_bert_mkldnn_int8.py
@@ -59,13 +59,10 @@ def test_mkldnn_int8():
         model_file="./bert/inference.pdmodel",
         params_file="./bert/inference.pdiparams",
     )
-    data_path = "./bert/data.txt"
-    images_list = test_suite.get_text_npy(data_path)
+    input_ids = np.load("./bert/input_ids.npy").astype("int64")
+    token_type_ids = np.load("./bert/token_type_ids.npy").astype("int64")
 
-    input_data_dict = {
-        "input_ids": np.array([images_list[0][0]]).astype("int64"),
-        "token_type_ids": np.array([images_list[0][1]]).astype("int64"),
-    }
+    input_data_dict = {"input_ids": np.array([input_ids]), "token_type_ids": np.array([token_type_ids])}
     output_data_dict = test_suite.get_truth_val(input_data_dict, device="cpu")
 
     del test_suite  # destroy class to save memory

--- a/inference/python_api_test/test_nlp_model/test_bert_ort.py
+++ b/inference/python_api_test/test_nlp_model/test_bert_ort.py
@@ -59,13 +59,10 @@ def test_onxxruntime():
         model_file="./bert/inference.pdmodel",
         params_file="./bert/inference.pdiparams",
     )
-    data_path = "./bert/data.txt"
-    images_list = test_suite.get_text_npy(data_path)
+    input_ids = np.load("./bert/input_ids.npy").astype("int64")
+    token_type_ids = np.load("./bert/token_type_ids.npy").astype("int64")
 
-    input_data_dict = {
-        "input_ids": np.array([images_list[0][0]]).astype("int64"),
-        "token_type_ids": np.array([images_list[0][1]]).astype("int64"),
-    }
+    input_data_dict = {"input_ids": np.array([input_ids]), "token_type_ids": np.array([token_type_ids])}
     output_data_dict = test_suite.get_truth_val(input_data_dict, device="cpu")
 
     del test_suite  # destroy class to save memory

--- a/inference/python_api_test/test_nlp_model/test_bert_trt_fp16.py
+++ b/inference/python_api_test/test_nlp_model/test_bert_trt_fp16.py
@@ -60,14 +60,11 @@ def test_trt_fp16_bz1():
         model_file="./bert/inference.pdmodel",
         params_file="./bert/inference.pdiparams",
     )
-    data_path = "./bert/data.txt"
-    images_list = test_suite.get_text_npy(data_path)
+    input_ids = np.load("./bert/input_ids.npy").astype("int64")
+    token_type_ids = np.load("./bert/token_type_ids.npy").astype("int64")
 
-    input_data_dict = {
-        "input_ids": np.array([images_list[0][0]]).astype("int64"),
-        "token_type_ids": np.array([images_list[0][1]]).astype("int64"),
-    }
-    output_data_dict = test_suite.get_truth_val(input_data_dict, device="cpu")
+    input_data_dict = {"input_ids": np.array([input_ids]), "token_type_ids": np.array([token_type_ids])}
+    output_data_dict = test_suite.get_truth_val(input_data_dict, device="gpu")
 
     del test_suite  # destroy class to save memory
 
@@ -117,14 +114,11 @@ def test_trt_fp16_bz1_multi_thread():
         model_file="./bert/inference.pdmodel",
         params_file="./bert/inference.pdiparams",
     )
-    data_path = "./bert/data.txt"
-    images_list = test_suite.get_text_npy(data_path)
+    input_ids = np.load("./bert/input_ids.npy").astype("int64")
+    token_type_ids = np.load("./bert/token_type_ids.npy").astype("int64")
 
-    input_data_dict = {
-        "input_ids": np.array([images_list[0][0]]).astype("int64"),
-        "token_type_ids": np.array([images_list[0][1]]).astype("int64"),
-    }
-    output_data_dict = test_suite.get_truth_val(input_data_dict, device="cpu")
+    input_data_dict = {"input_ids": np.array([input_ids]), "token_type_ids": np.array([token_type_ids])}
+    output_data_dict = test_suite.get_truth_val(input_data_dict, device="gpu")
 
     del test_suite  # destroy class to save memory
 

--- a/inference/python_api_test/test_nlp_model/test_bert_trt_fp32.py
+++ b/inference/python_api_test/test_nlp_model/test_bert_trt_fp32.py
@@ -60,14 +60,11 @@ def test_trt_fp32_bz1():
         model_file="./bert/inference.pdmodel",
         params_file="./bert/inference.pdiparams",
     )
-    data_path = "./bert/data.txt"
-    images_list = test_suite.get_text_npy(data_path)
+    input_ids = np.load("./bert/input_ids.npy").astype("int64")
+    token_type_ids = np.load("./bert/token_type_ids.npy").astype("int64")
 
-    input_data_dict = {
-        "input_ids": np.array([images_list[0][0]]).astype("int64"),
-        "token_type_ids": np.array([images_list[0][1]]).astype("int64"),
-    }
-    output_data_dict = test_suite.get_truth_val(input_data_dict, device="cpu")
+    input_data_dict = {"input_ids": np.array([input_ids]), "token_type_ids": np.array([token_type_ids])}
+    output_data_dict = test_suite.get_truth_val(input_data_dict, device="gpu")
 
     del test_suite  # destroy class to save memory
 
@@ -117,14 +114,11 @@ def test_trt_fp32_bz1_multi_thread():
         model_file="./bert/inference.pdmodel",
         params_file="./bert/inference.pdiparams",
     )
-    data_path = "./bert/data.txt"
-    images_list = test_suite.get_text_npy(data_path)
+    input_ids = np.load("./bert/input_ids.npy").astype("int64")
+    token_type_ids = np.load("./bert/token_type_ids.npy").astype("int64")
 
-    input_data_dict = {
-        "input_ids": np.array([images_list[0][0]]).astype("int64"),
-        "token_type_ids": np.array([images_list[0][1]]).astype("int64"),
-    }
-    output_data_dict = test_suite.get_truth_val(input_data_dict, device="cpu")
+    input_data_dict = {"input_ids": np.array([input_ids]), "token_type_ids": np.array([token_type_ids])}
+    output_data_dict = test_suite.get_truth_val(input_data_dict, device="gpu")
 
     del test_suite  # destroy class to save memory
 

--- a/inference/python_api_test/test_nlp_model/test_ernie_gpu.py
+++ b/inference/python_api_test/test_nlp_model/test_ernie_gpu.py
@@ -124,13 +124,10 @@ def test_gpu_mixed_precision_bz1():
         model_file="./ernie/inference.pdmodel",
         params_file="./ernie/inference.pdiparams",
     )
-    data_path = "./ernie/data.txt"
-    images_list = test_suite.get_text_npy(data_path)
+    input_ids = np.load("./ernie/input_ids.npy").astype("int64")
+    token_type_ids = np.load("./ernie/token_type_ids.npy").astype("int64")
 
-    input_data_dict = {
-        "input_ids": np.array([images_list[0][0]]).astype("int64"),
-        "token_type_ids": np.array([images_list[0][1]]).astype("int64"),
-    }
+    input_data_dict = {"input_ids": np.array([input_ids]), "token_type_ids": np.array([token_type_ids])}
     output_data_dict = test_suite.get_truth_val(input_data_dict, device="gpu")
 
     del test_suite  # destroy class to save memory

--- a/inference/python_api_test/test_nlp_model/test_ernie_gpu.py
+++ b/inference/python_api_test/test_nlp_model/test_ernie_gpu.py
@@ -80,13 +80,10 @@ def test_gpu_bz1():
         model_file="./ernie/inference.pdmodel",
         params_file="./ernie/inference.pdiparams",
     )
-    data_path = "./ernie/data.txt"
-    images_list = test_suite.get_text_npy(data_path)
+    input_ids = np.load("./ernie/input_ids.npy").astype("int64")
+    token_type_ids = np.load("./ernie/token_type_ids.npy").astype("int64")
 
-    input_data_dict = {
-        "input_ids": np.array([images_list[0][0]]).astype("int64"),
-        "token_type_ids": np.array([images_list[0][1]]).astype("int64"),
-    }
+    input_data_dict = {"input_ids": np.array([input_ids]), "token_type_ids": np.array([token_type_ids])}
     output_data_dict = test_suite.get_truth_val(input_data_dict, device="gpu")
 
     del test_suite  # destroy class to save memory

--- a/inference/python_api_test/test_nlp_model/test_ernie_mkldnn.py
+++ b/inference/python_api_test/test_nlp_model/test_ernie_mkldnn.py
@@ -59,13 +59,10 @@ def test_mkldnn():
         model_file="./ernie/inference.pdmodel",
         params_file="./ernie/inference.pdiparams",
     )
-    data_path = "./ernie/data.txt"
-    images_list = test_suite.get_text_npy(data_path)
+    input_ids = np.load("./ernie/input_ids.npy").astype("int64")
+    token_type_ids = np.load("./ernie/token_type_ids.npy").astype("int64")
 
-    input_data_dict = {
-        "input_ids": np.array([images_list[0][0]]).astype("int64"),
-        "token_type_ids": np.array([images_list[0][1]]).astype("int64"),
-    }
+    input_data_dict = {"input_ids": np.array([input_ids]), "token_type_ids": np.array([token_type_ids])}
     output_data_dict = test_suite.get_truth_val(input_data_dict, device="cpu")
 
     del test_suite  # destroy class to save memory

--- a/inference/python_api_test/test_nlp_model/test_ernie_mkldnn_int8.py
+++ b/inference/python_api_test/test_nlp_model/test_ernie_mkldnn_int8.py
@@ -59,13 +59,10 @@ def test_mkldnn_int8():
         model_file="./ernie/inference.pdmodel",
         params_file="./ernie/inference.pdiparams",
     )
-    data_path = "./ernie/data.txt"
-    images_list = test_suite.get_text_npy(data_path)
+    input_ids = np.load("./ernie/input_ids.npy").astype("int64")
+    token_type_ids = np.load("./ernie/token_type_ids.npy").astype("int64")
 
-    input_data_dict = {
-        "input_ids": np.array([images_list[0][0]]).astype("int64"),
-        "token_type_ids": np.array([images_list[0][1]]).astype("int64"),
-    }
+    input_data_dict = {"input_ids": np.array([input_ids]), "token_type_ids": np.array([token_type_ids])}
     output_data_dict = test_suite.get_truth_val(input_data_dict, device="cpu")
 
     del test_suite  # destroy class to save memory

--- a/inference/python_api_test/test_nlp_model/test_ernie_ort.py
+++ b/inference/python_api_test/test_nlp_model/test_ernie_ort.py
@@ -59,13 +59,10 @@ def test_onnxruntime():
         model_file="./ernie/inference.pdmodel",
         params_file="./ernie/inference.pdiparams",
     )
-    data_path = "./ernie/data.txt"
-    images_list = test_suite.get_text_npy(data_path)
+    input_ids = np.load("./ernie/input_ids.npy").astype("int64")
+    token_type_ids = np.load("./ernie/token_type_ids.npy").astype("int64")
 
-    input_data_dict = {
-        "input_ids": np.array([images_list[0][0]]).astype("int64"),
-        "token_type_ids": np.array([images_list[0][1]]).astype("int64"),
-    }
+    input_data_dict = {"input_ids": np.array([input_ids]), "token_type_ids": np.array([token_type_ids])}
     output_data_dict = test_suite.get_truth_val(input_data_dict, device="cpu")
 
     del test_suite  # destroy class to save memory

--- a/inference/python_api_test/test_nlp_model/test_ernie_trt_fp16.py
+++ b/inference/python_api_test/test_nlp_model/test_ernie_trt_fp16.py
@@ -60,13 +60,10 @@ def test_trt_fp16_bz1():
         model_file="./ernie/inference.pdmodel",
         params_file="./ernie/inference.pdiparams",
     )
-    data_path = "./ernie/data.txt"
-    images_list = test_suite.get_text_npy(data_path)
+    input_ids = np.load("./ernie/input_ids.npy").astype("int64")
+    token_type_ids = np.load("./ernie/token_type_ids.npy").astype("int64")
 
-    input_data_dict = {
-        "input_ids": np.array([images_list[0][0]]).astype("int64"),
-        "token_type_ids": np.array([images_list[0][1]]).astype("int64"),
-    }
+    input_data_dict = {"input_ids": np.array([input_ids]), "token_type_ids": np.array([token_type_ids])}
     output_data_dict = test_suite.get_truth_val(input_data_dict, device="gpu")
 
     del test_suite  # destroy class to save memory
@@ -117,13 +114,10 @@ def test_trt_fp16_bz1_multi_thread():
         model_file="./ernie/inference.pdmodel",
         params_file="./ernie/inference.pdiparams",
     )
-    data_path = "./ernie/data.txt"
-    images_list = test_suite.get_text_npy(data_path)
+    input_ids = np.load("./ernie/input_ids.npy").astype("int64")
+    token_type_ids = np.load("./ernie/token_type_ids.npy").astype("int64")
 
-    input_data_dict = {
-        "input_ids": np.array([images_list[0][0]]).astype("int64"),
-        "token_type_ids": np.array([images_list[0][1]]).astype("int64"),
-    }
+    input_data_dict = {"input_ids": np.array([input_ids]), "token_type_ids": np.array([token_type_ids])}
     output_data_dict = test_suite.get_truth_val(input_data_dict, device="gpu")
 
     del test_suite  # destroy class to save memory

--- a/inference/python_api_test/test_nlp_model/test_ernie_trt_fp32.py
+++ b/inference/python_api_test/test_nlp_model/test_ernie_trt_fp32.py
@@ -60,13 +60,10 @@ def test_trt_fp32_bz1():
         model_file="./ernie/inference.pdmodel",
         params_file="./ernie/inference.pdiparams",
     )
-    data_path = "./ernie/data.txt"
-    images_list = test_suite.get_text_npy(data_path)
+    input_ids = np.load("./ernie/input_ids.npy").astype("int64")
+    token_type_ids = np.load("./ernie/token_type_ids.npy").astype("int64")
 
-    input_data_dict = {
-        "input_ids": np.array([images_list[0][0]]).astype("int64"),
-        "token_type_ids": np.array([images_list[0][1]]).astype("int64"),
-    }
+    input_data_dict = {"input_ids": np.array([input_ids]), "token_type_ids": np.array([token_type_ids])}
     output_data_dict = test_suite.get_truth_val(input_data_dict, device="gpu")
 
     del test_suite  # destroy class to save memory
@@ -117,13 +114,10 @@ def test_trt_fp32_bz1_multi_thread():
         model_file="./ernie/inference.pdmodel",
         params_file="./ernie/inference.pdiparams",
     )
-    data_path = "./ernie/data.txt"
-    images_list = test_suite.get_text_npy(data_path)
+    input_ids = np.load("./ernie/input_ids.npy").astype("int64")
+    token_type_ids = np.load("./ernie/token_type_ids.npy").astype("int64")
 
-    input_data_dict = {
-        "input_ids": np.array([images_list[0][0]]).astype("int64"),
-        "token_type_ids": np.array([images_list[0][1]]).astype("int64"),
-    }
+    input_data_dict = {"input_ids": np.array([input_ids]), "token_type_ids": np.array([token_type_ids])}
     output_data_dict = test_suite.get_truth_val(input_data_dict, device="gpu")
 
     del test_suite  # destroy class to save memory


### PR DESCRIPTION
An error message stating that ONNX is not supported when installing paddlenlp and its dependencies on Python 3.11, one potential solution is to modify the code to save the input_ids and token_type_ids without relying on paddlenlp in text_processing stage.