### PR TITLE
[PIR+CINN]Fix to_tensor/assign_value_ has no InferSymbolic interface

### DIFF
--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/CSWinTransformer_CSWinTransformer_base_384/SIR_156.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/CSWinTransformer_CSWinTransformer_base_384/SIR_156.py
@@ -1,4 +1,4 @@
-# method:__add__||method:transpose||method:reshape||api:paddle.tensor.creation.to_tensor||method:reshape||method:transpose||method:reshape
+# method:__add__||method:transpose||method:reshape||method:reshape||method:transpose||method:reshape
 import paddle
 import unittest
 import numpy as np
@@ -15,7 +15,7 @@ class LayerCase(paddle.nn.Layer):
         var_2 = var_0.__add__(var_1)
         var_3 = var_2.transpose([0, 2, 1, 3])
         var_4 = var_3.reshape([-1, 288, 192])
-        var_5 = paddle.tensor.creation.to_tensor(6, 'int32')
+        var_5 = var_0.shape[0] / 2
         var_6 = var_4.reshape([var_5, 2, 1, 12, 24, 192])
         var_7 = var_6.transpose([0, 1, 3, 2, 4, 5])
         var_8 = var_7.reshape([var_5, 24, 24, 192])

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/CSWinTransformer_CSWinTransformer_base_384/SIR_180.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/CSWinTransformer_CSWinTransformer_base_384/SIR_180.py
@@ -1,4 +1,4 @@
-# api:paddle.tensor.creation.to_tensor||method:reshape||method:transpose||method:reshape
+# method:reshape||method:transpose||method:reshape
 import paddle
 import unittest
 import numpy as np
@@ -11,7 +11,7 @@ class LayerCase(paddle.nn.Layer):
         self,
         var_0,    # (shape: [12, 288, 192], dtype: paddle.float32, stop_gradient: False)
     ):
-        var_1 = paddle.tensor.creation.to_tensor(6, 'int32')
+        var_1 = var_0.shape[0] / 2
         var_2 = var_0.reshape([var_1, 2, 1, 12, 24, 192])
         var_3 = var_2.transpose([0, 1, 3, 2, 4, 5])
         var_4 = var_3.reshape([var_1, 24, 24, 192])

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/CSWinTransformer_CSWinTransformer_base_384/SIR_236.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/CSWinTransformer_CSWinTransformer_base_384/SIR_236.py
@@ -1,4 +1,4 @@
-# method:__add__||method:transpose||method:reshape||api:paddle.tensor.creation.to_tensor||method:reshape||method:transpose||method:reshape
+# method:__add__||method:transpose||method:reshape||method:reshape||method:transpose||method:reshape
 import paddle
 import unittest
 import numpy as np
@@ -15,7 +15,7 @@ class LayerCase(paddle.nn.Layer):
         var_2 = var_0.__add__(var_1)
         var_3 = var_2.transpose([0, 2, 1, 3])
         var_4 = var_3.reshape([-1, 144, 768])
-        var_5 = paddle.tensor.creation.to_tensor(6, 'int32')
+        var_5 = var_0.shape[0]
         var_6 = var_4.reshape([var_5, 1, 1, 12, 12, 768])
         var_7 = var_6.transpose([0, 1, 3, 2, 4, 5])
         var_8 = var_7.reshape([var_5, 12, 12, 768])

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/CSWinTransformer_CSWinTransformer_base_384/SIR_24.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/CSWinTransformer_CSWinTransformer_base_384/SIR_24.py
@@ -1,4 +1,4 @@
-# method:__add__||method:transpose||method:reshape||api:paddle.tensor.creation.to_tensor||method:reshape||method:transpose||method:reshape
+# method:__add__||method:transpose||method:reshape||method:reshape||method:transpose||method:reshape
 import paddle
 import unittest
 import numpy as np
@@ -15,7 +15,7 @@ class LayerCase(paddle.nn.Layer):
         var_2 = var_0.__add__(var_1)
         var_3 = var_2.transpose([0, 2, 1, 3])
         var_4 = var_3.reshape([-1, 96, 48])
