### PR TITLE
fix disable_gpu() error in swin_transformer_gpu

### DIFF
--- a/inference/python_api_test/test_case/infer_test.py
+++ b/inference/python_api_test/test_case/infer_test.py
@@ -236,6 +236,10 @@ class InferenceTest(object):
             None
         """
         self.pd_config.disable_gpu()
+        try:
+            self.pd_config.disable_mkldnn()
+        except AttributeError:
+            pass
         predictor = paddle_infer.create_predictor(self.pd_config)
 
         cuda_visible_devices = os.environ.get("CUDA_VISIBLE_DEVICES")

--- a/inference/python_api_test/test_class_model/test_swin_transformer_gpu.py
+++ b/inference/python_api_test/test_class_model/test_swin_transformer_gpu.py
@@ -45,8 +45,8 @@ def test_config():
     )
     test_suite.config_test()
 
-#默认开启mkldnn推理hang住，排查中
-#@pytest.mark.server
+
+@pytest.mark.server
 @pytest.mark.config_disablegpu_memory
 def test_disable_gpu():
     """


### PR DESCRIPTION
Adapt for default enable_mkldnn when set config.disable_gpu() to fix the problem of running hang.