### PR TITLE
[Fix] Update test_expand15 for supporting maximal expand api from 6D to 8D

### DIFF
--- a/framework/api/paddlebase/test_expand.py
+++ b/framework/api/paddlebase/test_expand.py
@@ -196,10 +196,10 @@ def test_expand14():
 @pytest.mark.api_base_expand_exception
 def test_expand15():
     """
-    shape.shape >6,c++error
+    expand_shape > 9, C++ error is expected to be raised
     """
     x = np.array([1])
-    shape = np.ones([7]).astype(np.int32)
+    shape = np.ones([9]).astype(np.int32)
     obj.exception(x=x, shape=shape, mode="c", etype="InvalidArgument")
 
 


### PR DESCRIPTION
PR https://github.com/PaddlePaddle/Paddle/pull/63061 support up to 8-dimension `expand_shape` for expand and expand_grad, so modify the trigger condition of `test_expand15` from 7D to 9D