-        var_5 = paddle.tensor.creation.to_tensor(6, 'int32')
+        var_5 = var_0.shape[0] / 96
         var_6 = var_4.reshape([var_5, 96, 1, 1, 96, 48])
         var_7 = var_6.transpose([0, 1, 3, 2, 4, 5])
         var_8 = var_7.reshape([var_5, 96, 96, 48])

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/CSWinTransformer_CSWinTransformer_base_384/SIR_291.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/CSWinTransformer_CSWinTransformer_base_384/SIR_291.py
@@ -1,4 +1,4 @@
-# method:__add__||method:transpose||method:reshape||api:paddle.tensor.creation.to_tensor||method:reshape||method:transpose||method:reshape
+# method:__add__||method:transpose||method:reshape||method:reshape||method:transpose||method:reshape
 import paddle
 import unittest
 import numpy as np
@@ -15,7 +15,7 @@ class LayerCase(paddle.nn.Layer):
         var_2 = var_0.__add__(var_1)
         var_3 = var_2.transpose([0, 2, 1, 3])
         var_4 = var_3.reshape([-1, 96, 48])
-        var_5 = paddle.tensor.creation.to_tensor(4, 'int32')
+        var_5 =var_0.shape[0] / 96
         var_6 = var_4.reshape([var_5, 1, 96, 96, 1, 48])
         var_7 = var_6.transpose([0, 1, 3, 2, 4, 5])
         var_8 = var_7.reshape([var_5, 96, 96, 48])

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/CSWinTransformer_CSWinTransformer_base_384/SIR_323.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/CSWinTransformer_CSWinTransformer_base_384/SIR_323.py
@@ -1,4 +1,4 @@
-# method:__add__||method:transpose||method:reshape||api:paddle.tensor.creation.to_tensor||method:reshape||method:transpose||method:reshape
+# method:__add__||method:transpose||method:reshape||method:reshape||method:transpose||method:reshape
 import paddle
 import unittest
 import numpy as np
@@ -15,7 +15,7 @@ class LayerCase(paddle.nn.Layer):
         var_2 = var_0.__add__(var_1)
         var_3 = var_2.transpose([0, 2, 1, 3])
         var_4 = var_3.reshape([-1, 96, 96])
-        var_5 = paddle.tensor.creation.to_tensor(4, 'int32')
+        var_5 = var_0.shape[0] / 24
         var_6 = var_4.reshape([var_5, 1, 24, 48, 2, 96])
         var_7 = var_6.transpose([0, 1, 3, 2, 4, 5])
         var_8 = var_7.reshape([var_5, 48, 48, 96])

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/CSWinTransformer_CSWinTransformer_base_384/SIR_381.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/CSWinTransformer_CSWinTransformer_base_384/SIR_381.py
@@ -1,4 +1,4 @@
-# method:__add__||method:transpose||method:reshape||api:paddle.tensor.creation.to_tensor||method:reshape||method:transpose||method:reshape
+# method:__add__||method:transpose||method:reshape||method:reshape||method:transpose||method:reshape
 import paddle
 import unittest
 import numpy as np
@@ -15,7 +15,7 @@ class LayerCase(paddle.nn.Layer):
         var_2 = var_0.__add__(var_1)
         var_3 = var_2.transpose([0, 2, 1, 3])
         var_4 = var_3.reshape([-1, 288, 192])
-        var_5 = paddle.tensor.creation.to_tensor(4, 'int32')
+        var_5 = var_0.shape[0] / 2
         var_6 = var_4.reshape([var_5, 1, 2, 24, 12, 192])
         var_7 = var_6.transpose([0, 1, 3, 2, 4, 5])
         var_8 = var_7.reshape([var_5, 24, 24, 192])

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/CSWinTransformer_CSWinTransformer_base_384/SIR_420.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/CSWinTransformer_CSWinTransformer_base_384/SIR_420.py
@@ -1,4 +1,4 @@
-# method:__add__||method:transpose||method:reshape||api:paddle.tensor.creation.to_tensor||method:reshape||method:transpose||method:reshape
+# method:__add__||method:transpose||method:reshape||method:reshape||method:transpose||method:reshape
 import paddle
 import unittest
 import numpy as np
@@ -15,7 +15,7 @@ class LayerCase(paddle.nn.Layer):
         var_2 = var_0.__add__(var_1)
         var_3 = var_2.transpose([0, 2, 1, 3])
         var_4 = var_3.reshape([-1, 144, 768])
-        var_5 = paddle.tensor.creation.to_tensor(4, 'int32')
+        var_5 = var_0.shape[0]
         var_6 = var_4.reshape([var_5, 1, 1, 12, 12, 768])
         var_7 = var_6.transpose([0, 1, 3, 2, 4, 5])
         var_8 = var_7.reshape([var_5, 12, 12, 768])

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/CSWinTransformer_CSWinTransformer_base_384/SIR_448.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/CSWinTransformer_CSWinTransformer_base_384/SIR_448.py
@@ -1,4 +1,4 @@
-# method:__add__||method:transpose||method:reshape||api:paddle.tensor.creation.to_tensor||method:reshape||method:transpose||method:reshape
+# method:__add__||method:transpose||method:reshape||method:reshape||method:transpose||method:reshape
 import paddle
 import unittest
 import numpy as np
