### PR TITLE
fix set_value index can be not int type

### DIFF
--- a/framework/api/paddlebase/test_dygraph_setitem.py
+++ b/framework/api/paddlebase/test_dygraph_setitem.py
@@ -163,8 +163,8 @@ def test_tensor_array():
     """
     paddle.disable_static()
     tensor_x = paddle.to_tensor(np.zeros(12).reshape(2, 6).astype(np.float64))
-    tensor_y1 = paddle.zeros([1]) + 1
-    tensor_y2 = paddle.zeros([1]) + 3
+    tensor_y1 = paddle.zeros([1], dtype='int32') + 1
+    tensor_y2 = paddle.zeros([1], dtype='int64') + 3
     tensor_x[tensor_y1, 1:tensor_y2] = np.array([1, 3]).astype(np.float64)
     res = tensor_x.numpy()
     exp = np.array([[0.0, 0.0, 0.0, 0.0, 0.0, 0.0], [0.0, 1.0, 3.0, 0.0, 0.0, 0.0]])

--- a/framework/api/paddlebase/test_dygraph_setitem.py
+++ b/framework/api/paddlebase/test_dygraph_setitem.py
@@ -163,8 +163,8 @@ def test_tensor_array():
     """
     paddle.disable_static()
     tensor_x = paddle.to_tensor(np.zeros(12).reshape(2, 6).astype(np.float64))
-    tensor_y1 = paddle.zeros([1], dtype='int32') + 1
-    tensor_y2 = paddle.zeros([1], dtype='int64') + 3
+    tensor_y1 = paddle.zeros([1], dtype="int32") + 1
+    tensor_y2 = paddle.zeros([1], dtype="int64") + 3
     tensor_x[tensor_y1, 1:tensor_y2] = np.array([1, 3]).astype(np.float64)
     res = tensor_x.numpy()
     exp = np.array([[0.0, 0.0, 0.0, 0.0, 0.0, 0.0], [0.0, 1.0, 3.0, 0.0, 0.0, 0.0]])


### PR DESCRIPTION
Dtype of index in OP `set_value` should be int32/int64. Current now, if this dtype is not int, it will be implicitly converted to int in `dygraph mode` but not in `static mode`. Or more precisely, in `tensor_method__setitem_eager_tensor` (simple case in dygraph mode)  but not in `_setitem_impl_`(all case in static mode and complex case in dygraph mode).


From the perspective of semantics and unification of dygraph and static, float type index should not be supported in future.