### PR TITLE
replace deprecated `paddle.nn.functional.diag_embed` with `paddle.diag_embed`

### DIFF
--- a/framework/e2e/api_benchmark_new/debug_case/diag_embed_0.py
+++ b/framework/e2e/api_benchmark_new/debug_case/diag_embed_0.py
@@ -43,7 +43,7 @@ def _randtool(dtype, low, high, shape):
         assert False, "dtype is not supported"
 
 
-api = "paddle.nn.functional.diag_embed"
+api = "paddle.diag_embed"
 all_data = {"input": {"random": True, "type": "Tensor", "dtype": "float32", "shape": [1, 1, 1, 1, 1], "range": [-1, 1]}}
 params = {"offset": 0, "dim1": -2, "dim2": -1}
 


### PR DESCRIPTION
`paddle.nn.functional.diag_embed` 已经弃用了，使用等价的 `paddle.diag_embed` 作为 benchmark 性能测试 API，以免 https://github.com/PaddlePaddle/Paddle/pull/60458 恢复 deprecated warning 后引起 API benchmark CI 挂掉

<img width="592" alt="image" src="https://github.com/PaddlePaddle/PaddleTest/assets/38436475/280f0bd8-168b-497a-91bb-adc3ee3c489e">