@@ -15,7 +15,7 @@ class LayerCase(paddle.nn.Layer):
         var_2 = var_0.__add__(var_1)
         var_3 = var_2.transpose([0, 2, 1, 3])
         var_4 = var_3.reshape([-1, 96, 48])
-        var_5 = paddle.tensor.creation.to_tensor(22, 'int32')
+        var_5 = var_0.shape[0] / 96
         var_6 = var_4.reshape([var_5, 96, 1, 1, 96, 48])
         var_7 = var_6.transpose([0, 1, 3, 2, 4, 5])
         var_8 = var_7.reshape([var_5, 96, 96, 48])

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/CSWinTransformer_CSWinTransformer_base_384/SIR_487.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/CSWinTransformer_CSWinTransformer_base_384/SIR_487.py
@@ -1,4 +1,4 @@
-# method:__add__||method:transpose||method:reshape||api:paddle.tensor.creation.to_tensor||method:reshape||method:transpose||method:reshape
+# method:__add__||method:transpose||method:reshape||method:reshape||method:transpose||method:reshape
 import paddle
 import unittest
 import numpy as np
@@ -15,7 +15,7 @@ class LayerCase(paddle.nn.Layer):
         var_2 = var_0.__add__(var_1)
         var_3 = var_2.transpose([0, 2, 1, 3])
         var_4 = var_3.reshape([-1, 96, 96])
-        var_5 = paddle.tensor.creation.to_tensor(22, 'int32')
+        var_5 = var_0.shape[0] / 24
         var_6 = var_4.reshape([var_5, 1, 24, 48, 2, 96])
         var_7 = var_6.transpose([0, 1, 3, 2, 4, 5])
         var_8 = var_7.reshape([var_5, 48, 48, 96])

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/CSWinTransformer_CSWinTransformer_base_384/SIR_520.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/CSWinTransformer_CSWinTransformer_base_384/SIR_520.py
@@ -1,4 +1,4 @@
-# method:__add__||method:transpose||method:reshape||api:paddle.tensor.creation.to_tensor||method:reshape||method:transpose||method:reshape
+# method:__add__||method:transpose||method:reshape||method:reshape||method:transpose||method:reshape
 import paddle
 import unittest
 import numpy as np
@@ -15,7 +15,7 @@ class LayerCase(paddle.nn.Layer):
         var_2 = var_0.__add__(var_1)
         var_3 = var_2.transpose([0, 2, 1, 3])
         var_4 = var_3.reshape([-1, 288, 192])
-        var_5 = paddle.tensor.creation.to_tensor(22, 'int32')
+        var_5 = var_0.shape[0] / 2
         var_6 = var_4.reshape([var_5, 1, 2, 24, 12, 192])
         var_7 = var_6.transpose([0, 1, 3, 2, 4, 5])
         var_8 = var_7.reshape([var_5, 24, 24, 192])

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/CSWinTransformer_CSWinTransformer_base_384/SIR_598.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/CSWinTransformer_CSWinTransformer_base_384/SIR_598.py
@@ -1,4 +1,4 @@
-# method:__add__||method:transpose||method:reshape||api:paddle.tensor.creation.to_tensor||method:reshape||method:transpose||method:reshape
+# method:__add__||method:transpose||method:reshape||method:reshape||method:transpose||method:reshape
 import paddle
 import unittest
 import numpy as np
@@ -15,7 +15,7 @@ class LayerCase(paddle.nn.Layer):
         var_2 = var_0.__add__(var_1)
         var_3 = var_2.transpose([0, 2, 1, 3])
         var_4 = var_3.reshape([-1, 144, 768])
-        var_5 = paddle.tensor.creation.to_tensor(22, 'int32')
+        var_5 = var_0.shape[0]
         var_6 = var_4.reshape([var_5, 1, 1, 12, 12, 768])
         var_7 = var_6.transpose([0, 1, 3, 2, 4, 5])
         var_8 = var_7.reshape([var_5, 12, 12, 768])

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/CSWinTransformer_CSWinTransformer_base_384/SIR_616.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/CSWinTransformer_CSWinTransformer_base_384/SIR_616.py
@@ -1,4 +1,4 @@
-# method:__add__||method:transpose||method:reshape||api:paddle.tensor.creation.to_tensor||method:reshape||method:transpose||method:reshape
+# method:__add__||method:transpose||method:reshape||method:reshape||method:transpose||method:reshape
 import paddle
 import unittest
 import numpy as np
