### PR TITLE
comment  test_more_bz_mkldnn

### DIFF
--- a/inference/python_api_test/test_det_model/test_ppyolov2_mkldnn.py
+++ b/inference/python_api_test/test_det_model/test_ppyolov2_mkldnn.py
@@ -46,7 +46,7 @@ def test_config():
     test_suite.config_test()
 
 
-# fused_softplus is about to be removed, test_more_bz_mkldnn uses fused_softplus and is disabled
+# fluid operator fused_softplus is about to be removed, test_more_bz_mkldnn uses fused_softplus and is disabled
 @pytest.mark.win
 @pytest.mark.server
 @pytest.mark.mkldnn

--- a/inference/python_api_test/test_det_model/test_ppyolov2_mkldnn.py
+++ b/inference/python_api_test/test_det_model/test_ppyolov2_mkldnn.py
@@ -46,10 +46,11 @@ def test_config():
     test_suite.config_test()
 
 
+# fused_softplus is about to be removed, test_more_bz_mkldnn uses fused_softplus and is disabled
 @pytest.mark.win
 @pytest.mark.server
 @pytest.mark.mkldnn
-def test_more_bz_mkldnn():
+def _test_more_bz_mkldnn():
     """
     compared mkldnn ppyolov2 batch_size = [1] outputs with true val
     """


### PR DESCRIPTION
https://github.com/PaddlePaddle/Paddle/pull/63459

fluid 中算子 fused_softplus 即将移除，test_more_bz_mkldnn测试yolo开启mkldnn使用了算子fused_softplus所以注释，不确定其他还有哪些测试用到，或者能否告知这样算子移除的应该怎么测试修改

https://xly.bce.baidu.com/paddlepaddle/paddle/newipipe/detail/10478746/job/25899726

![image](https://github.com/PaddlePaddle/PaddleTest/assets/4617245/c56f2f38-f427-4f25-a075-41dc80998516)

@EmmonsCurse 
