### PR TITLE
delete op with float32 shape tensor into trt in solov2 fp32

### DIFF
--- a/inference/python_api_test/test_case/infer_test.py
+++ b/inference/python_api_test/test_case/infer_test.py
@@ -77,7 +77,7 @@ class InferenceTest(object):
         if device == "cpu":
             self.pd_config.disable_gpu()
         elif device == "gpu":
-            self.pd_config.enable_use_gpu(gpu_mem, 1)
+            self.pd_config.enable_use_gpu(gpu_mem, 0)
         else:
             raise Exception(f"{device} not support in current test codes")
         self.pd_config.switch_ir_optim(False)
@@ -628,7 +628,7 @@ class InferenceTest(object):
             "trt_fp16": paddle_infer.PrecisionType.Half,
             "trt_int8": paddle_infer.PrecisionType.Int8,
         }
-        self.pd_config.enable_use_gpu(gpu_mem, 1)
+        self.pd_config.enable_use_gpu(gpu_mem, 0)
         if dynamic:
             if tuned:
                 self.pd_config.collect_shape_range_info("shape_range.pbtxt")

--- a/inference/python_api_test/test_case/infer_test.py
+++ b/inference/python_api_test/test_case/infer_test.py
@@ -77,7 +77,7 @@ class InferenceTest(object):
         if device == "cpu":
             self.pd_config.disable_gpu()
         elif device == "gpu":
-            self.pd_config.enable_use_gpu(gpu_mem, 0)
+            self.pd_config.enable_use_gpu(gpu_mem, 1)
         else:
             raise Exception(f"{device} not support in current test codes")
         self.pd_config.switch_ir_optim(False)
@@ -628,7 +628,7 @@ class InferenceTest(object):
             "trt_fp16": paddle_infer.PrecisionType.Half,
             "trt_int8": paddle_infer.PrecisionType.Int8,
         }
-        self.pd_config.enable_use_gpu(gpu_mem, 0)
+        self.pd_config.enable_use_gpu(gpu_mem, 1)
         if dynamic:
             if tuned:
                 self.pd_config.collect_shape_range_info("shape_range.pbtxt")

--- a/inference/python_api_test/test_det_model/test_solov2_trt_fp32.py
+++ b/inference/python_api_test/test_det_model/test_solov2_trt_fp32.py
@@ -116,4 +116,5 @@ def test_trt_fp32_more_bz():
             precision="trt_fp32",
             dynamic=True,
             tuned=False,
+            delete_op_list=["im_shape_slice_0", "im_shape_slice_0_slice_1", "cast_6.tmp_0", "im_shape_slice_0_slice_0", "cast_5.tmp_0", "im_shape_slice_0_slice_2", "tmp_65"]
         )

--- a/inference/python_api_test/test_det_model/test_solov2_trt_fp32.py
+++ b/inference/python_api_test/test_det_model/test_solov2_trt_fp32.py
@@ -116,5 +116,13 @@ def test_trt_fp32_more_bz():
             precision="trt_fp32",
             dynamic=True,
             tuned=False,
-            delete_op_list=["im_shape_slice_0", "im_shape_slice_0_slice_1", "cast_6.tmp_0", "im_shape_slice_0_slice_0", "cast_5.tmp_0", "im_shape_slice_0_slice_2", "tmp_65"]
+            delete_op_list=[
+                "im_shape_slice_0",
+                "im_shape_slice_0_slice_1",
+                "cast_6.tmp_0",
+                "im_shape_slice_0_slice_0",
+                "cast_5.tmp_0",
+                "im_shape_slice_0_slice_2",
+                "tmp_65",
+            ],
         )


### PR DESCRIPTION
在paddle-trt中是不支持op的shape tensor的类型是非INT32的，所以需要禁用相应的shape tensor的类型是非INT32的op，例如在solov2 fp32 trt中:
<img width="611" alt="image" src="https://github.com/PaddlePaddle/PaddleTest/assets/38247842/8116628d-c39a-47b4-ac74-461fbadc1d4a">
<img width="218" alt="image" src="https://github.com/PaddlePaddle/PaddleTest/assets/38247842/0f99c842-eb74-4984-8de5-8b4cfbd27efd">
以["im_shape_slice_0", "im_shape_slice_0_slice_1", "cast_6.tmp_0", "im_shape_slice_0_slice_0", "cast_5.tmp_0", "im_shape_slice_0_slice_2", "tmp_65"]为输出的op都有输入的shape tensor的类型是非INT32，所以需要将这些op禁止进入trt