@@ -15,7 +15,7 @@ class LayerCase(paddle.nn.Layer):
         var_2 = var_0.__add__(var_1)
         var_3 = var_2.transpose([0, 2, 1, 3])
         var_4 = var_3.reshape([-1, 96, 48])
-        var_5 = paddle.tensor.creation.to_tensor(10, 'int32')
+        var_5 = var_0.shape[0] / 96
         var_6 = var_4.reshape([var_5, 96, 1, 1, 96, 48])
         var_7 = var_6.transpose([0, 1, 3, 2, 4, 5])
         var_8 = var_7.reshape([var_5, 96, 96, 48])

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/CSWinTransformer_CSWinTransformer_base_384/SIR_634.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/CSWinTransformer_CSWinTransformer_base_384/SIR_634.py
@@ -1,4 +1,4 @@
-# method:__add__||method:transpose||method:reshape||api:paddle.tensor.creation.to_tensor||method:reshape||method:transpose||method:reshape
+# method:__add__||method:transpose||method:reshape||method:reshape||method:transpose||method:reshape
 import paddle
 import unittest
 import numpy as np
@@ -15,7 +15,7 @@ class LayerCase(paddle.nn.Layer):
         var_2 = var_0.__add__(var_1)
         var_3 = var_2.transpose([0, 2, 1, 3])
         var_4 = var_3.reshape([-1, 96, 96])
-        var_5 = paddle.tensor.creation.to_tensor(10, 'int32')
+        var_5 = var_0.shape[0] / 24
         var_6 = var_4.reshape([var_5, 1, 24, 48, 2, 96])
         var_7 = var_6.transpose([0, 1, 3, 2, 4, 5])
         var_8 = var_7.reshape([var_5, 48, 48, 96])

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/CSWinTransformer_CSWinTransformer_base_384/SIR_660.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/CSWinTransformer_CSWinTransformer_base_384/SIR_660.py
@@ -1,4 +1,4 @@
-# method:__add__||method:transpose||method:reshape||api:paddle.tensor.creation.to_tensor||method:reshape||method:transpose||method:reshape
+# method:__add__||method:transpose||method:reshape||method:reshape||method:transpose||method:reshape
 import paddle
 import unittest
 import numpy as np
@@ -15,7 +15,7 @@ class LayerCase(paddle.nn.Layer):
         var_2 = var_0.__add__(var_1)
         var_3 = var_2.transpose([0, 2, 1, 3])
         var_4 = var_3.reshape([-1, 288, 192])
-        var_5 = paddle.tensor.creation.to_tensor(10, 'int32')
+        var_5 = var_0.shape[0] / 2
         var_6 = var_4.reshape([var_5, 1, 2, 24, 12, 192])
         var_7 = var_6.transpose([0, 1, 3, 2, 4, 5])
         var_8 = var_7.reshape([var_5, 24, 24, 192])

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/CSWinTransformer_CSWinTransformer_base_384/SIR_67.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/CSWinTransformer_CSWinTransformer_base_384/SIR_67.py
@@ -1,4 +1,4 @@
-# method:__add__||method:transpose||method:reshape||api:paddle.tensor.creation.to_tensor||method:reshape||method:transpose||method:reshape
+# method:__add__||method:transpose||method:reshape||method:reshape||method:transpose||method:reshape
 import paddle
 import unittest
 import numpy as np
@@ -15,7 +15,7 @@ class LayerCase(paddle.nn.Layer):
         var_2 = var_0.__add__(var_1)
         var_3 = var_2.transpose([0, 2, 1, 3])
         var_4 = var_3.reshape([-1, 96, 96])
-        var_5 = paddle.tensor.creation.to_tensor(6, 'int32')
+        var_5 = var_0.shape[0] / 24
         var_6 = var_4.reshape([var_5, 1, 24, 48, 2, 96])
         var_7 = var_6.transpose([0, 1, 3, 2, 4, 5])
         var_8 = var_7.reshape([var_5, 48, 48, 96])

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/mot_jde_jde_darknet53_30e_864x480/SIR_75.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/mot_jde_jde_darknet53_30e_864x480/SIR_75.py
@@ -1,4 +1,4 @@
-# api:paddle.tensor.creation.to_tensor||method:__neg__||api:paddle.tensor.ops.exp||method:__mul__||method:__add__||method:__mul__||method:__neg__||api:paddle.tensor.ops.exp||method:__mul__||method:__add__||method:__mul__||method:__add__||method:__neg__||api:paddle.tensor.ops.exp||method:__mul__||method:__add__||method:__mul__||method:__add__||method:__neg__||api:paddle.tensor.ops.exp||method:__mul__||method:__add__||method:__mul__||method:__neg__||api:paddle.tensor.ops.exp||method:__mul__||method:__add__||method:__mul__||method:__add__||method:__neg__||api:paddle.tensor.ops.exp||method:__mul__||method:__add__||method:__mul__||method:__add__||method:__neg__||api:paddle.tensor.ops.exp||method:__mul__||method:__add__||method:__mul__||method:__neg__||api:paddle.tensor.ops.exp||method:__mul__||method:__add__||method:__mul__||method:__add__||method:__neg__||api:paddle.tensor.ops.exp||method:__mul__||method:__add__||method:__mul__||method:__add__||method:__radd__||method:__add__||method:__add__||method:__radd__||method:__add__||method:__add__||method:__radd__||method:__add__||method:__add__||method:__radd__||method:__add__||method:__add__
+# method:__neg__||api:paddle.tensor.ops.exp||method:__mul__||method:__add__||method:__mul__||method:__neg__||api:paddle.tensor.ops.exp||method:__mul__||method:__add__||method:__mul__||method:__add__||method:__neg__||api:paddle.tensor.ops.exp||method:__mul__||method:__add__||method:__mul__||method:__add__||method:__neg__||api:paddle.tensor.ops.exp||method:__mul__||method:__add__||method:__mul__||method:__neg__||api:paddle.tensor.ops.exp||method:__mul__||method:__add__||method:__mul__||method:__add__||method:__neg__||api:paddle.tensor.ops.exp||method:__mul__||method:__add__||method:__mul__||method:__add__||method:__neg__||api:paddle.tensor.ops.exp||method:__mul__||method:__add__||method:__mul__||method:__neg__||api:paddle.tensor.ops.exp||method:__mul__||method:__add__||method:__mul__||method:__add__||method:__neg__||api:paddle.tensor.ops.exp||method:__mul__||method:__add__||method:__mul__||method:__add__||method:__radd__||method:__add__||method:__add__||method:__radd__||method:__add__||method:__add__||method:__radd__||method:__add__||method:__add__||method:__radd__||method:__add__||method:__add__
 import paddle
 import unittest
 import numpy as np
@@ -55,7 +55,6 @@ class LayerCase(paddle.nn.Layer):
         var_7,    # (shape: [], dtype: paddle.float32, stop_gradient: False)
         var_8,    # (shape: [], dtype: paddle.float32, stop_gradient: False)
     ):
-        var_9 = paddle.tensor.creation.to_tensor(26.0, dtype='float32')
         var_10 = self.parameter_3.__neg__()
         var_11 = paddle.tensor.ops.exp(var_10)
         var_12 = var_11.__mul__(var_0)
@@ -119,7 +118,7 @@ class LayerCase(paddle.nn.Layer):
         var_70 = var_26.__radd__(0)
         var_71 = var_70.__add__(var_43)
         var_72 = var_71.__add__(var_60)
-        return var_63, var_66, var_69, var_72, var_9
+        return var_63, var_66, var_69, var_72
 
 
 def create_paddle_inputs():

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_voc_ppyoloe_plus_crn_l_30e_voc/SIR_182.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_voc_ppyoloe_plus_crn_l_30e_voc/SIR_182.py
@@ -1,4 +1,4 @@
-# method:argmax||method:__mul__||method:__add__||method:flatten||method:flatten||api:paddle.tensor.manipulation.gather||method:reshape||method:__gt__||api:paddle.tensor.creation.full_like||api:paddle.tensor.search.where||method:reshape||method:flatten||api:paddle.tensor.manipulation.gather||method:reshape||api:paddle.nn.functional.input.one_hot||api:paddle.tensor.creation.to_tensor||api:paddle.tensor.search.index_select||method:__mul__||method:max||method:__mul__||method:max||method:__add__||method:__truediv__||method:__mul__||method:max||method:unsqueeze||method:__mul__
+# method:argmax||method:__mul__||method:__add__||method:flatten||method:flatten||api:paddle.tensor.manipulation.gather||method:reshape||method:__gt__||api:paddle.tensor.creation.full_like||api:paddle.tensor.search.where||method:reshape||method:flatten||api:paddle.tensor.manipulation.gather||method:reshape||api:paddle.nn.functional.input.one_hot||api:paddle.tensor.search.index_select||method:__mul__||method:max||method:__mul__||method:max||method:__add__||method:__truediv__||method:__mul__||method:max||method:unsqueeze||method:__mul__
 import paddle
 import unittest
 import numpy as np
@@ -32,7 +32,7 @@ class LayerCase(paddle.nn.Layer):
         var_19 = paddle.tensor.manipulation.gather(var_17, var_18, axis=0)
         var_20 = var_19.reshape([1, 4116, 4])
         var_21 = paddle.nn.functional.input.one_hot(var_16, 21)
-        var_22 = paddle.tensor.creation.to_tensor([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19])
+        var_22 = paddle.arange(20)
         var_23 = paddle.tensor.search.index_select(var_21, var_22, axis=-1)
         var_24 = var_5.__mul__(var_0)
         var_25 = var_24.max(axis=-1, keepdim=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_voc_ppyoloe_plus_crn_s_30e_voc/SIR_179.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_voc_ppyoloe_plus_crn_s_30e_voc/SIR_179.py
@@ -1,4 +1,4 @@
-# method:argmax||method:__mul__||method:__add__||method:flatten||method:flatten||api:paddle.tensor.manipulation.gather||method:reshape||method:__gt__||api:paddle.tensor.creation.full_like||api:paddle.tensor.search.where||method:reshape||method:flatten||api:paddle.tensor.manipulation.gather||method:reshape||api:paddle.nn.functional.input.one_hot||api:paddle.tensor.creation.to_tensor||api:paddle.tensor.search.index_select||method:__mul__||method:max||method:__mul__||method:max||method:__add__||method:__truediv__||method:__mul__||method:max||method:unsqueeze||method:__mul__
+# method:argmax||method:__mul__||method:__add__||method:flatten||method:flatten||api:paddle.tensor.manipulation.gather||method:reshape||method:__gt__||api:paddle.tensor.creation.full_like||api:paddle.tensor.search.where||method:reshape||method:flatten||api:paddle.tensor.manipulation.gather||method:reshape||api:paddle.nn.functional.input.one_hot||api:paddle.tensor.search.index_select||method:__mul__||method:max||method:__mul__||method:max||method:__add__||method:__truediv__||method:__mul__||method:max||method:unsqueeze||method:__mul__
 import paddle
 import unittest
 import numpy as np
@@ -32,7 +32,7 @@ class LayerCase(paddle.nn.Layer):
         var_19 = paddle.tensor.manipulation.gather(var_17, var_18, axis=0)
         var_20 = var_19.reshape([1, 2100, 4])
         var_21 = paddle.nn.functional.input.one_hot(var_16, 21)
-        var_22 = paddle.tensor.creation.to_tensor([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19])
+        var_22 = paddle.arange(20)
         var_23 = paddle.tensor.search.index_select(var_21, var_22, axis=-1)
         var_24 = var_5.__mul__(var_0)
         var_25 = var_24.max(axis=-1, keepdim=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/smalldet_ppyoloe_plus_sod_crn_l_80e_coco/SIR_174.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/smalldet_ppyoloe_plus_sod_crn_l_80e_coco/SIR_174.py
@@ -1,4 +1,4 @@
-# method:argmax||method:__mul__||method:__add__||method:flatten||method:flatten||api:paddle.tensor.manipulation.gather||method:reshape||method:__gt__||api:paddle.tensor.creation.full_like||api:paddle.tensor.search.where||method:reshape||method:flatten||api:paddle.tensor.manipulation.gather||method:reshape||api:paddle.nn.functional.input.one_hot||api:paddle.tensor.creation.to_tensor||api:paddle.tensor.search.index_select||method:__mul__||method:max||method:__mul__||method:max||method:__add__||method:__truediv__||method:__mul__||method:max||method:unsqueeze||method:__mul__
+# method:argmax||method:__mul__||method:__add__||method:flatten||method:flatten||api:paddle.tensor.manipulation.gather||method:reshape||method:__gt__||api:paddle.tensor.creation.full_like||api:paddle.tensor.search.where||method:reshape||method:flatten||api:paddle.tensor.manipulation.gather||method:reshape||api:paddle.nn.functional.input.one_hot||api:paddle.tensor.search.index_select||method:__mul__||method:max||method:__mul__||method:max||method:__add__||method:__truediv__||method:__mul__||method:max||method:unsqueeze||method:__mul__
 import paddle
 import unittest
 import numpy as np
@@ -32,7 +32,7 @@ class LayerCase(paddle.nn.Layer):
         var_19 = paddle.tensor.manipulation.gather(var_17, var_18, axis=0)
         var_20 = var_19.reshape([1, 3549, 4])
         var_21 = paddle.nn.functional.input.one_hot(var_16, 81)
-        var_22 = paddle.tensor.creation.to_tensor([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79])
+        var_22 = paddle.arange(80)
         var_23 = paddle.tensor.search.index_select(var_21, var_22, axis=-1)
         var_24 = var_5.__mul__(var_0)
         var_25 = var_24.max(axis=-1, keepdim=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Clas_cases/CSWinTransformer_CSWinTransformer_base_384/SIR_116.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Clas_cases/CSWinTransformer_CSWinTransformer_base_384/SIR_116.py
@@ -1,4 +1,4 @@
-# method:__add__||method:transpose||method:reshape||api:paddle.tensor.creation.to_tensor||method:reshape||method:transpose||method:reshape
+# method:__add__||method:transpose||method:reshape||method:reshape||method:transpose||method:reshape
 import paddle
 import unittest
 import numpy as np
@@ -15,7 +15,7 @@ class LayerCase(paddle.nn.Layer):
         var_2 = var_0.__add__(var_1)
         var_3 = var_2.transpose([0, 2, 1, 3])
         var_4 = var_3.reshape([-1, 288, 192])
-        var_5 = paddle.tensor.creation.to_tensor(6, 'int32')
+        var_5 = var_0.shape[0] / 2
         var_6 = var_4.reshape([var_5, 1, 2, 24, 12, 192])
         var_7 = var_6.transpose([0, 1, 3, 2, 4, 5])
         var_8 = var_7.reshape([var_5, 24, 24, 192])

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Clas_cases/CSWinTransformer_CSWinTransformer_base_384/SIR_178.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Clas_cases/CSWinTransformer_CSWinTransformer_base_384/SIR_178.py
@@ -1,4 +1,4 @@
-# api:paddle.tensor.creation.to_tensor||method:reshape||method:transpose||method:reshape
+# method:reshape||method:transpose||method:reshape
 import paddle
 import unittest
 import numpy as np
@@ -11,7 +11,7 @@ class LayerCase(paddle.nn.Layer):
         self,
         var_0,    # (shape: [12, 288, 192], dtype: paddle.float32, stop_gradient: False)
     ):
-        var_1 = paddle.tensor.creation.to_tensor(6, 'int32')
+        var_1 = var_0.shape[0] / 2
         var_2 = var_0.reshape([var_1, 1, 2, 24, 12, 192])
         var_3 = var_2.transpose([0, 1, 3, 2, 4, 5])
         var_4 = var_3.reshape([var_1, 24, 24, 192])

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/mot_jde_jde_darknet53_30e_864x480/SIR_75.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/mot_jde_jde_darknet53_30e_864x480/SIR_75.py
@@ -1,4 +1,4 @@
-# api:paddle.tensor.creation.to_tensor||method:__neg__||api:paddle.tensor.ops.exp||method:__mul__||method:__add__||method:__mul__||method:__neg__||api:paddle.tensor.ops.exp||method:__mul__||method:__add__||method:__mul__||method:__add__||method:__neg__||api:paddle.tensor.ops.exp||method:__mul__||method:__add__||method:__mul__||method:__add__||method:__neg__||api:paddle.tensor.ops.exp||method:__mul__||method:__add__||method:__mul__||method:__neg__||api:paddle.tensor.ops.exp||method:__mul__||method:__add__||method:__mul__||method:__add__||method:__neg__||api:paddle.tensor.ops.exp||method:__mul__||method:__add__||method:__mul__||method:__add__||method:__neg__||api:paddle.tensor.ops.exp||method:__mul__||method:__add__||method:__mul__||method:__neg__||api:paddle.tensor.ops.exp||method:__mul__||method:__add__||method:__mul__||method:__add__||method:__neg__||api:paddle.tensor.ops.exp||method:__mul__||method:__add__||method:__mul__||method:__add__||method:__radd__||method:__add__||method:__add__||method:__radd__||method:__add__||method:__add__||method:__radd__||method:__add__||method:__add__||method:__radd__||method:__add__||method:__add__
+# method:__neg__||api:paddle.tensor.ops.exp||method:__mul__||method:__add__||method:__mul__||method:__neg__||api:paddle.tensor.ops.exp||method:__mul__||method:__add__||method:__mul__||method:__add__||method:__neg__||api:paddle.tensor.ops.exp||method:__mul__||method:__add__||method:__mul__||method:__add__||method:__neg__||api:paddle.tensor.ops.exp||method:__mul__||method:__add__||method:__mul__||method:__neg__||api:paddle.tensor.ops.exp||method:__mul__||method:__add__||method:__mul__||method:__add__||method:__neg__||api:paddle.tensor.ops.exp||method:__mul__||method:__add__||method:__mul__||method:__add__||method:__neg__||api:paddle.tensor.ops.exp||method:__mul__||method:__add__||method:__mul__||method:__neg__||api:paddle.tensor.ops.exp||method:__mul__||method:__add__||method:__mul__||method:__add__||method:__neg__||api:paddle.tensor.ops.exp||method:__mul__||method:__add__||method:__mul__||method:__add__||method:__radd__||method:__add__||method:__add__||method:__radd__||method:__add__||method:__add__||method:__radd__||method:__add__||method:__add__||method:__radd__||method:__add__||method:__add__
 import paddle
 import unittest
 import numpy as np
@@ -55,7 +55,6 @@ class LayerCase(paddle.nn.Layer):
         var_7,    # (shape: [], dtype: paddle.float32, stop_gradient: False)
         var_8,    # (shape: [], dtype: paddle.float32, stop_gradient: False)
     ):
-        var_9 = paddle.tensor.creation.to_tensor(26.0, dtype='float32')
         var_10 = self.parameter_2.__neg__()
         var_11 = paddle.tensor.ops.exp(var_10)
         var_12 = var_11.__mul__(var_0)
@@ -119,7 +118,7 @@ class LayerCase(paddle.nn.Layer):
         var_70 = var_26.__radd__(0)
         var_71 = var_70.__add__(var_43)
         var_72 = var_71.__add__(var_60)
-        return var_63, var_66, var_69, var_72, var_9
+        return var_63, var_66, var_69, var_72
 
 
 def create_paddle_inputs():

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/smalldet_ppyoloe_plus_sod_crn_l_80e_coco/SIR_174.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/smalldet_ppyoloe_plus_sod_crn_l_80e_coco/SIR_174.py
@@ -1,4 +1,4 @@
-# method:argmax||method:__mul__||method:__add__||method:flatten||method:flatten||api:paddle.tensor.manipulation.gather||method:reshape||method:__gt__||api:paddle.tensor.creation.full_like||api:paddle.tensor.search.where||method:reshape||method:flatten||api:paddle.tensor.manipulation.gather||method:reshape||api:paddle.nn.functional.input.one_hot||api:paddle.tensor.creation.to_tensor||api:paddle.tensor.search.index_select||method:__mul__||method:max||method:__mul__||method:max||method:__add__||method:__truediv__||method:__mul__||method:max||method:unsqueeze||method:__mul__
+# method:argmax||method:__mul__||method:__add__||method:flatten||method:flatten||api:paddle.tensor.manipulation.gather||method:reshape||method:__gt__||api:paddle.tensor.creation.full_like||api:paddle.tensor.search.where||method:reshape||method:flatten||api:paddle.tensor.manipulation.gather||method:reshape||api:paddle.nn.functional.input.one_hot||api:paddle.tensor.search.index_select||method:__mul__||method:max||method:__mul__||method:max||method:__add__||method:__truediv__||method:__mul__||method:max||method:unsqueeze||method:__mul__
 import paddle
 import unittest
 import numpy as np
@@ -32,7 +32,7 @@ class LayerCase(paddle.nn.Layer):
         var_19 = paddle.tensor.manipulation.gather(var_17, var_18, axis=0)
         var_20 = var_19.reshape([1, 7581, 4])
         var_21 = paddle.nn.functional.input.one_hot(var_16, 81)
-        var_22 = paddle.tensor.creation.to_tensor([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79])
+        var_22 = paddle.arange(80)
         var_23 = paddle.tensor.search.index_select(var_21, var_22, axis=-1)
         var_24 = var_5.__mul__(var_0)
         var_25 = var_24.max(axis=-1, keepdim=True)


### PR DESCRIPTION
paddle.to_tensor 在静态图下会隐式创建 assign_value_ 算子，此算子目前是没有符号推导接口的，故改为paddle.shape