### PR TITLE
[CINN]Fix random shape leading dynamic UT Failed

### DIFF
--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/SwinTransformer_SwinTransformer_small_patch4_window7_224/SIR_214.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/SwinTransformer_SwinTransformer_small_patch4_window7_224/SIR_214.py
@@ -7,12 +7,13 @@ import numpy as np
 class LayerCase(paddle.nn.Layer):
     def __init__(self):
         super().__init__()
+
     def forward(
         self,
-        var_0,    # (shape: [44, 7, 7, 384], dtype: paddle.float32, stop_gradient: True)
-        var_1,    # (shape: [], dtype: paddle.int32, stop_gradient: True)
-        var_2,    # (shape: [], dtype: paddle.int32, stop_gradient: True)
-        var_3,    # (shape: [], dtype: paddle.int32, stop_gradient: True)
+        var_0,  # (shape: [44, 7, 7, 384], dtype: paddle.float32, stop_gradient: True)
+        var_1,  # (shape: [], dtype: paddle.int32, stop_gradient: True)
+        var_2,  # (shape: [], dtype: paddle.int32, stop_gradient: True)
+        var_3,  # (shape: [], dtype: paddle.int32, stop_gradient: True)
     ):
         var_4 = var_1.__floordiv__(7)
         var_5 = var_2.__floordiv__(7)
@@ -25,19 +26,19 @@ class LayerCase(paddle.nn.Layer):
 def create_tensor_inputs():
     inputs = (
         paddle.rand(shape=[44, 7, 7, 384], dtype=paddle.float32),
-        paddle.randint(low=0, high=10, shape=[1], dtype=paddle.int32),
-        paddle.randint(low=0, high=10, shape=[1], dtype=paddle.int32),
-        paddle.randint(low=0, high=10, shape=[1], dtype=paddle.int32),
+        paddle.to_tensor(28, dtype=paddle.int32),
+        paddle.to_tensor(77, dtype=paddle.int32),
+        paddle.to_tensor(384, dtype=paddle.int32),
     )
     return inputs
 
 
 def create_numpy_inputs():
     inputs = (
-        np.random.random(size=[44, 7, 7, 384]).astype('float32'),
-        np.random.randint(low=0, high=10, size=[1], dtype='int32'),
-        np.random.randint(low=0, high=10, size=[1], dtype='int32'),
-        np.random.randint(low=0, high=10, size=[1], dtype='int32'),
+        np.random.random(size=[44, 7, 7, 384]).astype("float32"),
+        np.array([28], dtype="int32"),
+        np.array([77], dtype="int32"),
+        np.array([384], dtype="int32"),
     )
     return inputs
 
@@ -46,9 +47,10 @@ class TestLayer(unittest.TestCase):
     def setUp(self):
         self.inputs = create_tensor_inputs()
         self.net = LayerCase()
+
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.set_flags({"FLAGS_prim_all": with_prim})
             if with_cinn:
                 build_strategy = paddle.static.BuildStrategy()
                 build_strategy.build_cinn_pass = True
@@ -58,6 +60,7 @@ class TestLayer(unittest.TestCase):
         paddle.seed(123)
         outs = net(*self.inputs)
         return outs
+
     def test_ast_prim_cinn(self):
         st_out = self.train(self.net, to_static=True)
         cinn_out = self.train(self.net, to_static=True, with_prim=True, with_cinn=True)
@@ -65,5 +68,5 @@ class TestLayer(unittest.TestCase):
             np.testing.assert_allclose(st.numpy(), cinn.numpy(), atol=1e-8)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/hardnet_hardnet_cityscapes_1024x1024_160k/SIR_126.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/hardnet_hardnet_cityscapes_1024x1024_160k/SIR_126.py
@@ -8,35 +8,50 @@ class LayerCase(paddle.nn.Layer):
     def __init__(self):
         super().__init__()
         self.parameter_0 = self.create_parameter(
-           shape=[19],
-           dtype=paddle.float32,
+            shape=[19],
+            dtype=paddle.float32,
         )
         self.parameter_1 = self.create_parameter(
-           shape=[19, 48, 1, 1],
-           dtype=paddle.float32,
+            shape=[19, 48, 1, 1],
+            dtype=paddle.float32,
         )
+
     def forward(
         self,
-        var_0,    # (shape: [1, 48, 512, 512], dtype: paddle.float32, stop_gradient: False)
-        var_1,    # (shape: [2], dtype: paddle.int32, stop_gradient: True)
+        var_0,  # (shape: [1, 48, 512, 512], dtype: paddle.float32, stop_gradient: False)
+        var_1,  # (shape: [2], dtype: paddle.int32, stop_gradient: True)
     ):
-        var_2 = paddle.nn.functional.conv._conv_nd(var_0, self.parameter_1, bias=self.parameter_0, stride=[1, 1], padding=[0, 0], padding_algorithm='EXPLICIT', dilation=[1, 1], groups=1, data_format='NCHW', channel_dim=1, op_type='conv2d', use_cudnn=True)
-        var_3 = paddle.nn.functional.common.interpolate(var_2, size=var_1, mode='bilinear', align_corners=False)
+        var_2 = paddle.nn.functional.conv._conv_nd(
+            var_0,
+            self.parameter_1,
+            bias=self.parameter_0,
+            stride=[1, 1],
+            padding=[0, 0],
+            padding_algorithm="EXPLICIT",
+            dilation=[1, 1],
+            groups=1,
+            data_format="NCHW",
+            channel_dim=1,
+            op_type="conv2d",
+            use_cudnn=True,
+        )
+        # breakpoint()
+        var_3 = paddle.nn.functional.common.interpolate(var_2, size=var_1, mode="bilinear", align_corners=False)
         return var_3
 
 
 def create_tensor_inputs():
     inputs = (
         paddle.rand(shape=[1, 48, 512, 512], dtype=paddle.float32),
-        paddle.randint(low=0, high=10, shape=[2], dtype=paddle.int32),
+        paddle.to_tensor([128, 128], dtype=paddle.int32),
     )
     return inputs
 
 
 def create_numpy_inputs():
     inputs = (
-        np.random.random(size=[1, 48, 512, 512]).astype('float32'),
-        np.random.randint(low=0, high=10, size=[2], dtype='int32'),
+        np.random.random(size=[1, 48, 512, 512]).astype("float32"),
+        np.array([128, 128], dtype="int32"),
     )
     return inputs
 
@@ -45,9 +60,10 @@ class TestLayer(unittest.TestCase):
     def setUp(self):
         self.inputs = create_tensor_inputs()
         self.net = LayerCase()
+
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.set_flags({"FLAGS_prim_all": with_prim})
             if with_cinn:
                 build_strategy = paddle.static.BuildStrategy()
                 build_strategy.build_cinn_pass = True
@@ -57,6 +73,7 @@ class TestLayer(unittest.TestCase):
         paddle.seed(123)
         outs = net(*self.inputs)
         return outs
+
     def test_ast_prim_cinn(self):
         st_out = self.train(self.net, to_static=True)
         cinn_out = self.train(self.net, to_static=True, with_prim=True, with_cinn=True)
@@ -64,5 +81,5 @@ class TestLayer(unittest.TestCase):
             np.testing.assert_allclose(st.numpy(), cinn.numpy(), atol=1e-8)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/isanet_isanet_resnet101_os8_voc12aug_512x512_40k/SIR_33.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/isanet_isanet_resnet101_os8_voc12aug_512x512_40k/SIR_33.py
@@ -7,12 +7,13 @@ import numpy as np
 class LayerCase(paddle.nn.Layer):
     def __init__(self):
         super().__init__()
+
     def forward(
         self,
-        var_0,    # (shape: [1, 512, 64, 64], dtype: paddle.float32, stop_gradient: False)
-        var_1,    # (shape: [4], dtype: paddle.int32, stop_gradient: True)
-        var_2,    # (shape: [1], dtype: paddle.int32, stop_gradient: True)
-        var_3,    # (shape: [1], dtype: paddle.int32, stop_gradient: True)
+        var_0,  # (shape: [1, 512, 64, 64], dtype: paddle.float32, stop_gradient: False)
+        var_1,  # (shape: [4], dtype: paddle.int32, stop_gradient: True)
+        var_2,  # (shape: [1], dtype: paddle.int32, stop_gradient: True)
+        var_3,  # (shape: [1], dtype: paddle.int32, stop_gradient: True)
     ):
         var_4 = var_1.__getitem__(1)
         var_5 = var_0.reshape([0, var_4, var_2, 8, var_3, 8])
@@ -24,19 +25,19 @@ class LayerCase(paddle.nn.Layer):
 def create_tensor_inputs():
     inputs = (
         paddle.rand(shape=[1, 512, 64, 64], dtype=paddle.float32),
-        paddle.randint(low=0, high=10, shape=[4], dtype=paddle.int32),
-        paddle.randint(low=0, high=10, shape=[1], dtype=paddle.int32),
-        paddle.randint(low=0, high=10, shape=[1], dtype=paddle.int32),
+        paddle.to_tensor([1, 512, 1, 1], dtype=paddle.int32),
+        paddle.to_tensor(4, dtype=paddle.int32),
+        paddle.to_tensor(16, dtype=paddle.int32),
     )
     return inputs
 
 
 def create_numpy_inputs():
     inputs = (
-        np.random.random(size=[1, 512, 64, 64]).astype('float32'),
-        np.random.randint(low=0, high=10, size=[4], dtype='int32'),
-        np.random.randint(low=0, high=10, size=[1], dtype='int32'),
-        np.random.randint(low=0, high=10, size=[1], dtype='int32'),
+        np.random.random(size=[1, 512, 64, 64]).astype("float32"),
+        np.array([1, 512, 1, 1], dtype="int32"),
+        np.array(4, dtype="int32"),
+        np.array(16, dtype="int32"),
     )
     return inputs
 
@@ -45,9 +46,10 @@ class TestLayer(unittest.TestCase):
     def setUp(self):
         self.inputs = create_tensor_inputs()
         self.net = LayerCase()
+
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.set_flags({"FLAGS_prim_all": with_prim})
             if with_cinn:
                 build_strategy = paddle.static.BuildStrategy()
                 build_strategy.build_cinn_pass = True
@@ -57,6 +59,7 @@ class TestLayer(unittest.TestCase):
         paddle.seed(123)
         outs = net(*self.inputs)
         return outs
+
     def test_ast_prim_cinn(self):
         st_out = self.train(self.net, to_static=True)
         cinn_out = self.train(self.net, to_static=True, with_prim=True, with_cinn=True)
@@ -64,5 +67,5 @@ class TestLayer(unittest.TestCase):
             np.testing.assert_allclose(st.numpy(), cinn.numpy(), atol=1e-8)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/isanet_isanet_resnet101_os8_voc12aug_512x512_40k/SIR_34.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/isanet_isanet_resnet101_os8_voc12aug_512x512_40k/SIR_34.py
@@ -7,12 +7,13 @@ import numpy as np
 class LayerCase(paddle.nn.Layer):
     def __init__(self):
         super().__init__()
+
     def forward(
         self,
-        var_0,    # (shape: [64, 512, 8, 8], dtype: paddle.float32, stop_gradient: False)
-        var_1,    # (shape: [4], dtype: paddle.int32, stop_gradient: True)
-        var_2,    # (shape: [1], dtype: paddle.int32, stop_gradient: True)
-        var_3,    # (shape: [1], dtype: paddle.int32, stop_gradient: True)
+        var_0,  # (shape: [64, 512, 8, 8], dtype: paddle.float32, stop_gradient: False)
+        var_1,  # (shape: [4], dtype: paddle.int32, stop_gradient: True)
+        var_2,  # (shape: [1], dtype: paddle.int32, stop_gradient: True)
+        var_3,  # (shape: [1], dtype: paddle.int32, stop_gradient: True)
     ):
         var_4 = var_1.__getitem__(0)
         var_5 = var_1.__getitem__(1)
@@ -25,19 +26,19 @@ class LayerCase(paddle.nn.Layer):
 def create_tensor_inputs():
     inputs = (
         paddle.rand(shape=[64, 512, 8, 8], dtype=paddle.float32),
-        paddle.randint(low=0, high=10, shape=[4], dtype=paddle.int32),
-        paddle.randint(low=0, high=10, shape=[1], dtype=paddle.int32),
-        paddle.randint(low=0, high=10, shape=[1], dtype=paddle.int32),
+        paddle.to_tensor([4, 128, 1, 1], dtype=paddle.int32),
+        paddle.to_tensor(4, dtype=paddle.int32),
+        paddle.to_tensor(16, dtype=paddle.int32),
     )
     return inputs
 
 
 def create_numpy_inputs():
     inputs = (
-        np.random.random(size=[64, 512, 8, 8]).astype('float32'),
-        np.random.randint(low=0, high=10, size=[4], dtype='int32'),
-        np.random.randint(low=0, high=10, size=[1], dtype='int32'),
-        np.random.randint(low=0, high=10, size=[1], dtype='int32'),
+        np.random.random(size=[64, 512, 8, 8]).astype("float32"),
+        np.array([4, 128, 1, 1], dtype="int32"),
+        np.array(4, dtype="int32"),
+        np.array(16, dtype="int32"),
     )
     return inputs
 
@@ -46,9 +47,10 @@ class TestLayer(unittest.TestCase):
     def setUp(self):
         self.inputs = create_tensor_inputs()
         self.net = LayerCase()
+
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.set_flags({"FLAGS_prim_all": with_prim})
             if with_cinn:
                 build_strategy = paddle.static.BuildStrategy()
                 build_strategy.build_cinn_pass = True
@@ -58,6 +60,7 @@ class TestLayer(unittest.TestCase):
         paddle.seed(123)
         outs = net(*self.inputs)
         return outs
+
     def test_ast_prim_cinn(self):
         st_out = self.train(self.net, to_static=True)
         cinn_out = self.train(self.net, to_static=True, with_prim=True, with_cinn=True)
@@ -65,5 +68,5 @@ class TestLayer(unittest.TestCase):
             np.testing.assert_allclose(st.numpy(), cinn.numpy(), atol=1e-8)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/isanet_isanet_resnet101_os8_voc12aug_512x512_40k/SIR_35.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/isanet_isanet_resnet101_os8_voc12aug_512x512_40k/SIR_35.py
@@ -7,13 +7,14 @@ import numpy as np
 class LayerCase(paddle.nn.Layer):
     def __init__(self):
         super().__init__()
+
     def forward(
         self,
-        var_0,    # (shape: [64, 512, 8, 8], dtype: paddle.float32, stop_gradient: False)
-        var_1,    # (shape: [4], dtype: paddle.int32, stop_gradient: True)
-        var_2,    # (shape: [1], dtype: paddle.int32, stop_gradient: True)
-        var_3,    # (shape: [1], dtype: paddle.int32, stop_gradient: True)
-        var_4,    # (shape: [1], dtype: paddle.int32, stop_gradient: True)
+        var_0,  # (shape: [64, 512, 8, 8], dtype: paddle.float32, stop_gradient: False)
+        var_1,  # (shape: [4], dtype: paddle.int32, stop_gradient: True)
+        var_2,  # (shape: [1], dtype: paddle.int32, stop_gradient: True)
+        var_3,  # (shape: [1], dtype: paddle.int32, stop_gradient: True)
+        var_4,  # (shape: [1], dtype: paddle.int32, stop_gradient: True)
     ):
         var_5 = var_1.__getitem__(0)
         var_6 = var_1.__getitem__(1)
@@ -29,9 +30,9 @@ class LayerCase(paddle.nn.Layer):
 def create_tensor_inputs():
     inputs = (
         paddle.rand(shape=[64, 512, 8, 8], dtype=paddle.float32),
-        paddle.randint(low=0, high=10, shape=[4], dtype=paddle.int32),
-        paddle.randint(low=0, high=10, shape=[1], dtype=paddle.int32),
-        paddle.randint(low=0, high=10, shape=[1], dtype=paddle.int32),
+        paddle.to_tensor([1, 512, 1, 1], dtype=paddle.int32),
+        paddle.to_tensor(4, dtype=paddle.int32),
+        paddle.to_tensor(16, dtype=paddle.int32),
         paddle.randint(low=0, high=10, shape=[1], dtype=paddle.int32),
     )
     return inputs
@@ -39,11 +40,11 @@ def create_tensor_inputs():
 
 def create_numpy_inputs():
     inputs = (
-        np.random.random(size=[64, 512, 8, 8]).astype('float32'),
-        np.random.randint(low=0, high=10, size=[4], dtype='int32'),
-        np.random.randint(low=0, high=10, size=[1], dtype='int32'),
-        np.random.randint(low=0, high=10, size=[1], dtype='int32'),
-        np.random.randint(low=0, high=10, size=[1], dtype='int32'),
+        np.random.random(size=[64, 512, 8, 8]).astype("float32"),
+        np.array([1, 512, 1, 1], dtype="int32"),
+        np.array(4, dtype="int32"),
+        np.array(16, dtype="int32"),
+        np.random.randint(low=0, high=10, size=[1], dtype="int32"),
     )
     return inputs
 
@@ -52,9 +53,10 @@ class TestLayer(unittest.TestCase):
     def setUp(self):
         self.inputs = create_tensor_inputs()
         self.net = LayerCase()
+
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.set_flags({"FLAGS_prim_all": with_prim})
             if with_cinn:
                 build_strategy = paddle.static.BuildStrategy()
                 build_strategy.build_cinn_pass = True
@@ -64,6 +66,7 @@ class TestLayer(unittest.TestCase):
         paddle.seed(123)
         outs = net(*self.inputs)
         return outs
+
     def test_ast_prim_cinn(self):
         st_out = self.train(self.net, to_static=True)
         cinn_out = self.train(self.net, to_static=True, with_prim=True, with_cinn=True)
@@ -71,5 +74,5 @@ class TestLayer(unittest.TestCase):
             np.testing.assert_allclose(st.numpy(), cinn.numpy(), atol=1e-8)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/isanet_isanet_resnet50_os8_cityscapes_769x769_80k/SIR_32.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/isanet_isanet_resnet50_os8_cityscapes_769x769_80k/SIR_32.py
@@ -7,14 +7,15 @@ import numpy as np
 class LayerCase(paddle.nn.Layer):
     def __init__(self):
         super().__init__()
+
     def forward(
         self,
-        var_0,    # (shape: [1], dtype: paddle.int32, stop_gradient: True)
-        var_1,    # (shape: [1], dtype: paddle.int32, stop_gradient: True)
-        var_2,    # (shape: [1, 512, 97, 97], dtype: paddle.float32, stop_gradient: False)
-        var_3,    # (shape: [4], dtype: paddle.int32, stop_gradient: True)
-        var_4,    # (shape: [1], dtype: paddle.int32, stop_gradient: True)
-        var_5,    # (shape: [1], dtype: paddle.int32, stop_gradient: True)
+        var_0,  # (shape: [1], dtype: paddle.int32, stop_gradient: True)
+        var_1,  # (shape: [1], dtype: paddle.int32, stop_gradient: True)
+        var_2,  # (shape: [1, 512, 97, 97], dtype: paddle.float32, stop_gradient: False)
+        var_3,  # (shape: [4], dtype: paddle.int32, stop_gradient: True)
+        var_4,  # (shape: [1], dtype: paddle.int32, stop_gradient: True)
+        var_5,  # (shape: [1], dtype: paddle.int32, stop_gradient: True)
     ):
         var_6 = var_0.__floordiv__(2)
         var_7 = var_0.__floordiv__(2)
@@ -36,21 +37,21 @@ def create_tensor_inputs():
         paddle.randint(low=0, high=10, shape=[1], dtype=paddle.int32),
         paddle.randint(low=0, high=10, shape=[1], dtype=paddle.int32),
         paddle.rand(shape=[1, 512, 97, 97], dtype=paddle.float32),
-        paddle.randint(low=0, high=10, shape=[4], dtype=paddle.int32),
-        paddle.randint(low=0, high=10, shape=[1], dtype=paddle.int32),
-        paddle.randint(low=0, high=10, shape=[1], dtype=paddle.int32),
+        paddle.to_tensor([1, 8], dtype=paddle.int32),
+        paddle.to_tensor(52, dtype=paddle.int32),
+        paddle.to_tensor([202], dtype=paddle.int32),
     )
     return inputs
 
 
 def create_numpy_inputs():
     inputs = (
-        np.random.randint(low=0, high=10, size=[1], dtype='int32'),
-        np.random.randint(low=0, high=10, size=[1], dtype='int32'),
-        np.random.random(size=[1, 512, 97, 97]).astype('float32'),
-        np.random.randint(low=0, high=10, size=[4], dtype='int32'),
-        np.random.randint(low=0, high=10, size=[1], dtype='int32'),
-        np.random.randint(low=0, high=10, size=[1], dtype='int32'),
+        np.random.randint(low=0, high=10, size=[1], dtype="int32"),
+        np.random.randint(low=0, high=10, size=[1], dtype="int32"),
+        np.random.random(size=[1, 512, 97, 97]).astype("float32"),
+        np.array([1, 8], dtype="int32"),
+        np.array(52, dtype="int32"),
+        np.array(202, dtype="int32"),
     )
     return inputs
 
@@ -59,9 +60,10 @@ class TestLayer(unittest.TestCase):
     def setUp(self):
         self.inputs = create_tensor_inputs()
         self.net = LayerCase()
+
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.set_flags({"FLAGS_prim_all": with_prim})
             if with_cinn:
                 build_strategy = paddle.static.BuildStrategy()
                 build_strategy.build_cinn_pass = True
@@ -71,6 +73,7 @@ class TestLayer(unittest.TestCase):
         paddle.seed(123)
         outs = net(*self.inputs)
         return outs
+
     def test_ast_prim_cinn(self):
         st_out = self.train(self.net, to_static=True)
         cinn_out = self.train(self.net, to_static=True, with_prim=True, with_cinn=True)
@@ -78,5 +81,5 @@ class TestLayer(unittest.TestCase):
             np.testing.assert_allclose(st.numpy(), cinn.numpy(), atol=1e-8)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/isanet_isanet_resnet50_os8_cityscapes_769x769_80k/SIR_33.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/isanet_isanet_resnet50_os8_cityscapes_769x769_80k/SIR_33.py
@@ -7,12 +7,13 @@ import numpy as np
 class LayerCase(paddle.nn.Layer):
     def __init__(self):
         super().__init__()
+
     def forward(
         self,
-        var_0,    # (shape: [64, 512, 13, 13], dtype: paddle.float32, stop_gradient: False)
-        var_1,    # (shape: [4], dtype: paddle.int32, stop_gradient: True)
-        var_2,    # (shape: [1], dtype: paddle.int32, stop_gradient: True)
-        var_3,    # (shape: [1], dtype: paddle.int32, stop_gradient: True)
+        var_0,  # (shape: [64, 512, 13, 13], dtype: paddle.float32, stop_gradient: False)
+        var_1,  # (shape: [4], dtype: paddle.int32, stop_gradient: True)
+        var_2,  # (shape: [1], dtype: paddle.int32, stop_gradient: True)
+        var_3,  # (shape: [1], dtype: paddle.int32, stop_gradient: True)
     ):
         var_4 = var_1.__getitem__(0)
         var_5 = var_1.__getitem__(1)
@@ -25,19 +26,19 @@ class LayerCase(paddle.nn.Layer):
 def create_tensor_inputs():
     inputs = (
         paddle.rand(shape=[64, 512, 13, 13], dtype=paddle.float32),
-        paddle.randint(low=0, high=10, shape=[4], dtype=paddle.int32),
-        paddle.randint(low=0, high=10, shape=[1], dtype=paddle.int32),
-        paddle.randint(low=0, high=10, shape=[1], dtype=paddle.int32),
+        paddle.to_tensor([4, 128], dtype=paddle.int32),
+        paddle.array(13, dtype=paddle.int32),
+        paddle.array(13, dtype=paddle.int32),
     )
     return inputs
 
 
 def create_numpy_inputs():
     inputs = (
-        np.random.random(size=[64, 512, 13, 13]).astype('float32'),
-        np.random.randint(low=0, high=10, size=[4], dtype='int32'),
-        np.random.randint(low=0, high=10, size=[1], dtype='int32'),
-        np.random.randint(low=0, high=10, size=[1], dtype='int32'),
+        np.random.random(size=[64, 512, 13, 13]).astype("float32"),
+        np.array([4, 128], dtype="int32"),
+        np.array(13, dtype="int32"),
+        np.array(13, dtype="int32"),
     )
     return inputs
 
@@ -46,9 +47,10 @@ class TestLayer(unittest.TestCase):
     def setUp(self):
         self.inputs = create_tensor_inputs()
         self.net = LayerCase()
+
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.set_flags({"FLAGS_prim_all": with_prim})
             if with_cinn:
                 build_strategy = paddle.static.BuildStrategy()
                 build_strategy.build_cinn_pass = True
@@ -58,6 +60,7 @@ class TestLayer(unittest.TestCase):
         paddle.seed(123)
         outs = net(*self.inputs)
         return outs
+
     def test_ast_prim_cinn(self):
         st_out = self.train(self.net, to_static=True)
         cinn_out = self.train(self.net, to_static=True, with_prim=True, with_cinn=True)
@@ -65,5 +68,5 @@ class TestLayer(unittest.TestCase):
             np.testing.assert_allclose(st.numpy(), cinn.numpy(), atol=1e-8)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/isanet_isanet_resnet50_os8_cityscapes_769x769_80k/SIR_34.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/isanet_isanet_resnet50_os8_cityscapes_769x769_80k/SIR_34.py
@@ -7,13 +7,14 @@ import numpy as np
 class LayerCase(paddle.nn.Layer):
     def __init__(self):
         super().__init__()
+
     def forward(
         self,
-        var_0,    # (shape: [169, 512, 8, 8], dtype: paddle.float32, stop_gradient: False)
-        var_1,    # (shape: [4], dtype: paddle.int32, stop_gradient: True)
-        var_2,    # (shape: [1], dtype: paddle.int32, stop_gradient: True)
-        var_3,    # (shape: [1], dtype: paddle.int32, stop_gradient: True)
-        var_4,    # (shape: [1], dtype: paddle.int32, stop_gradient: True)
+        var_0,  # (shape: [169, 512, 8, 8], dtype: paddle.float32, stop_gradient: False)
+        var_1,  # (shape: [4], dtype: paddle.int32, stop_gradient: True)
+        var_2,  # (shape: [1], dtype: paddle.int32, stop_gradient: True)
+        var_3,  # (shape: [1], dtype: paddle.int32, stop_gradient: True)
+        var_4,  # (shape: [1], dtype: paddle.int32, stop_gradient: True)
     ):
         var_5 = var_1.__getitem__(0)
         var_6 = var_1.__getitem__(1)
@@ -29,9 +30,9 @@ class LayerCase(paddle.nn.Layer):
 def create_tensor_inputs():
     inputs = (
         paddle.rand(shape=[169, 512, 8, 8], dtype=paddle.float32),
-        paddle.randint(low=0, high=10, shape=[4], dtype=paddle.int32),
-        paddle.randint(low=0, high=10, shape=[1], dtype=paddle.int32),
-        paddle.randint(low=0, high=10, shape=[1], dtype=paddle.int32),
+        paddle.to_tensor([1, 512], dtype=paddle.int32),
+        paddle.to_tensor(13, dtype=paddle.int32),
+        paddle.to_tensor(13, dtype=paddle.int32),
         paddle.randint(low=0, high=10, shape=[1], dtype=paddle.int32),
     )
     return inputs
@@ -39,11 +40,11 @@ def create_tensor_inputs():
 
 def create_numpy_inputs():
     inputs = (
-        np.random.random(size=[169, 512, 8, 8]).astype('float32'),
-        np.random.randint(low=0, high=10, size=[4], dtype='int32'),
-        np.random.randint(low=0, high=10, size=[1], dtype='int32'),
-        np.random.randint(low=0, high=10, size=[1], dtype='int32'),
-        np.random.randint(low=0, high=10, size=[1], dtype='int32'),
+        np.random.random(size=[169, 512, 8, 8]).astype("float32"),
+        np.array([1, 512], dtype="int32"),
+        np.array(13, dtype="int32"),
+        np.array(13, dtype="int32"),
+        np.random.randint(low=0, high=10, size=[1], dtype="int32"),
     )
     return inputs
 
@@ -52,9 +53,10 @@ class TestLayer(unittest.TestCase):
     def setUp(self):
         self.inputs = create_tensor_inputs()
         self.net = LayerCase()
+
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.set_flags({"FLAGS_prim_all": with_prim})
             if with_cinn:
                 build_strategy = paddle.static.BuildStrategy()
                 build_strategy.build_cinn_pass = True
@@ -64,6 +66,7 @@ class TestLayer(unittest.TestCase):
         paddle.seed(123)
         outs = net(*self.inputs)
         return outs
+
     def test_ast_prim_cinn(self):
         st_out = self.train(self.net, to_static=True)
         cinn_out = self.train(self.net, to_static=True, with_prim=True, with_cinn=True)
@@ -71,5 +74,5 @@ class TestLayer(unittest.TestCase):
             np.testing.assert_allclose(st.numpy(), cinn.numpy(), atol=1e-8)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/isanet_isanet_resnet50_os8_cityscapes_769x769_80k/SIR_35.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/isanet_isanet_resnet50_os8_cityscapes_769x769_80k/SIR_35.py
@@ -7,13 +7,14 @@ import numpy as np
 class LayerCase(paddle.nn.Layer):
     def __init__(self):
         super().__init__()
+
     def forward(
         self,
-        var_0,    # (shape: [1, 512, 104, 104], dtype: paddle.float32, stop_gradient: False)
-        var_1,    # (shape: [1], dtype: paddle.int32, stop_gradient: True)
-        var_2,    # (shape: [1], dtype: paddle.int32, stop_gradient: True)
-        var_3,    # (shape: [4], dtype: paddle.int32, stop_gradient: True)
-        var_4,    # (shape: [1, 512, 97, 97], dtype: paddle.float32, stop_gradient: False)
+        var_0,  # (shape: [1, 512, 104, 104], dtype: paddle.float32, stop_gradient: False)
+        var_1,  # (shape: [1], dtype: paddle.int32, stop_gradient: True)
+        var_2,  # (shape: [1], dtype: paddle.int32, stop_gradient: True)
+        var_3,  # (shape: [4], dtype: paddle.int32, stop_gradient: True)
+        var_4,  # (shape: [1, 512, 97, 97], dtype: paddle.float32, stop_gradient: False)
     ):
         var_5 = var_1.__floordiv__(2)
         var_6 = var_2.__floordiv__(2)
@@ -31,9 +32,9 @@ class LayerCase(paddle.nn.Layer):
 def create_tensor_inputs():
     inputs = (
         paddle.rand(shape=[1, 512, 104, 104], dtype=paddle.float32),
-        paddle.randint(low=0, high=10, shape=[1], dtype=paddle.int32),
-        paddle.randint(low=0, high=10, shape=[1], dtype=paddle.int32),
-        paddle.randint(low=0, high=10, shape=[4], dtype=paddle.int32),
+        paddle.to_tensor(2, dtype=paddle.int32),
+        paddle.to_tensor(4, dtype=paddle.int32),
+        paddle.array([1, 1, 97, 97], dtype=paddle.int32),
         paddle.rand(shape=[1, 512, 97, 97], dtype=paddle.float32),
     )
     return inputs
@@ -41,11 +42,11 @@ def create_tensor_inputs():
 
 def create_numpy_inputs():
     inputs = (
-        np.random.random(size=[1, 512, 104, 104]).astype('float32'),
-        np.random.randint(low=0, high=10, size=[1], dtype='int32'),
-        np.random.randint(low=0, high=10, size=[1], dtype='int32'),
-        np.random.randint(low=0, high=10, size=[4], dtype='int32'),
-        np.random.random(size=[1, 512, 97, 97]).astype('float32'),
+        np.random.random(size=[1, 512, 104, 104]).astype("float32"),
+        np.array(2, dtype="int32"),
+        np.array(4, dtype="int32"),
+        np.array([1, 1, 97, 97], dtype="int32"),
+        np.random.random(size=[1, 512, 97, 97]).astype("float32"),
     )
     return inputs
 
@@ -54,9 +55,10 @@ class TestLayer(unittest.TestCase):
     def setUp(self):
         self.inputs = create_tensor_inputs()
         self.net = LayerCase()
+
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.set_flags({"FLAGS_prim_all": with_prim})
             if with_cinn:
                 build_strategy = paddle.static.BuildStrategy()
                 build_strategy.build_cinn_pass = True
@@ -66,6 +68,7 @@ class TestLayer(unittest.TestCase):
         paddle.seed(123)
         outs = net(*self.inputs)
         return outs
+
     def test_ast_prim_cinn(self):
         st_out = self.train(self.net, to_static=True)
         cinn_out = self.train(self.net, to_static=True, with_prim=True, with_cinn=True)
@@ -73,5 +76,5 @@ class TestLayer(unittest.TestCase):
             np.testing.assert_allclose(st.numpy(), cinn.numpy(), atol=1e-8)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/segformer_segformer_b0_cityscapes_1024x1024_160k/SIR_12.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/segformer_segformer_b0_cityscapes_1024x1024_160k/SIR_12.py
@@ -8,65 +8,83 @@ class LayerCase(paddle.nn.Layer):
     def __init__(self):
         super().__init__()
         self.parameter_0 = self.create_parameter(
-           shape=[64],
-           dtype=paddle.float32,
+            shape=[64],
+            dtype=paddle.float32,
         )
         self.parameter_1 = self.create_parameter(
-           shape=[64],
-           dtype=paddle.float32,
+            shape=[64],
+            dtype=paddle.float32,
         )
         self.parameter_2 = self.create_parameter(
-           shape=[64],
-           dtype=paddle.float32,
+            shape=[64],
+            dtype=paddle.float32,
         )
         self.parameter_3 = self.create_parameter(
-           shape=[32],
-           dtype=paddle.float32,
+            shape=[32],
+            dtype=paddle.float32,
         )
         self.parameter_4 = self.create_parameter(
-           shape=[64, 32, 3, 3],
-           dtype=paddle.float32,
+            shape=[64, 32, 3, 3],
+            dtype=paddle.float32,
         )
         self.parameter_5 = self.create_parameter(
-           shape=[32],
-           dtype=paddle.float32,
+            shape=[32],
+            dtype=paddle.float32,
         )
+
     def forward(
         self,
-        var_0,    # (shape: [1, 65536, 32], dtype: paddle.float32, stop_gradient: False)
-        var_1,    # (shape: [], dtype: paddle.int32, stop_gradient: True)
-        var_2,    # (shape: [], dtype: paddle.int32, stop_gradient: True)
-        var_3,    # (shape: [], dtype: paddle.int32, stop_gradient: True)
+        var_0,  # (shape: [1, 65536, 32], dtype: paddle.float32, stop_gradient: False)
+        var_1,  # (shape: [], dtype: paddle.int32, stop_gradient: True)
+        var_2,  # (shape: [], dtype: paddle.int32, stop_gradient: True)
+        var_3,  # (shape: [], dtype: paddle.int32, stop_gradient: True)
     ):
-        var_4 = paddle.nn.functional.norm.layer_norm(var_0, normalized_shape=[32], weight=self.parameter_5, bias=self.parameter_3, epsilon=1e-06)
+        var_4 = paddle.nn.functional.norm.layer_norm(
+            var_0, normalized_shape=[32], weight=self.parameter_5, bias=self.parameter_3, epsilon=1e-06
+        )
         var_5 = var_4.reshape([var_1, var_2, var_3, 32])
         var_6 = var_5.transpose([0, 3, 1, 2])
-        var_7 = paddle.nn.functional.conv._conv_nd(var_6, self.parameter_4, bias=self.parameter_1, stride=[2, 2], padding=[1, 1], padding_algorithm='EXPLICIT', dilation=[1, 1], groups=1, data_format='NCHW', channel_dim=1, op_type='conv2d', use_cudnn=True)
+        var_7 = paddle.nn.functional.conv._conv_nd(
+            var_6,
+            self.parameter_4,
+            bias=self.parameter_1,
+            stride=[2, 2],
+            padding=[1, 1],
+            padding_algorithm="EXPLICIT",
+            dilation=[1, 1],
+            groups=1,
+            data_format="NCHW",
+            channel_dim=1,
+            op_type="conv2d",
+            use_cudnn=True,
+        )
         var_8 = var_7.shape
         var_9 = var_8.__getitem__(2)
         var_10 = var_8.__getitem__(3)
         var_11 = var_7.flatten(2)
         var_12 = var_11.transpose([0, 2, 1])
-        var_13 = paddle.nn.functional.norm.layer_norm(var_12, normalized_shape=[64], weight=self.parameter_2, bias=self.parameter_0, epsilon=1e-05)
+        var_13 = paddle.nn.functional.norm.layer_norm(
+            var_12, normalized_shape=[64], weight=self.parameter_2, bias=self.parameter_0, epsilon=1e-05
+        )
         return var_13, var_9, var_10, var_6
 
 
 def create_tensor_inputs():
     inputs = (
         paddle.rand(shape=[1, 65536, 32], dtype=paddle.float32),
-        paddle.randint(low=0, high=10, shape=[1], dtype=paddle.int32),
-        paddle.randint(low=0, high=10, shape=[1], dtype=paddle.int32),
-        paddle.randint(low=0, high=10, shape=[1], dtype=paddle.int32),
+        paddle.to_tensor(64, dtype=paddle.int32),
+        paddle.to_tensor(64, dtype=paddle.int32),
+        paddle.to_tensor(16, dtype=paddle.int32),
     )
     return inputs
 
 
 def create_numpy_inputs():
     inputs = (
-        np.random.random(size=[1, 65536, 32]).astype('float32'),
-        np.random.randint(low=0, high=10, size=[1], dtype='int32'),
-        np.random.randint(low=0, high=10, size=[1], dtype='int32'),
-        np.random.randint(low=0, high=10, size=[1], dtype='int32'),
+        np.random.random(size=[1, 65536, 32]).astype("float32"),
+        np.array(64, dtype="int32"),
+        np.array(64, dtype="int32"),
+        np.array(16, dtype="int32"),
     )
     return inputs
 
@@ -75,9 +93,10 @@ class TestLayer(unittest.TestCase):
     def setUp(self):
         self.inputs = create_tensor_inputs()
         self.net = LayerCase()
+
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.set_flags({"FLAGS_prim_all": with_prim})
             if with_cinn:
                 build_strategy = paddle.static.BuildStrategy()
                 build_strategy.build_cinn_pass = True
@@ -87,6 +106,7 @@ class TestLayer(unittest.TestCase):
         paddle.seed(123)
         outs = net(*self.inputs)
         return outs
+
     def test_ast_prim_cinn(self):
         st_out = self.train(self.net, to_static=True)
         cinn_out = self.train(self.net, to_static=True, with_prim=True, with_cinn=True)
@@ -94,5 +114,5 @@ class TestLayer(unittest.TestCase):
             np.testing.assert_allclose(st.numpy(), cinn.numpy(), atol=1e-8)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/segformer_segformer_b0_cityscapes_1024x1024_160k/SIR_14.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/segformer_segformer_b0_cityscapes_1024x1024_160k/SIR_14.py
@@ -8,60 +8,63 @@ class LayerCase(paddle.nn.Layer):
     def __init__(self):
         super().__init__()
         self.parameter_0 = self.create_parameter(
-           shape=[64],
-           dtype=paddle.float32,
+            shape=[64],
+            dtype=paddle.float32,
         )
         self.parameter_1 = self.create_parameter(
-           shape=[64, 64, 4, 4],
-           dtype=paddle.float32,
+            shape=[64, 64, 4, 4],
+            dtype=paddle.float32,
         )
         self.parameter_2 = self.create_parameter(
-           shape=[64, 128],
-           dtype=paddle.float32,
+            shape=[64, 128],
+            dtype=paddle.float32,
         )
         self.parameter_3 = self.create_parameter(
-           shape=[64],
-           dtype=paddle.float32,
+            shape=[64],
+            dtype=paddle.float32,
         )
         self.parameter_4 = self.create_parameter(
-           shape=[64],
-           dtype=paddle.float32,
+            shape=[64],
+            dtype=paddle.float32,
         )
         self.parameter_5 = self.create_parameter(
-           shape=[64],
-           dtype=paddle.float32,
+            shape=[64],
+            dtype=paddle.float32,
         )
         self.parameter_6 = self.create_parameter(
-           shape=[128],
-           dtype=paddle.float32,
+            shape=[128],
+            dtype=paddle.float32,
         )
         self.parameter_7 = self.create_parameter(
-           shape=[64],
-           dtype=paddle.float32,
+            shape=[64],
+            dtype=paddle.float32,
         )
         self.parameter_8 = self.create_parameter(
-           shape=[64, 64],
-           dtype=paddle.float32,
+            shape=[64, 64],
+            dtype=paddle.float32,
         )
         self.parameter_9 = self.create_parameter(
-           shape=[64, 64],
-           dtype=paddle.float32,
+            shape=[64, 64],
+            dtype=paddle.float32,
         )
         self.parameter_10 = self.create_parameter(
-           shape=[64],
-           dtype=paddle.float32,
+            shape=[64],
+            dtype=paddle.float32,
         )
         self.parameter_11 = self.create_parameter(
-           shape=[64],
-           dtype=paddle.float32,
+            shape=[64],
+            dtype=paddle.float32,
         )
+
     def forward(
         self,
-        var_0,    # (shape: [1, 16384, 64], dtype: paddle.float32, stop_gradient: False)
-        var_1,    # (shape: [], dtype: paddle.int32, stop_gradient: True)
-        var_2,    # (shape: [], dtype: paddle.int32, stop_gradient: True)
+        var_0,  # (shape: [1, 16384, 64], dtype: paddle.float32, stop_gradient: False)
+        var_1,  # (shape: [], dtype: paddle.int32, stop_gradient: True)
+        var_2,  # (shape: [], dtype: paddle.int32, stop_gradient: True)
     ):
-        var_3 = paddle.nn.functional.norm.layer_norm(var_0, normalized_shape=[64], weight=self.parameter_7, bias=self.parameter_10, epsilon=1e-06)
+        var_3 = paddle.nn.functional.norm.layer_norm(
+            var_0, normalized_shape=[64], weight=self.parameter_7, bias=self.parameter_10, epsilon=1e-06
+        )
         var_4 = var_3.shape
         var_5 = var_4.__getitem__(0)
         var_6 = var_4.__getitem__(1)
@@ -70,10 +73,25 @@ class LayerCase(paddle.nn.Layer):
         var_9 = var_8.transpose([0, 2, 1, 3])
         var_10 = var_3.transpose([0, 2, 1])
         var_11 = var_10.reshape([var_5, 64, var_1, var_2])
-        var_12 = paddle.nn.functional.conv._conv_nd(var_11, self.parameter_1, bias=self.parameter_11, stride=[4, 4], padding=[0, 0], padding_algorithm='EXPLICIT', dilation=[1, 1], groups=1, data_format='NCHW', channel_dim=1, op_type='conv2d', use_cudnn=True)
+        var_12 = paddle.nn.functional.conv._conv_nd(
+            var_11,
+            self.parameter_1,
+            bias=self.parameter_11,
+            stride=[4, 4],
+            padding=[0, 0],
+            padding_algorithm="EXPLICIT",
+            dilation=[1, 1],
+            groups=1,
+            data_format="NCHW",
+            channel_dim=1,
+            op_type="conv2d",
+            use_cudnn=True,
+        )
         var_13 = var_12.reshape([var_5, 64, -1])
         var_14 = var_13.transpose([0, 2, 1])
-        var_15 = paddle.nn.functional.norm.layer_norm(var_14, normalized_shape=[64], weight=self.parameter_5, bias=self.parameter_3, epsilon=1e-05)
+        var_15 = paddle.nn.functional.norm.layer_norm(
+            var_14, normalized_shape=[64], weight=self.parameter_5, bias=self.parameter_3, epsilon=1e-05
+        )
         var_16 = paddle.nn.functional.common.linear(x=var_15, weight=self.parameter_2, bias=self.parameter_6, name=None)
         var_17 = var_16.reshape([var_5, -1, 2, 2, 32])
         var_18 = var_17.transpose([2, 0, 3, 1, 4])
@@ -83,29 +101,33 @@ class LayerCase(paddle.nn.Layer):
         var_22 = var_9.__matmul__(var_21)
         var_23 = var_22.__mul__(0.1767766952966369)
         var_24 = paddle.nn.functional.activation.softmax(var_23, axis=-1)
-        var_25 = paddle.nn.functional.common.dropout(var_24, p=0.0, axis=None, training=True, mode='upscale_in_train', name=None)
+        var_25 = paddle.nn.functional.common.dropout(
+            var_24, p=0.0, axis=None, training=True, mode="upscale_in_train", name=None
+        )
         var_26 = var_25.__matmul__(var_20)
         var_27 = var_26.transpose([0, 2, 1, 3])
         var_28 = var_27.reshape([var_5, var_6, 64])
         var_29 = paddle.nn.functional.common.linear(x=var_28, weight=self.parameter_8, bias=self.parameter_0, name=None)
-        var_30 = paddle.nn.functional.common.dropout(var_29, p=0.0, axis=None, training=True, mode='upscale_in_train', name=None)
+        var_30 = paddle.nn.functional.common.dropout(
+            var_29, p=0.0, axis=None, training=True, mode="upscale_in_train", name=None
+        )
         return var_30
 
 
 def create_tensor_inputs():
     inputs = (
         paddle.rand(shape=[1, 16384, 64], dtype=paddle.float32),
-        paddle.randint(low=0, high=10, shape=[1], dtype=paddle.int32),
-        paddle.randint(low=0, high=10, shape=[1], dtype=paddle.int32),
+        paddle.to_tensor(64, dtype=paddle.int32),
+        paddle.to_tensor(256, dtype=paddle.int32),
     )
     return inputs
 
 
 def create_numpy_inputs():
     inputs = (
-        np.random.random(size=[1, 16384, 64]).astype('float32'),
-        np.random.randint(low=0, high=10, size=[1], dtype='int32'),
-        np.random.randint(low=0, high=10, size=[1], dtype='int32'),
+        np.random.random(size=[1, 16384, 64]).astype("float32"),
+        np.array(64, dtype="int32"),
+        np.array(256, dtype="int32"),
     )
     return inputs
 
@@ -114,9 +136,10 @@ class TestLayer(unittest.TestCase):
     def setUp(self):
         self.inputs = create_tensor_inputs()
         self.net = LayerCase()
+
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.set_flags({"FLAGS_prim_all": with_prim})
             if with_cinn:
                 build_strategy = paddle.static.BuildStrategy()
                 build_strategy.build_cinn_pass = True
@@ -126,6 +149,7 @@ class TestLayer(unittest.TestCase):
         paddle.seed(123)
         outs = net(*self.inputs)
         return outs
+
     def test_ast_prim_cinn(self):
         st_out = self.train(self.net, to_static=True)
         cinn_out = self.train(self.net, to_static=True, with_prim=True, with_cinn=True)
@@ -133,5 +157,5 @@ class TestLayer(unittest.TestCase):
             np.testing.assert_allclose(st.numpy(), cinn.numpy(), atol=1e-8)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/segformer_segformer_b0_cityscapes_1024x1024_160k/SIR_24.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/segformer_segformer_b0_cityscapes_1024x1024_160k/SIR_24.py
@@ -8,65 +8,83 @@ class LayerCase(paddle.nn.Layer):
     def __init__(self):
         super().__init__()
         self.parameter_0 = self.create_parameter(
-           shape=[160],
-           dtype=paddle.float32,
+            shape=[160],
+            dtype=paddle.float32,
         )
         self.parameter_1 = self.create_parameter(
-           shape=[160],
-           dtype=paddle.float32,
+            shape=[160],
+            dtype=paddle.float32,
         )
         self.parameter_2 = self.create_parameter(
-           shape=[64],
-           dtype=paddle.float32,
+            shape=[64],
+            dtype=paddle.float32,
         )
         self.parameter_3 = self.create_parameter(
-           shape=[64],
-           dtype=paddle.float32,
+            shape=[64],
+            dtype=paddle.float32,
         )
         self.parameter_4 = self.create_parameter(
-           shape=[160],
-           dtype=paddle.float32,
+            shape=[160],
+            dtype=paddle.float32,
         )
         self.parameter_5 = self.create_parameter(
-           shape=[160, 64, 3, 3],
-           dtype=paddle.float32,
+            shape=[160, 64, 3, 3],
+            dtype=paddle.float32,
         )
+
     def forward(
         self,
-        var_0,    # (shape: [1, 16384, 64], dtype: paddle.float32, stop_gradient: False)
-        var_1,    # (shape: [], dtype: paddle.int32, stop_gradient: True)
-        var_2,    # (shape: [], dtype: paddle.int32, stop_gradient: True)
-        var_3,    # (shape: [], dtype: paddle.int32, stop_gradient: True)
+        var_0,  # (shape: [1, 16384, 64], dtype: paddle.float32, stop_gradient: False)
+        var_1,  # (shape: [], dtype: paddle.int32, stop_gradient: True)
+        var_2,  # (shape: [], dtype: paddle.int32, stop_gradient: True)
+        var_3,  # (shape: [], dtype: paddle.int32, stop_gradient: True)
     ):
-        var_4 = paddle.nn.functional.norm.layer_norm(var_0, normalized_shape=[64], weight=self.parameter_3, bias=self.parameter_2, epsilon=1e-06)
+        var_4 = paddle.nn.functional.norm.layer_norm(
+            var_0, normalized_shape=[64], weight=self.parameter_3, bias=self.parameter_2, epsilon=1e-06
+        )
         var_5 = var_4.reshape([var_1, var_2, var_3, 64])
         var_6 = var_5.transpose([0, 3, 1, 2])
-        var_7 = paddle.nn.functional.conv._conv_nd(var_6, self.parameter_5, bias=self.parameter_4, stride=[2, 2], padding=[1, 1], padding_algorithm='EXPLICIT', dilation=[1, 1], groups=1, data_format='NCHW', channel_dim=1, op_type='conv2d', use_cudnn=True)
+        var_7 = paddle.nn.functional.conv._conv_nd(
+            var_6,
+            self.parameter_5,
+            bias=self.parameter_4,
+            stride=[2, 2],
+            padding=[1, 1],
+            padding_algorithm="EXPLICIT",
+            dilation=[1, 1],
+            groups=1,
+            data_format="NCHW",
+            channel_dim=1,
+            op_type="conv2d",
+            use_cudnn=True,
+        )
         var_8 = var_7.shape
         var_9 = var_8.__getitem__(2)
         var_10 = var_8.__getitem__(3)
         var_11 = var_7.flatten(2)
         var_12 = var_11.transpose([0, 2, 1])
-        var_13 = paddle.nn.functional.norm.layer_norm(var_12, normalized_shape=[160], weight=self.parameter_0, bias=self.parameter_1, epsilon=1e-05)
+        var_13 = paddle.nn.functional.norm.layer_norm(
+            var_12, normalized_shape=[160], weight=self.parameter_0, bias=self.parameter_1, epsilon=1e-05
+        )
         return var_13, var_9, var_10, var_6
 
 
 def create_tensor_inputs():
     inputs = (
         paddle.rand(shape=[1, 16384, 64], dtype=paddle.float32),
-        paddle.randint(low=0, high=10, shape=[1], dtype=paddle.int32),
-        paddle.randint(low=0, high=10, shape=[1], dtype=paddle.int32),
-        paddle.randint(low=0, high=10, shape=[1], dtype=paddle.int32),
+        paddle.to_tensor(8, dtype=paddle.int32),
+        paddle.to_tensor(32, dtype=paddle.int32),
+        paddle.to_tensor(64, dtype=paddle.int32),
     )
     return inputs
 
 
 def create_numpy_inputs():
     inputs = (
-        np.random.random(size=[1, 16384, 64]).astype('float32'),
-        np.random.randint(low=0, high=10, size=[1], dtype='int32'),
-        np.random.randint(low=0, high=10, size=[1], dtype='int32'),
-        np.random.randint(low=0, high=10, size=[1], dtype='int32'),
+        np.random.random(size=[1, 16384, 64]).astype("float32"),
+        np.array(8, dtype="int32"),
+        np.array(32, dtype="int32"),
+        np.array(64, dtype="int32"),
     )
     return inputs
 
@@ -75,9 +93,10 @@ class TestLayer(unittest.TestCase):
     def setUp(self):
         self.inputs = create_tensor_inputs()
         self.net = LayerCase()
+
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.set_flags({"FLAGS_prim_all": with_prim})
             if with_cinn:
                 build_strategy = paddle.static.BuildStrategy()
                 build_strategy.build_cinn_pass = True
@@ -87,6 +106,7 @@ class TestLayer(unittest.TestCase):
         paddle.seed(123)
         outs = net(*self.inputs)
         return outs
+
     def test_ast_prim_cinn(self):
         st_out = self.train(self.net, to_static=True)
         cinn_out = self.train(self.net, to_static=True, with_prim=True, with_cinn=True)
@@ -94,5 +114,5 @@ class TestLayer(unittest.TestCase):
             np.testing.assert_allclose(st.numpy(), cinn.numpy(), atol=1e-8)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/segformer_segformer_b0_cityscapes_1024x1024_160k/SIR_26.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/segformer_segformer_b0_cityscapes_1024x1024_160k/SIR_26.py
@@ -8,60 +8,63 @@ class LayerCase(paddle.nn.Layer):
     def __init__(self):
         super().__init__()
         self.parameter_0 = self.create_parameter(
-           shape=[160],
-           dtype=paddle.float32,
+            shape=[160],
+            dtype=paddle.float32,
         )
         self.parameter_1 = self.create_parameter(
-           shape=[160, 160],
-           dtype=paddle.float32,
+            shape=[160, 160],
+            dtype=paddle.float32,
         )
         self.parameter_2 = self.create_parameter(
-           shape=[160, 160],
-           dtype=paddle.float32,
+            shape=[160, 160],
+            dtype=paddle.float32,
         )
         self.parameter_3 = self.create_parameter(
-           shape=[160],
-           dtype=paddle.float32,
+            shape=[160],
+            dtype=paddle.float32,
         )
         self.parameter_4 = self.create_parameter(
-           shape=[160, 320],
-           dtype=paddle.float32,
+            shape=[160, 320],
+            dtype=paddle.float32,
         )
         self.parameter_5 = self.create_parameter(
-           shape=[320],
-           dtype=paddle.float32,
+            shape=[320],
+            dtype=paddle.float32,
         )
         self.parameter_6 = self.create_parameter(
-           shape=[160],
-           dtype=paddle.float32,
+            shape=[160],
+            dtype=paddle.float32,
         )
         self.parameter_7 = self.create_parameter(
-           shape=[160],
-           dtype=paddle.float32,
+            shape=[160],
+            dtype=paddle.float32,
         )
         self.parameter_8 = self.create_parameter(
-           shape=[160, 160, 2, 2],
-           dtype=paddle.float32,
+            shape=[160, 160, 2, 2],
+            dtype=paddle.float32,
         )
         self.parameter_9 = self.create_parameter(
-           shape=[160],
-           dtype=paddle.float32,
+            shape=[160],
+            dtype=paddle.float32,
         )
         self.parameter_10 = self.create_parameter(
-           shape=[160],
-           dtype=paddle.float32,
+            shape=[160],
+            dtype=paddle.float32,
         )
         self.parameter_11 = self.create_parameter(
-           shape=[160],
-           dtype=paddle.float32,
+            shape=[160],
+            dtype=paddle.float32,
         )
+
     def forward(
         self,
-        var_0,    # (shape: [1, 4096, 160], dtype: paddle.float32, stop_gradient: False)
-        var_1,    # (shape: [], dtype: paddle.int32, stop_gradient: True)
-        var_2,    # (shape: [], dtype: paddle.int32, stop_gradient: True)
+        var_0,  # (shape: [1, 4096, 160], dtype: paddle.float32, stop_gradient: False)
+        var_1,  # (shape: [], dtype: paddle.int32, stop_gradient: True)
+        var_2,  # (shape: [], dtype: paddle.int32, stop_gradient: True)
     ):
-        var_3 = paddle.nn.functional.norm.layer_norm(var_0, normalized_shape=[160], weight=self.parameter_6, bias=self.parameter_11, epsilon=1e-06)
+        var_3 = paddle.nn.functional.norm.layer_norm(
+            var_0, normalized_shape=[160], weight=self.parameter_6, bias=self.parameter_11, epsilon=1e-06
+        )
         var_4 = var_3.shape
         var_5 = var_4.__getitem__(0)
         var_6 = var_4.__getitem__(1)
@@ -70,10 +73,25 @@ class LayerCase(paddle.nn.Layer):
         var_9 = var_8.transpose([0, 2, 1, 3])
         var_10 = var_3.transpose([0, 2, 1])
         var_11 = var_10.reshape([var_5, 160, var_1, var_2])
-        var_12 = paddle.nn.functional.conv._conv_nd(var_11, self.parameter_8, bias=self.parameter_9, stride=[2, 2], padding=[0, 0], padding_algorithm='EXPLICIT', dilation=[1, 1], groups=1, data_format='NCHW', channel_dim=1, op_type='conv2d', use_cudnn=True)
+        var_12 = paddle.nn.functional.conv._conv_nd(
+            var_11,
+            self.parameter_8,
+            bias=self.parameter_9,
+            stride=[2, 2],
+            padding=[0, 0],
+            padding_algorithm="EXPLICIT",
+            dilation=[1, 1],
+            groups=1,
+            data_format="NCHW",
+            channel_dim=1,
+            op_type="conv2d",
+            use_cudnn=True,
+        )
         var_13 = var_12.reshape([var_5, 160, -1])
         var_14 = var_13.transpose([0, 2, 1])
-        var_15 = paddle.nn.functional.norm.layer_norm(var_14, normalized_shape=[160], weight=self.parameter_0, bias=self.parameter_3, epsilon=1e-05)
+        var_15 = paddle.nn.functional.norm.layer_norm(
+            var_14, normalized_shape=[160], weight=self.parameter_0, bias=self.parameter_3, epsilon=1e-05
+        )
         var_16 = paddle.nn.functional.common.linear(x=var_15, weight=self.parameter_4, bias=self.parameter_5, name=None)
         var_17 = var_16.reshape([var_5, -1, 2, 5, 32])
         var_18 = var_17.transpose([2, 0, 3, 1, 4])
@@ -83,29 +101,33 @@ class LayerCase(paddle.nn.Layer):
         var_22 = var_9.__matmul__(var_21)
         var_23 = var_22.__mul__(0.1767766952966369)
         var_24 = paddle.nn.functional.activation.softmax(var_23, axis=-1)
-        var_25 = paddle.nn.functional.common.dropout(var_24, p=0.0, axis=None, training=True, mode='upscale_in_train', name=None)
+        var_25 = paddle.nn.functional.common.dropout(
+            var_24, p=0.0, axis=None, training=True, mode="upscale_in_train", name=None
+        )
         var_26 = var_25.__matmul__(var_20)
         var_27 = var_26.transpose([0, 2, 1, 3])
         var_28 = var_27.reshape([var_5, var_6, 160])
         var_29 = paddle.nn.functional.common.linear(x=var_28, weight=self.parameter_1, bias=self.parameter_7, name=None)
-        var_30 = paddle.nn.functional.common.dropout(var_29, p=0.0, axis=None, training=True, mode='upscale_in_train', name=None)
+        var_30 = paddle.nn.functional.common.dropout(
+            var_29, p=0.0, axis=None, training=True, mode="upscale_in_train", name=None
+        )
         return var_30
 
 
 def create_tensor_inputs():
     inputs = (
         paddle.rand(shape=[1, 4096, 160], dtype=paddle.float32),
-        paddle.randint(low=0, high=10, shape=[1], dtype=paddle.int32),
-        paddle.randint(low=0, high=10, shape=[1], dtype=paddle.int32),
+        paddle.to_tensor(32, dtype=paddle.int32),
+        paddle.to_tensor(128, dtype=paddle.int32),
     )
     return inputs
 
 
 def create_numpy_inputs():
     inputs = (
-        np.random.random(size=[1, 4096, 160]).astype('float32'),
-        np.random.randint(low=0, high=10, size=[1], dtype='int32'),
-        np.random.randint(low=0, high=10, size=[1], dtype='int32'),
+        np.random.random(size=[1, 4096, 160]).astype("float32"),
+        np.array(32, dtype="int32"),
+        np.array(128, dtype="int32"),
     )
     return inputs
 
@@ -114,9 +136,10 @@ class TestLayer(unittest.TestCase):
     def setUp(self):
         self.inputs = create_tensor_inputs()
         self.net = LayerCase()
+
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.set_flags({"FLAGS_prim_all": with_prim})
             if with_cinn:
                 build_strategy = paddle.static.BuildStrategy()
                 build_strategy.build_cinn_pass = True
@@ -126,6 +149,7 @@ class TestLayer(unittest.TestCase):
         paddle.seed(123)
         outs = net(*self.inputs)
         return outs
+
     def test_ast_prim_cinn(self):
         st_out = self.train(self.net, to_static=True)
         cinn_out = self.train(self.net, to_static=True, with_prim=True, with_cinn=True)
@@ -133,5 +157,5 @@ class TestLayer(unittest.TestCase):
             np.testing.assert_allclose(st.numpy(), cinn.numpy(), atol=1e-8)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/segformer_segformer_b0_cityscapes_1024x1024_160k/SIR_36.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/segformer_segformer_b0_cityscapes_1024x1024_160k/SIR_36.py
@@ -8,46 +8,64 @@ class LayerCase(paddle.nn.Layer):
     def __init__(self):
         super().__init__()
         self.parameter_0 = self.create_parameter(
-           shape=[256, 160, 3, 3],
-           dtype=paddle.float32,
+            shape=[256, 160, 3, 3],
+            dtype=paddle.float32,
         )
         self.parameter_1 = self.create_parameter(
-           shape=[256],
-           dtype=paddle.float32,
+            shape=[256],
+            dtype=paddle.float32,
         )
         self.parameter_2 = self.create_parameter(
-           shape=[256],
-           dtype=paddle.float32,
+            shape=[256],
+            dtype=paddle.float32,
         )
         self.parameter_3 = self.create_parameter(
-           shape=[160],
-           dtype=paddle.float32,
+            shape=[160],
+            dtype=paddle.float32,
         )
         self.parameter_4 = self.create_parameter(
-           shape=[256],
-           dtype=paddle.float32,
+            shape=[256],
+            dtype=paddle.float32,
         )
         self.parameter_5 = self.create_parameter(
-           shape=[160],
-           dtype=paddle.float32,
+            shape=[160],
+            dtype=paddle.float32,
         )
+
     def forward(
         self,
-        var_0,    # (shape: [1, 4096, 160], dtype: paddle.float32, stop_gradient: False)
-        var_1,    # (shape: [], dtype: paddle.int32, stop_gradient: True)
-        var_2,    # (shape: [], dtype: paddle.int32, stop_gradient: True)
-        var_3,    # (shape: [], dtype: paddle.int32, stop_gradient: True)
+        var_0,  # (shape: [1, 4096, 160], dtype: paddle.float32, stop_gradient: False)
+        var_1,  # (shape: [], dtype: paddle.int32, stop_gradient: True)
+        var_2,  # (shape: [], dtype: paddle.int32, stop_gradient: True)
+        var_3,  # (shape: [], dtype: paddle.int32, stop_gradient: True)
     ):
-        var_4 = paddle.nn.functional.norm.layer_norm(var_0, normalized_shape=[160], weight=self.parameter_3, bias=self.parameter_5, epsilon=1e-06)
+        var_4 = paddle.nn.functional.norm.layer_norm(
+            var_0, normalized_shape=[160], weight=self.parameter_3, bias=self.parameter_5, epsilon=1e-06
+        )
         var_5 = var_4.reshape([var_1, var_2, var_3, 160])
         var_6 = var_5.transpose([0, 3, 1, 2])
-        var_7 = paddle.nn.functional.conv._conv_nd(var_6, self.parameter_0, bias=self.parameter_1, stride=[2, 2], padding=[1, 1], padding_algorithm='EXPLICIT', dilation=[1, 1], groups=1, data_format='NCHW', channel_dim=1, op_type='conv2d', use_cudnn=True)
+        var_7 = paddle.nn.functional.conv._conv_nd(
+            var_6,
+            self.parameter_0,
+            bias=self.parameter_1,
+            stride=[2, 2],
+            padding=[1, 1],
+            padding_algorithm="EXPLICIT",
+            dilation=[1, 1],
+            groups=1,
+            data_format="NCHW",
+            channel_dim=1,
+            op_type="conv2d",
+            use_cudnn=True,
+        )
         var_8 = var_7.shape
         var_9 = var_8.__getitem__(2)
         var_10 = var_8.__getitem__(3)
         var_11 = var_7.flatten(2)
         var_12 = var_11.transpose([0, 2, 1])
-        var_13 = paddle.nn.functional.norm.layer_norm(var_12, normalized_shape=[256], weight=self.parameter_4, bias=self.parameter_2, epsilon=1e-05)
+        var_13 = paddle.nn.functional.norm.layer_norm(
+            var_12, normalized_shape=[256], weight=self.parameter_4, bias=self.parameter_2, epsilon=1e-05
+        )
         return var_13, var_9, var_10, var_6
 
 
@@ -63,10 +81,10 @@ def create_tensor_inputs():
 
 def create_numpy_inputs():
     inputs = (
-        np.random.random(size=[1, 4096, 160]).astype('float32'),
-        np.random.randint(low=0, high=10, size=[1], dtype='int32'),
-        np.random.randint(low=0, high=10, size=[1], dtype='int32'),
-        np.random.randint(low=0, high=10, size=[1], dtype='int32'),
+        np.random.random(size=[1, 4096, 160]).astype("float32"),
+        np.array(8, dtype="int32"),
+        np.array(16, dtype="int32"),
+        np.array(32, dtype="int32"),
     )
     return inputs
 
@@ -75,9 +93,10 @@ class TestLayer(unittest.TestCase):
     def setUp(self):
         self.inputs = create_tensor_inputs()
         self.net = LayerCase()
+
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.set_flags({"FLAGS_prim_all": with_prim})
             if with_cinn:
                 build_strategy = paddle.static.BuildStrategy()
                 build_strategy.build_cinn_pass = True
@@ -87,6 +106,7 @@ class TestLayer(unittest.TestCase):
         paddle.seed(123)
         outs = net(*self.inputs)
         return outs
+
     def test_ast_prim_cinn(self):
         st_out = self.train(self.net, to_static=True)
         cinn_out = self.train(self.net, to_static=True, with_prim=True, with_cinn=True)
@@ -94,5 +114,5 @@ class TestLayer(unittest.TestCase):
             np.testing.assert_allclose(st.numpy(), cinn.numpy(), atol=1e-8)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/segformer_segformer_b0_cityscapes_1024x1024_160k/SIR_5.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/segformer_segformer_b0_cityscapes_1024x1024_160k/SIR_5.py
@@ -8,60 +8,63 @@ class LayerCase(paddle.nn.Layer):
     def __init__(self):
         super().__init__()
         self.parameter_0 = self.create_parameter(
-           shape=[32],
-           dtype=paddle.float32,
+            shape=[32],
+            dtype=paddle.float32,
         )
         self.parameter_1 = self.create_parameter(
-           shape=[32],
-           dtype=paddle.float32,
+            shape=[32],
+            dtype=paddle.float32,
         )
         self.parameter_2 = self.create_parameter(
-           shape=[32, 32],
-           dtype=paddle.float32,
+            shape=[32, 32],
+            dtype=paddle.float32,
         )
         self.parameter_3 = self.create_parameter(
-           shape=[32, 32, 8, 8],
-           dtype=paddle.float32,
+            shape=[32, 32, 8, 8],
+            dtype=paddle.float32,
         )
         self.parameter_4 = self.create_parameter(
-           shape=[32, 64],
-           dtype=paddle.float32,
+            shape=[32, 64],
+            dtype=paddle.float32,
         )
         self.parameter_5 = self.create_parameter(
-           shape=[32],
-           dtype=paddle.float32,
+            shape=[32],
+            dtype=paddle.float32,
         )
         self.parameter_6 = self.create_parameter(
-           shape=[32, 32],
-           dtype=paddle.float32,
+            shape=[32, 32],
+            dtype=paddle.float32,
         )
         self.parameter_7 = self.create_parameter(
-           shape=[32],
-           dtype=paddle.float32,
+            shape=[32],
+            dtype=paddle.float32,
         )
         self.parameter_8 = self.create_parameter(
-           shape=[32],
-           dtype=paddle.float32,
+            shape=[32],
+            dtype=paddle.float32,
         )
         self.parameter_9 = self.create_parameter(
-           shape=[64],
-           dtype=paddle.float32,
+            shape=[64],
+            dtype=paddle.float32,
         )
         self.parameter_10 = self.create_parameter(
-           shape=[32],
-           dtype=paddle.float32,
+            shape=[32],
+            dtype=paddle.float32,
         )
         self.parameter_11 = self.create_parameter(
-           shape=[32],
-           dtype=paddle.float32,
+            shape=[32],
+            dtype=paddle.float32,
         )
+
     def forward(
         self,
-        var_0,    # (shape: [1, 65536, 32], dtype: paddle.float32, stop_gradient: False)
-        var_1,    # (shape: [], dtype: paddle.int32, stop_gradient: True)
-        var_2,    # (shape: [], dtype: paddle.int32, stop_gradient: True)
+        var_0,  # (shape: [1, 65536, 32], dtype: paddle.float32, stop_gradient: False)
+        var_1,  # (shape: [], dtype: paddle.int32, stop_gradient: True)
+        var_2,  # (shape: [], dtype: paddle.int32, stop_gradient: True)
     ):
-        var_3 = paddle.nn.functional.norm.layer_norm(var_0, normalized_shape=[32], weight=self.parameter_0, bias=self.parameter_8, epsilon=1e-06)
+        var_3 = paddle.nn.functional.norm.layer_norm(
+            var_0, normalized_shape=[32], weight=self.parameter_0, bias=self.parameter_8, epsilon=1e-06
+        )
         var_4 = var_3.shape
         var_5 = var_4.__getitem__(0)
         var_6 = var_4.__getitem__(1)
@@ -70,10 +73,25 @@ class LayerCase(paddle.nn.Layer):
         var_9 = var_8.transpose([0, 2, 1, 3])
         var_10 = var_3.transpose([0, 2, 1])
         var_11 = var_10.reshape([var_5, 32, var_1, var_2])
-        var_12 = paddle.nn.functional.conv._conv_nd(var_11, self.parameter_3, bias=self.parameter_1, stride=[8, 8], padding=[0, 0], padding_algorithm='EXPLICIT', dilation=[1, 1], groups=1, data_format='NCHW', channel_dim=1, op_type='conv2d', use_cudnn=True)
+        var_12 = paddle.nn.functional.conv._conv_nd(
+            var_11,
+            self.parameter_3,
+            bias=self.parameter_1,
+            stride=[8, 8],
+            padding=[0, 0],
+            padding_algorithm="EXPLICIT",
+            dilation=[1, 1],
+            groups=1,
+            data_format="NCHW",
+            channel_dim=1,
+            op_type="conv2d",
+            use_cudnn=True,
+        )
         var_13 = var_12.reshape([var_5, 32, -1])
         var_14 = var_13.transpose([0, 2, 1])
-        var_15 = paddle.nn.functional.norm.layer_norm(var_14, normalized_shape=[32], weight=self.parameter_11, bias=self.parameter_10, epsilon=1e-05)
+        var_15 = paddle.nn.functional.norm.layer_norm(
+            var_14, normalized_shape=[32], weight=self.parameter_11, bias=self.parameter_10, epsilon=1e-05
+        )
         var_16 = paddle.nn.functional.common.linear(x=var_15, weight=self.parameter_4, bias=self.parameter_9, name=None)
         var_17 = var_16.reshape([var_5, -1, 2, 1, 32])
         var_18 = var_17.transpose([2, 0, 3, 1, 4])
@@ -83,29 +101,33 @@ class LayerCase(paddle.nn.Layer):
         var_22 = var_9.__matmul__(var_21)
         var_23 = var_22.__mul__(0.1767766952966369)
         var_24 = paddle.nn.functional.activation.softmax(var_23, axis=-1)
-        var_25 = paddle.nn.functional.common.dropout(var_24, p=0.0, axis=None, training=True, mode='upscale_in_train', name=None)
+        var_25 = paddle.nn.functional.common.dropout(
+            var_24, p=0.0, axis=None, training=True, mode="upscale_in_train", name=None
+        )
         var_26 = var_25.__matmul__(var_20)
         var_27 = var_26.transpose([0, 2, 1, 3])
         var_28 = var_27.reshape([var_5, var_6, 32])
         var_29 = paddle.nn.functional.common.linear(x=var_28, weight=self.parameter_2, bias=self.parameter_5, name=None)
-        var_30 = paddle.nn.functional.common.dropout(var_29, p=0.0, axis=None, training=True, mode='upscale_in_train', name=None)
+        var_30 = paddle.nn.functional.common.dropout(
+            var_29, p=0.0, axis=None, training=True, mode="upscale_in_train", name=None
+        )
         return var_30
 
 
 def create_tensor_inputs():
     inputs = (
         paddle.rand(shape=[1, 65536, 32], dtype=paddle.float32),
-        paddle.randint(low=0, high=10, shape=[1], dtype=paddle.int32),
-        paddle.randint(low=0, high=10, shape=[1], dtype=paddle.int32),
+        paddle.to_tensor(128, dtype=paddle.int32),
+        paddle.to_tensor(512, dtype=paddle.int32),
     )
     return inputs
 
 
 def create_numpy_inputs():
     inputs = (
-        np.random.random(size=[1, 65536, 32]).astype('float32'),
-        np.random.randint(low=0, high=10, size=[1], dtype='int32'),
-        np.random.randint(low=0, high=10, size=[1], dtype='int32'),
+        np.random.random(size=[1, 65536, 32]).astype("float32"),
+        np.array(128, dtype="int32"),
+        np.array(512, dtype="int32"),
     )
     return inputs
 
@@ -114,9 +136,10 @@ class TestLayer(unittest.TestCase):
     def setUp(self):
         self.inputs = create_tensor_inputs()
         self.net = LayerCase()
+
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.set_flags({"FLAGS_prim_all": with_prim})
             if with_cinn:
                 build_strategy = paddle.static.BuildStrategy()
                 build_strategy.build_cinn_pass = True
@@ -126,6 +149,7 @@ class TestLayer(unittest.TestCase):
         paddle.seed(123)
         outs = net(*self.inputs)
         return outs
+
     def test_ast_prim_cinn(self):
         st_out = self.train(self.net, to_static=True)
         cinn_out = self.train(self.net, to_static=True, with_prim=True, with_cinn=True)
@@ -133,5 +157,5 @@ class TestLayer(unittest.TestCase):
             np.testing.assert_allclose(st.numpy(), cinn.numpy(), atol=1e-8)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/segformer_segformer_b0_cityscapes_1024x512_160k/SIR_12.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/segformer_segformer_b0_cityscapes_1024x512_160k/SIR_12.py
@@ -8,65 +8,83 @@ class LayerCase(paddle.nn.Layer):
     def __init__(self):
         super().__init__()
         self.parameter_0 = self.create_parameter(
-           shape=[64],
-           dtype=paddle.float32,
+            shape=[64],
+            dtype=paddle.float32,
         )
         self.parameter_1 = self.create_parameter(
-           shape=[32],
-           dtype=paddle.float32,
+            shape=[32],
+            dtype=paddle.float32,
         )
         self.parameter_2 = self.create_parameter(
-           shape=[64],
-           dtype=paddle.float32,
+            shape=[64],
+            dtype=paddle.float32,
         )
         self.parameter_3 = self.create_parameter(
-           shape=[64, 32, 3, 3],
-           dtype=paddle.float32,
+            shape=[64, 32, 3, 3],
+            dtype=paddle.float32,
         )
         self.parameter_4 = self.create_parameter(
-           shape=[32],
-           dtype=paddle.float32,
+            shape=[32],
+            dtype=paddle.float32,
         )
         self.parameter_5 = self.create_parameter(
-           shape=[64],
-           dtype=paddle.float32,
+            shape=[64],
+            dtype=paddle.float32,
         )
+
     def forward(
         self,
-        var_0,    # (shape: [1, 32768, 32], dtype: paddle.float32, stop_gradient: False)
-        var_1,    # (shape: [], dtype: paddle.int32, stop_gradient: True)
-        var_2,    # (shape: [], dtype: paddle.int32, stop_gradient: True)
-        var_3,    # (shape: [], dtype: paddle.int32, stop_gradient: True)
+        var_0,  # (shape: [1, 32768, 32], dtype: paddle.float32, stop_gradient: False)
+        var_1,  # (shape: [], dtype: paddle.int32, stop_gradient: True)
+        var_2,  # (shape: [], dtype: paddle.int32, stop_gradient: True)
+        var_3,  # (shape: [], dtype: paddle.int32, stop_gradient: True)
     ):
-        var_4 = paddle.nn.functional.norm.layer_norm(var_0, normalized_shape=[32], weight=self.parameter_1, bias=self.parameter_4, epsilon=1e-06)
+        var_4 = paddle.nn.functional.norm.layer_norm(
+            var_0, normalized_shape=[32], weight=self.parameter_1, bias=self.parameter_4, epsilon=1e-06
+        )
         var_5 = var_4.reshape([var_1, var_2, var_3, 32])
         var_6 = var_5.transpose([0, 3, 1, 2])
-        var_7 = paddle.nn.functional.conv._conv_nd(var_6, self.parameter_3, bias=self.parameter_0, stride=[2, 2], padding=[1, 1], padding_algorithm='EXPLICIT', dilation=[1, 1], groups=1, data_format='NCHW', channel_dim=1, op_type='conv2d', use_cudnn=True)
+        var_7 = paddle.nn.functional.conv._conv_nd(
+            var_6,
+            self.parameter_3,
+            bias=self.parameter_0,
+            stride=[2, 2],
+            padding=[1, 1],
+            padding_algorithm="EXPLICIT",
+            dilation=[1, 1],
+            groups=1,
+            data_format="NCHW",
+            channel_dim=1,
+            op_type="conv2d",
+            use_cudnn=True,
+        )
         var_8 = var_7.shape
         var_9 = var_8.__getitem__(2)
         var_10 = var_8.__getitem__(3)
         var_11 = var_7.flatten(2)
         var_12 = var_11.transpose([0, 2, 1])
-        var_13 = paddle.nn.functional.norm.layer_norm(var_12, normalized_shape=[64], weight=self.parameter_5, bias=self.parameter_2, epsilon=1e-05)
+        var_13 = paddle.nn.functional.norm.layer_norm(
+            var_12, normalized_shape=[64], weight=self.parameter_5, bias=self.parameter_2, epsilon=1e-05
+        )
         return var_13, var_9, var_10, var_6
 
 
 def create_tensor_inputs():
     inputs = (
         paddle.rand(shape=[1, 32768, 32], dtype=paddle.float32),
-        paddle.randint(low=0, high=10, shape=[1], dtype=paddle.int32),
-        paddle.randint(low=0, high=10, shape=[1], dtype=paddle.int32),
-        paddle.randint(low=0, high=10, shape=[1], dtype=paddle.int32),
+        paddle.to_tensor(16, dtype=paddle.int32),
+        paddle.to_tensor(32, dtype=paddle.int32),
+        paddle.to_tensor(64, dtype=paddle.int32),
     )
     return inputs
 
 
 def create_numpy_inputs():
     inputs = (
-        np.random.random(size=[1, 32768, 32]).astype('float32'),
-        np.random.randint(low=0, high=10, size=[1], dtype='int32'),
-        np.random.randint(low=0, high=10, size=[1], dtype='int32'),
-        np.random.randint(low=0, high=10, size=[1], dtype='int32'),
+        np.random.random(size=[1, 32768, 32]).astype("float32"),
+        np.array(16, dtype="int32"),
+        np.array(32, dtype="int32"),
+        np.array(64, dtype="int32"),
     )
     return inputs
 
@@ -75,9 +93,10 @@ class TestLayer(unittest.TestCase):
     def setUp(self):
         self.inputs = create_tensor_inputs()
         self.net = LayerCase()
+
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.set_flags({"FLAGS_prim_all": with_prim})
             if with_cinn:
                 build_strategy = paddle.static.BuildStrategy()
                 build_strategy.build_cinn_pass = True
@@ -87,6 +106,7 @@ class TestLayer(unittest.TestCase):
         paddle.seed(123)
         outs = net(*self.inputs)
         return outs
+
     def test_ast_prim_cinn(self):
         st_out = self.train(self.net, to_static=True)
         cinn_out = self.train(self.net, to_static=True, with_prim=True, with_cinn=True)
@@ -94,5 +114,5 @@ class TestLayer(unittest.TestCase):
             np.testing.assert_allclose(st.numpy(), cinn.numpy(), atol=1e-8)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/segformer_segformer_b0_cityscapes_1024x512_160k/SIR_14.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/segformer_segformer_b0_cityscapes_1024x512_160k/SIR_14.py
@@ -8,60 +8,63 @@ class LayerCase(paddle.nn.Layer):
     def __init__(self):
         super().__init__()
         self.parameter_0 = self.create_parameter(
-           shape=[64],
-           dtype=paddle.float32,
+            shape=[64],
+            dtype=paddle.float32,
         )
         self.parameter_1 = self.create_parameter(
-           shape=[64],
-           dtype=paddle.float32,
+            shape=[64],
+            dtype=paddle.float32,
         )
         self.parameter_2 = self.create_parameter(
-           shape=[128],
-           dtype=paddle.float32,
+            shape=[128],
+            dtype=paddle.float32,
         )
         self.parameter_3 = self.create_parameter(
-           shape=[64, 64],
-           dtype=paddle.float32,
+            shape=[64, 64],
+            dtype=paddle.float32,
         )
         self.parameter_4 = self.create_parameter(
-           shape=[64],
-           dtype=paddle.float32,
+            shape=[64],
+            dtype=paddle.float32,
         )
         self.parameter_5 = self.create_parameter(
-           shape=[64, 64],
-           dtype=paddle.float32,
+            shape=[64, 64],
+            dtype=paddle.float32,
         )
         self.parameter_6 = self.create_parameter(
-           shape=[64],
-           dtype=paddle.float32,
+            shape=[64],
+            dtype=paddle.float32,
         )
         self.parameter_7 = self.create_parameter(
-           shape=[64],
-           dtype=paddle.float32,
+            shape=[64],
+            dtype=paddle.float32,
         )
         self.parameter_8 = self.create_parameter(
-           shape=[64],
-           dtype=paddle.float32,
+            shape=[64],
+            dtype=paddle.float32,
         )
         self.parameter_9 = self.create_parameter(
-           shape=[64, 128],
-           dtype=paddle.float32,
+            shape=[64, 128],
+            dtype=paddle.float32,
         )
         self.parameter_10 = self.create_parameter(
-           shape=[64],
-           dtype=paddle.float32,
+            shape=[64],
+            dtype=paddle.float32,
         )
         self.parameter_11 = self.create_parameter(
-           shape=[64, 64, 4, 4],
-           dtype=paddle.float32,
+            shape=[64, 64, 4, 4],
+            dtype=paddle.float32,
         )
+
     def forward(
         self,
-        var_0,    # (shape: [1, 8192, 64], dtype: paddle.float32, stop_gradient: False)
-        var_1,    # (shape: [], dtype: paddle.int32, stop_gradient: True)
-        var_2,    # (shape: [], dtype: paddle.int32, stop_gradient: True)
+        var_0,  # (shape: [1, 8192, 64], dtype: paddle.float32, stop_gradient: False)
+        var_1,  # (shape: [], dtype: paddle.int32, stop_gradient: True)
+        var_2,  # (shape: [], dtype: paddle.int32, stop_gradient: True)
     ):
-        var_3 = paddle.nn.functional.norm.layer_norm(var_0, normalized_shape=[64], weight=self.parameter_7, bias=self.parameter_1, epsilon=1e-06)
+        var_3 = paddle.nn.functional.norm.layer_norm(
+            var_0, normalized_shape=[64], weight=self.parameter_7, bias=self.parameter_1, epsilon=1e-06
+        )
         var_4 = var_3.shape
         var_5 = var_4.__getitem__(0)
         var_6 = var_4.__getitem__(1)
@@ -70,10 +73,25 @@ class LayerCase(paddle.nn.Layer):
         var_9 = var_8.transpose([0, 2, 1, 3])
         var_10 = var_3.transpose([0, 2, 1])
         var_11 = var_10.reshape([var_5, 64, var_1, var_2])
-        var_12 = paddle.nn.functional.conv._conv_nd(var_11, self.parameter_11, bias=self.parameter_6, stride=[4, 4], padding=[0, 0], padding_algorithm='EXPLICIT', dilation=[1, 1], groups=1, data_format='NCHW', channel_dim=1, op_type='conv2d', use_cudnn=True)
+        var_12 = paddle.nn.functional.conv._conv_nd(
+            var_11,
+            self.parameter_11,
+            bias=self.parameter_6,
+            stride=[4, 4],
+            padding=[0, 0],
+            padding_algorithm="EXPLICIT",
+            dilation=[1, 1],
+            groups=1,
+            data_format="NCHW",
+            channel_dim=1,
+            op_type="conv2d",
+            use_cudnn=True,
+        )
         var_13 = var_12.reshape([var_5, 64, -1])
         var_14 = var_13.transpose([0, 2, 1])
-        var_15 = paddle.nn.functional.norm.layer_norm(var_14, normalized_shape=[64], weight=self.parameter_8, bias=self.parameter_10, epsilon=1e-05)
+        var_15 = paddle.nn.functional.norm.layer_norm(
+            var_14, normalized_shape=[64], weight=self.parameter_8, bias=self.parameter_10, epsilon=1e-05
+        )
         var_16 = paddle.nn.functional.common.linear(x=var_15, weight=self.parameter_9, bias=self.parameter_2, name=None)
         var_17 = var_16.reshape([var_5, -1, 2, 2, 32])
         var_18 = var_17.transpose([2, 0, 3, 1, 4])
@@ -83,29 +101,33 @@ class LayerCase(paddle.nn.Layer):
         var_22 = var_9.__matmul__(var_21)
         var_23 = var_22.__mul__(0.1767766952966369)
         var_24 = paddle.nn.functional.activation.softmax(var_23, axis=-1)
-        var_25 = paddle.nn.functional.common.dropout(var_24, p=0.0, axis=None, training=True, mode='upscale_in_train', name=None)
+        var_25 = paddle.nn.functional.common.dropout(
+            var_24, p=0.0, axis=None, training=True, mode="upscale_in_train", name=None
+        )
         var_26 = var_25.__matmul__(var_20)
         var_27 = var_26.transpose([0, 2, 1, 3])
         var_28 = var_27.reshape([var_5, var_6, 64])
         var_29 = paddle.nn.functional.common.linear(x=var_28, weight=self.parameter_3, bias=self.parameter_4, name=None)
-        var_30 = paddle.nn.functional.common.dropout(var_29, p=0.0, axis=None, training=True, mode='upscale_in_train', name=None)
+        var_30 = paddle.nn.functional.common.dropout(
+            var_29, p=0.0, axis=None, training=True, mode="upscale_in_train", name=None
+        )
         return var_30
 
 
 def create_tensor_inputs():
     inputs = (
         paddle.rand(shape=[1, 8192, 64], dtype=paddle.float32),
-        paddle.randint(low=0, high=10, shape=[1], dtype=paddle.int32),
-        paddle.randint(low=0, high=10, shape=[1], dtype=paddle.int32),
+        paddle.to_tensor(32, dtype=paddle.int32),
+        paddle.to_tensor(256, dtype=paddle.int32),
     )
     return inputs
 
 
 def create_numpy_inputs():
     inputs = (
-        np.random.random(size=[1, 8192, 64]).astype('float32'),
-        np.random.randint(low=0, high=10, size=[1], dtype='int32'),
-        np.random.randint(low=0, high=10, size=[1], dtype='int32'),
+        np.random.random(size=[1, 8192, 64]).astype("float32"),
+        np.array(32, dtype="int32"),
+        np.array(256, dtype="int32"),
     )
     return inputs
 
@@ -114,9 +136,10 @@ class TestLayer(unittest.TestCase):
     def setUp(self):
         self.inputs = create_tensor_inputs()
         self.net = LayerCase()
+
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.set_flags({"FLAGS_prim_all": with_prim})
             if with_cinn:
                 build_strategy = paddle.static.BuildStrategy()
                 build_strategy.build_cinn_pass = True
@@ -126,6 +149,7 @@ class TestLayer(unittest.TestCase):
         paddle.seed(123)
         outs = net(*self.inputs)
         return outs
+
     def test_ast_prim_cinn(self):
         st_out = self.train(self.net, to_static=True)
         cinn_out = self.train(self.net, to_static=True, with_prim=True, with_cinn=True)
@@ -133,5 +157,5 @@ class TestLayer(unittest.TestCase):
             np.testing.assert_allclose(st.numpy(), cinn.numpy(), atol=1e-8)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/segformer_segformer_b0_cityscapes_1024x512_160k/SIR_24.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/segformer_segformer_b0_cityscapes_1024x512_160k/SIR_24.py
@@ -8,65 +8,83 @@ class LayerCase(paddle.nn.Layer):
     def __init__(self):
         super().__init__()
         self.parameter_0 = self.create_parameter(
-           shape=[160, 64, 3, 3],
-           dtype=paddle.float32,
+            shape=[160, 64, 3, 3],
+            dtype=paddle.float32,
         )
         self.parameter_1 = self.create_parameter(
-           shape=[160],
-           dtype=paddle.float32,
+            shape=[160],
+            dtype=paddle.float32,
         )
         self.parameter_2 = self.create_parameter(
-           shape=[160],
-           dtype=paddle.float32,
+            shape=[160],
+            dtype=paddle.float32,
         )
         self.parameter_3 = self.create_parameter(
-           shape=[160],
-           dtype=paddle.float32,
+            shape=[160],
+            dtype=paddle.float32,
         )
         self.parameter_4 = self.create_parameter(
-           shape=[64],
-           dtype=paddle.float32,
+            shape=[64],
+            dtype=paddle.float32,
         )
         self.parameter_5 = self.create_parameter(
-           shape=[64],
-           dtype=paddle.float32,
+            shape=[64],
+            dtype=paddle.float32,
         )
+
     def forward(
         self,
-        var_0,    # (shape: [1, 8192, 64], dtype: paddle.float32, stop_gradient: False)
-        var_1,    # (shape: [], dtype: paddle.int32, stop_gradient: True)
-        var_2,    # (shape: [], dtype: paddle.int32, stop_gradient: True)
-        var_3,    # (shape: [], dtype: paddle.int32, stop_gradient: True)
+        var_0,  # (shape: [1, 8192, 64], dtype: paddle.float32, stop_gradient: False)
+        var_1,  # (shape: [], dtype: paddle.int32, stop_gradient: True)
+        var_2,  # (shape: [], dtype: paddle.int32, stop_gradient: True)
+        var_3,  # (shape: [], dtype: paddle.int32, stop_gradient: True)
     ):
-        var_4 = paddle.nn.functional.norm.layer_norm(var_0, normalized_shape=[64], weight=self.parameter_5, bias=self.parameter_4, epsilon=1e-06)
+        var_4 = paddle.nn.functional.norm.layer_norm(
+            var_0, normalized_shape=[64], weight=self.parameter_5, bias=self.parameter_4, epsilon=1e-06
+        )
         var_5 = var_4.reshape([var_1, var_2, var_3, 64])
         var_6 = var_5.transpose([0, 3, 1, 2])
-        var_7 = paddle.nn.functional.conv._conv_nd(var_6, self.parameter_0, bias=self.parameter_3, stride=[2, 2], padding=[1, 1], padding_algorithm='EXPLICIT', dilation=[1, 1], groups=1, data_format='NCHW', channel_dim=1, op_type='conv2d', use_cudnn=True)
+        var_7 = paddle.nn.functional.conv._conv_nd(
+            var_6,
+            self.parameter_0,
+            bias=self.parameter_3,
+            stride=[2, 2],
+            padding=[1, 1],
+            padding_algorithm="EXPLICIT",
+            dilation=[1, 1],
+            groups=1,
+            data_format="NCHW",
+            channel_dim=1,
+            op_type="conv2d",
+            use_cudnn=True,
+        )
         var_8 = var_7.shape
         var_9 = var_8.__getitem__(2)
         var_10 = var_8.__getitem__(3)
         var_11 = var_7.flatten(2)
         var_12 = var_11.transpose([0, 2, 1])
-        var_13 = paddle.nn.functional.norm.layer_norm(var_12, normalized_shape=[160], weight=self.parameter_1, bias=self.parameter_2, epsilon=1e-05)
+        var_13 = paddle.nn.functional.norm.layer_norm(
+            var_12, normalized_shape=[160], weight=self.parameter_1, bias=self.parameter_2, epsilon=1e-05
+        )
         return var_13, var_9, var_10, var_6
 
 
 def create_tensor_inputs():
     inputs = (
         paddle.rand(shape=[1, 8192, 64], dtype=paddle.float32),
-        paddle.randint(low=0, high=10, shape=[1], dtype=paddle.int32),
-        paddle.randint(low=0, high=10, shape=[1], dtype=paddle.int32),
-        paddle.randint(low=0, high=10, shape=[1], dtype=paddle.int32),
+        paddle.to_tensor(8, dtype=paddle.int32),
+        paddle.to_tensor(16, dtype=paddle.int32),
+        paddle.to_tensor(64, dtype=paddle.int32),
     )
     return inputs
 
 
 def create_numpy_inputs():
     inputs = (
-        np.random.random(size=[1, 8192, 64]).astype('float32'),
-        np.random.randint(low=0, high=10, size=[1], dtype='int32'),
-        np.random.randint(low=0, high=10, size=[1], dtype='int32'),
-        np.random.randint(low=0, high=10, size=[1], dtype='int32'),
+        np.random.random(size=[1, 8192, 64]).astype("float32"),
+        np.array(8, dtype="int32"),
+        np.array(16, dtype="int32"),
+        np.array(64, dtype="int32"),
     )
     return inputs
 
@@ -75,9 +93,10 @@ class TestLayer(unittest.TestCase):
     def setUp(self):
         self.inputs = create_tensor_inputs()
         self.net = LayerCase()
+
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.set_flags({"FLAGS_prim_all": with_prim})
             if with_cinn:
                 build_strategy = paddle.static.BuildStrategy()
                 build_strategy.build_cinn_pass = True
@@ -87,6 +106,7 @@ class TestLayer(unittest.TestCase):
         paddle.seed(123)
         outs = net(*self.inputs)
         return outs
+
     def test_ast_prim_cinn(self):
         st_out = self.train(self.net, to_static=True)
         cinn_out = self.train(self.net, to_static=True, with_prim=True, with_cinn=True)
@@ -94,5 +114,5 @@ class TestLayer(unittest.TestCase):
             np.testing.assert_allclose(st.numpy(), cinn.numpy(), atol=1e-8)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/segformer_segformer_b0_cityscapes_1024x512_160k/SIR_26.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/segformer_segformer_b0_cityscapes_1024x512_160k/SIR_26.py
@@ -8,60 +8,63 @@ class LayerCase(paddle.nn.Layer):
     def __init__(self):
         super().__init__()
         self.parameter_0 = self.create_parameter(
-           shape=[160],
-           dtype=paddle.float32,
+            shape=[160],
+            dtype=paddle.float32,
         )
         self.parameter_1 = self.create_parameter(
-           shape=[160],
-           dtype=paddle.float32,
+            shape=[160],
+            dtype=paddle.float32,
         )
         self.parameter_2 = self.create_parameter(
-           shape=[160],
-           dtype=paddle.float32,
+            shape=[160],
+            dtype=paddle.float32,
         )
         self.parameter_3 = self.create_parameter(
-           shape=[160, 160, 2, 2],
-           dtype=paddle.float32,
+            shape=[160, 160, 2, 2],
+            dtype=paddle.float32,
         )
         self.parameter_4 = self.create_parameter(
-           shape=[160],
-           dtype=paddle.float32,
+            shape=[160],
+            dtype=paddle.float32,
         )
         self.parameter_5 = self.create_parameter(
-           shape=[160],
-           dtype=paddle.float32,
+            shape=[160],
+            dtype=paddle.float32,
         )
         self.parameter_6 = self.create_parameter(
-           shape=[320],
-           dtype=paddle.float32,
+            shape=[320],
+            dtype=paddle.float32,
         )
         self.parameter_7 = self.create_parameter(
-           shape=[160],
-           dtype=paddle.float32,
+            shape=[160],
+            dtype=paddle.float32,
         )
         self.parameter_8 = self.create_parameter(
-           shape=[160],
-           dtype=paddle.float32,
+            shape=[160],
+            dtype=paddle.float32,
         )
         self.parameter_9 = self.create_parameter(
-           shape=[160, 160],
-           dtype=paddle.float32,
+            shape=[160, 160],
+            dtype=paddle.float32,
         )
         self.parameter_10 = self.create_parameter(
-           shape=[160, 320],
-           dtype=paddle.float32,
+            shape=[160, 320],
+            dtype=paddle.float32,
         )
         self.parameter_11 = self.create_parameter(
-           shape=[160, 160],
-           dtype=paddle.float32,
+            shape=[160, 160],
+            dtype=paddle.float32,
         )
+
     def forward(
         self,
-        var_0,    # (shape: [1, 2048, 160], dtype: paddle.float32, stop_gradient: False)
-        var_1,    # (shape: [], dtype: paddle.int32, stop_gradient: True)
-        var_2,    # (shape: [], dtype: paddle.int32, stop_gradient: True)
+        var_0,  # (shape: [1, 2048, 160], dtype: paddle.float32, stop_gradient: False)
+        var_1,  # (shape: [], dtype: paddle.int32, stop_gradient: True)
+        var_2,  # (shape: [], dtype: paddle.int32, stop_gradient: True)
     ):
-        var_3 = paddle.nn.functional.norm.layer_norm(var_0, normalized_shape=[160], weight=self.parameter_2, bias=self.parameter_0, epsilon=1e-06)
+        var_3 = paddle.nn.functional.norm.layer_norm(
+            var_0, normalized_shape=[160], weight=self.parameter_2, bias=self.parameter_0, epsilon=1e-06
+        )
         var_4 = var_3.shape
         var_5 = var_4.__getitem__(0)
         var_6 = var_4.__getitem__(1)
@@ -70,11 +73,28 @@ class LayerCase(paddle.nn.Layer):
         var_9 = var_8.transpose([0, 2, 1, 3])
         var_10 = var_3.transpose([0, 2, 1])
         var_11 = var_10.reshape([var_5, 160, var_1, var_2])
-        var_12 = paddle.nn.functional.conv._conv_nd(var_11, self.parameter_3, bias=self.parameter_7, stride=[2, 2], padding=[0, 0], padding_algorithm='EXPLICIT', dilation=[1, 1], groups=1, data_format='NCHW', channel_dim=1, op_type='conv2d', use_cudnn=True)
+        var_12 = paddle.nn.functional.conv._conv_nd(
+            var_11,
+            self.parameter_3,
+            bias=self.parameter_7,
+            stride=[2, 2],
+            padding=[0, 0],
+            padding_algorithm="EXPLICIT",
+            dilation=[1, 1],
+            groups=1,
+            data_format="NCHW",
+            channel_dim=1,
+            op_type="conv2d",
+            use_cudnn=True,
+        )
         var_13 = var_12.reshape([var_5, 160, -1])
         var_14 = var_13.transpose([0, 2, 1])
-        var_15 = paddle.nn.functional.norm.layer_norm(var_14, normalized_shape=[160], weight=self.parameter_8, bias=self.parameter_5, epsilon=1e-05)
-        var_16 = paddle.nn.functional.common.linear(x=var_15, weight=self.parameter_10, bias=self.parameter_6, name=None)
+        var_15 = paddle.nn.functional.norm.layer_norm(
+            var_14, normalized_shape=[160], weight=self.parameter_8, bias=self.parameter_5, epsilon=1e-05
+        )
+        var_16 = paddle.nn.functional.common.linear(
+            x=var_15, weight=self.parameter_10, bias=self.parameter_6, name=None
+        )
         var_17 = var_16.reshape([var_5, -1, 2, 5, 32])
         var_18 = var_17.transpose([2, 0, 3, 1, 4])
         var_19 = var_18.__getitem__(0)
@@ -83,29 +103,33 @@ class LayerCase(paddle.nn.Layer):
         var_22 = var_9.__matmul__(var_21)
         var_23 = var_22.__mul__(0.1767766952966369)
         var_24 = paddle.nn.functional.activation.softmax(var_23, axis=-1)
-        var_25 = paddle.nn.functional.common.dropout(var_24, p=0.0, axis=None, training=True, mode='upscale_in_train', name=None)
+        var_25 = paddle.nn.functional.common.dropout(
+            var_24, p=0.0, axis=None, training=True, mode="upscale_in_train", name=None
+        )
         var_26 = var_25.__matmul__(var_20)
         var_27 = var_26.transpose([0, 2, 1, 3])
         var_28 = var_27.reshape([var_5, var_6, 160])
         var_29 = paddle.nn.functional.common.linear(x=var_28, weight=self.parameter_9, bias=self.parameter_4, name=None)
-        var_30 = paddle.nn.functional.common.dropout(var_29, p=0.0, axis=None, training=True, mode='upscale_in_train', name=None)
+        var_30 = paddle.nn.functional.common.dropout(
+            var_29, p=0.0, axis=None, training=True, mode="upscale_in_train", name=None
+        )
         return var_30
 
 
 def create_tensor_inputs():
     inputs = (
         paddle.rand(shape=[1, 2048, 160], dtype=paddle.float32),
-        paddle.randint(low=0, high=10, shape=[1], dtype=paddle.int32),
-        paddle.randint(low=0, high=10, shape=[1], dtype=paddle.int32),
+        paddle.to_tensor(32, dtype=paddle.int32),
+        paddle.to_tensor(64, dtype=paddle.int32),
     )
     return inputs
 
 
 def create_numpy_inputs():
     inputs = (
-        np.random.random(size=[1, 2048, 160]).astype('float32'),
-        np.random.randint(low=0, high=10, size=[1], dtype='int32'),
-        np.random.randint(low=0, high=10, size=[1], dtype='int32'),
+        np.random.random(size=[1, 2048, 160]).astype("float32"),
+        np.array(32, dtype="int32"),
+        np.array(64, dtype="int32"),
     )
     return inputs
 
@@ -114,9 +138,10 @@ class TestLayer(unittest.TestCase):
     def setUp(self):
         self.inputs = create_tensor_inputs()
         self.net = LayerCase()
+
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.set_flags({"FLAGS_prim_all": with_prim})
             if with_cinn:
                 build_strategy = paddle.static.BuildStrategy()
                 build_strategy.build_cinn_pass = True
@@ -126,6 +151,7 @@ class TestLayer(unittest.TestCase):
         paddle.seed(123)
         outs = net(*self.inputs)
         return outs
+
     def test_ast_prim_cinn(self):
         st_out = self.train(self.net, to_static=True)
         cinn_out = self.train(self.net, to_static=True, with_prim=True, with_cinn=True)
@@ -133,5 +159,5 @@ class TestLayer(unittest.TestCase):
             np.testing.assert_allclose(st.numpy(), cinn.numpy(), atol=1e-8)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/segformer_segformer_b0_cityscapes_1024x512_160k/SIR_36.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/segformer_segformer_b0_cityscapes_1024x512_160k/SIR_36.py
@@ -8,65 +8,83 @@ class LayerCase(paddle.nn.Layer):
     def __init__(self):
         super().__init__()
         self.parameter_0 = self.create_parameter(
-           shape=[256],
-           dtype=paddle.float32,
+            shape=[256],
+            dtype=paddle.float32,
         )
         self.parameter_1 = self.create_parameter(
-           shape=[160],
-           dtype=paddle.float32,
+            shape=[160],
+            dtype=paddle.float32,
         )
         self.parameter_2 = self.create_parameter(
-           shape=[256],
-           dtype=paddle.float32,
+            shape=[256],
+            dtype=paddle.float32,
         )
         self.parameter_3 = self.create_parameter(
-           shape=[160],
-           dtype=paddle.float32,
+            shape=[160],
+            dtype=paddle.float32,
         )
         self.parameter_4 = self.create_parameter(
-           shape=[256, 160, 3, 3],
-           dtype=paddle.float32,
+            shape=[256, 160, 3, 3],
+            dtype=paddle.float32,
         )
         self.parameter_5 = self.create_parameter(
-           shape=[256],
-           dtype=paddle.float32,
+            shape=[256],
+            dtype=paddle.float32,
         )
+
     def forward(
         self,
-        var_0,    # (shape: [1, 2048, 160], dtype: paddle.float32, stop_gradient: False)
-        var_1,    # (shape: [], dtype: paddle.int32, stop_gradient: True)
-        var_2,    # (shape: [], dtype: paddle.int32, stop_gradient: True)
-        var_3,    # (shape: [], dtype: paddle.int32, stop_gradient: True)
+        var_0,  # (shape: [1, 2048, 160], dtype: paddle.float32, stop_gradient: False)
+        var_1,  # (shape: [], dtype: paddle.int32, stop_gradient: True)
+        var_2,  # (shape: [], dtype: paddle.int32, stop_gradient: True)
+        var_3,  # (shape: [], dtype: paddle.int32, stop_gradient: True)
     ):
-        var_4 = paddle.nn.functional.norm.layer_norm(var_0, normalized_shape=[160], weight=self.parameter_1, bias=self.parameter_3, epsilon=1e-06)
+        var_4 = paddle.nn.functional.norm.layer_norm(
+            var_0, normalized_shape=[160], weight=self.parameter_1, bias=self.parameter_3, epsilon=1e-06
+        )
         var_5 = var_4.reshape([var_1, var_2, var_3, 160])
         var_6 = var_5.transpose([0, 3, 1, 2])
-        var_7 = paddle.nn.functional.conv._conv_nd(var_6, self.parameter_4, bias=self.parameter_2, stride=[2, 2], padding=[1, 1], padding_algorithm='EXPLICIT', dilation=[1, 1], groups=1, data_format='NCHW', channel_dim=1, op_type='conv2d', use_cudnn=True)
+        var_7 = paddle.nn.functional.conv._conv_nd(
+            var_6,
+            self.parameter_4,
+            bias=self.parameter_2,
+            stride=[2, 2],
+            padding=[1, 1],
+            padding_algorithm="EXPLICIT",
+            dilation=[1, 1],
+            groups=1,
+            data_format="NCHW",
+            channel_dim=1,
+            op_type="conv2d",
+            use_cudnn=True,
+        )
         var_8 = var_7.shape
         var_9 = var_8.__getitem__(2)
         var_10 = var_8.__getitem__(3)
         var_11 = var_7.flatten(2)
         var_12 = var_11.transpose([0, 2, 1])
-        var_13 = paddle.nn.functional.norm.layer_norm(var_12, normalized_shape=[256], weight=self.parameter_0, bias=self.parameter_5, epsilon=1e-05)
+        var_13 = paddle.nn.functional.norm.layer_norm(
+            var_12, normalized_shape=[256], weight=self.parameter_0, bias=self.parameter_5, epsilon=1e-05
+        )
         return var_13, var_9, var_10, var_6
 
 
 def create_tensor_inputs():
     inputs = (
         paddle.rand(shape=[1, 2048, 160], dtype=paddle.float32),
-        paddle.randint(low=0, high=10, shape=[1], dtype=paddle.int32),
-        paddle.randint(low=0, high=10, shape=[1], dtype=paddle.int32),
-        paddle.randint(low=0, high=10, shape=[1], dtype=paddle.int32),
+        paddle.to_tensor(4, dtype=paddle.int32),
+        paddle.to_tensor(16, dtype=paddle.int32),
+        paddle.to_tensor(32, dtype=paddle.int32),
     )
     return inputs
 
 
 def create_numpy_inputs():
     inputs = (
-        np.random.random(size=[1, 2048, 160]).astype('float32'),
-        np.random.randint(low=0, high=10, size=[1], dtype='int32'),
-        np.random.randint(low=0, high=10, size=[1], dtype='int32'),
-        np.random.randint(low=0, high=10, size=[1], dtype='int32'),
+        np.random.random(size=[1, 2048, 160]).astype("float32"),
+        np.array(4, dtype="int32"),
+        np.array(16, dtype="int32"),
+        np.array(32, dtype="int32"),
     )
     return inputs
 
@@ -75,9 +93,10 @@ class TestLayer(unittest.TestCase):
     def setUp(self):
         self.inputs = create_tensor_inputs()
         self.net = LayerCase()
+
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.set_flags({"FLAGS_prim_all": with_prim})
             if with_cinn:
                 build_strategy = paddle.static.BuildStrategy()
                 build_strategy.build_cinn_pass = True
@@ -87,6 +106,7 @@ class TestLayer(unittest.TestCase):
         paddle.seed(123)
         outs = net(*self.inputs)
         return outs
+
     def test_ast_prim_cinn(self):
         st_out = self.train(self.net, to_static=True)
         cinn_out = self.train(self.net, to_static=True, with_prim=True, with_cinn=True)
@@ -94,5 +114,5 @@ class TestLayer(unittest.TestCase):
             np.testing.assert_allclose(st.numpy(), cinn.numpy(), atol=1e-8)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/segformer_segformer_b0_cityscapes_1024x512_160k/SIR_5.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/segformer_segformer_b0_cityscapes_1024x512_160k/SIR_5.py
@@ -8,60 +8,63 @@ class LayerCase(paddle.nn.Layer):
     def __init__(self):
         super().__init__()
         self.parameter_0 = self.create_parameter(
-           shape=[32, 32, 8, 8],
-           dtype=paddle.float32,
+            shape=[32, 32, 8, 8],
+            dtype=paddle.float32,
         )
         self.parameter_1 = self.create_parameter(
-           shape=[32],
-           dtype=paddle.float32,
+            shape=[32],
+            dtype=paddle.float32,
         )
         self.parameter_2 = self.create_parameter(
-           shape=[32],
-           dtype=paddle.float32,
+            shape=[32],
+            dtype=paddle.float32,
         )
         self.parameter_3 = self.create_parameter(
-           shape=[32, 64],
-           dtype=paddle.float32,
+            shape=[32, 64],
+            dtype=paddle.float32,
         )
         self.parameter_4 = self.create_parameter(
-           shape=[32],
-           dtype=paddle.float32,
+            shape=[32],
+            dtype=paddle.float32,
         )
         self.parameter_5 = self.create_parameter(
-           shape=[32, 32],
-           dtype=paddle.float32,
+            shape=[32, 32],
+            dtype=paddle.float32,
         )
         self.parameter_6 = self.create_parameter(
-           shape=[32],
-           dtype=paddle.float32,
+            shape=[32],
+            dtype=paddle.float32,
         )
         self.parameter_7 = self.create_parameter(
-           shape=[32, 32],
-           dtype=paddle.float32,
+            shape=[32, 32],
+            dtype=paddle.float32,
         )
         self.parameter_8 = self.create_parameter(
-           shape=[32],
-           dtype=paddle.float32,
+            shape=[32],
+            dtype=paddle.float32,
         )
         self.parameter_9 = self.create_parameter(
-           shape=[32],
-           dtype=paddle.float32,
+            shape=[32],
+            dtype=paddle.float32,
         )
         self.parameter_10 = self.create_parameter(
-           shape=[64],
-           dtype=paddle.float32,
+            shape=[64],
+            dtype=paddle.float32,
         )
         self.parameter_11 = self.create_parameter(
-           shape=[32],
-           dtype=paddle.float32,
+            shape=[32],
+            dtype=paddle.float32,
         )
+
     def forward(
         self,
-        var_0,    # (shape: [1, 32768, 32], dtype: paddle.float32, stop_gradient: False)
-        var_1,    # (shape: [], dtype: paddle.int32, stop_gradient: True)
-        var_2,    # (shape: [], dtype: paddle.int32, stop_gradient: True)
+        var_0,  # (shape: [1, 32768, 32], dtype: paddle.float32, stop_gradient: False)
+        var_1,  # (shape: [], dtype: paddle.int32, stop_gradient: True)
+        var_2,  # (shape: [], dtype: paddle.int32, stop_gradient: True)
     ):
-        var_3 = paddle.nn.functional.norm.layer_norm(var_0, normalized_shape=[32], weight=self.parameter_2, bias=self.parameter_9, epsilon=1e-06)
+        var_3 = paddle.nn.functional.norm.layer_norm(
+            var_0, normalized_shape=[32], weight=self.parameter_2, bias=self.parameter_9, epsilon=1e-06
+        )
         var_4 = var_3.shape
         var_5 = var_4.__getitem__(0)
         var_6 = var_4.__getitem__(1)
@@ -70,11 +73,28 @@ class LayerCase(paddle.nn.Layer):
         var_9 = var_8.transpose([0, 2, 1, 3])
         var_10 = var_3.transpose([0, 2, 1])
         var_11 = var_10.reshape([var_5, 32, var_1, var_2])
-        var_12 = paddle.nn.functional.conv._conv_nd(var_11, self.parameter_0, bias=self.parameter_11, stride=[8, 8], padding=[0, 0], padding_algorithm='EXPLICIT', dilation=[1, 1], groups=1, data_format='NCHW', channel_dim=1, op_type='conv2d', use_cudnn=True)
+        var_12 = paddle.nn.functional.conv._conv_nd(
+            var_11,
+            self.parameter_0,
+            bias=self.parameter_11,
+            stride=[8, 8],
+            padding=[0, 0],
+            padding_algorithm="EXPLICIT",
+            dilation=[1, 1],
+            groups=1,
+            data_format="NCHW",
+            channel_dim=1,
+            op_type="conv2d",
+            use_cudnn=True,
+        )
         var_13 = var_12.reshape([var_5, 32, -1])
         var_14 = var_13.transpose([0, 2, 1])
-        var_15 = paddle.nn.functional.norm.layer_norm(var_14, normalized_shape=[32], weight=self.parameter_6, bias=self.parameter_4, epsilon=1e-05)
-        var_16 = paddle.nn.functional.common.linear(x=var_15, weight=self.parameter_3, bias=self.parameter_10, name=None)
+        var_15 = paddle.nn.functional.norm.layer_norm(
+            var_14, normalized_shape=[32], weight=self.parameter_6, bias=self.parameter_4, epsilon=1e-05
+        )
+        var_16 = paddle.nn.functional.common.linear(
+            x=var_15, weight=self.parameter_3, bias=self.parameter_10, name=None
+        )
         var_17 = var_16.reshape([var_5, -1, 2, 1, 32])
         var_18 = var_17.transpose([2, 0, 3, 1, 4])
         var_19 = var_18.__getitem__(0)
@@ -83,29 +103,33 @@ class LayerCase(paddle.nn.Layer):
         var_22 = var_9.__matmul__(var_21)
         var_23 = var_22.__mul__(0.1767766952966369)
         var_24 = paddle.nn.functional.activation.softmax(var_23, axis=-1)
-        var_25 = paddle.nn.functional.common.dropout(var_24, p=0.0, axis=None, training=True, mode='upscale_in_train', name=None)
+        var_25 = paddle.nn.functional.common.dropout(
+            var_24, p=0.0, axis=None, training=True, mode="upscale_in_train", name=None
+        )
         var_26 = var_25.__matmul__(var_20)
         var_27 = var_26.transpose([0, 2, 1, 3])
         var_28 = var_27.reshape([var_5, var_6, 32])
         var_29 = paddle.nn.functional.common.linear(x=var_28, weight=self.parameter_7, bias=self.parameter_1, name=None)
-        var_30 = paddle.nn.functional.common.dropout(var_29, p=0.0, axis=None, training=True, mode='upscale_in_train', name=None)
+        var_30 = paddle.nn.functional.common.dropout(
+            var_29, p=0.0, axis=None, training=True, mode="upscale_in_train", name=None
+        )
         return var_30
 
 
 def create_tensor_inputs():
     inputs = (
         paddle.rand(shape=[1, 32768, 32], dtype=paddle.float32),
-        paddle.randint(low=0, high=10, shape=[1], dtype=paddle.int32),
-        paddle.randint(low=0, high=10, shape=[1], dtype=paddle.int32),
+        paddle.to_tensor(128, dtype=paddle.int32),
+        paddle.to_tensor(256, dtype=paddle.int32),
     )
     return inputs
 
 
 def create_numpy_inputs():
     inputs = (
-        np.random.random(size=[1, 32768, 32]).astype('float32'),
-        np.random.randint(low=0, high=10, size=[1], dtype='int32'),
-        np.random.randint(low=0, high=10, size=[1], dtype='int32'),
+        np.random.random(size=[1, 32768, 32]).astype("float32"),
+        np.array(128, dtype="int32"),
+        np.array(256, dtype="int32"),
     )
     return inputs
 
@@ -114,9 +138,10 @@ class TestLayer(unittest.TestCase):
     def setUp(self):
         self.inputs = create_tensor_inputs()
         self.net = LayerCase()
+
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.set_flags({"FLAGS_prim_all": with_prim})
             if with_cinn:
                 build_strategy = paddle.static.BuildStrategy()
                 build_strategy.build_cinn_pass = True
@@ -126,6 +151,7 @@ class TestLayer(unittest.TestCase):
         paddle.seed(123)
         outs = net(*self.inputs)
         return outs
+
     def test_ast_prim_cinn(self):
         st_out = self.train(self.net, to_static=True)
         cinn_out = self.train(self.net, to_static=True, with_prim=True, with_cinn=True)
@@ -133,5 +159,5 @@ class TestLayer(unittest.TestCase):
             np.testing.assert_allclose(st.numpy(), cinn.numpy(), atol=1e-8)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/segformer_segformer_b3_cityscapes_1024x1024_160k/SIR_104.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/segformer_segformer_b3_cityscapes_1024x1024_160k/SIR_104.py
@@ -8,65 +8,83 @@ class LayerCase(paddle.nn.Layer):
     def __init__(self):
         super().__init__()
         self.parameter_0 = self.create_parameter(
-           shape=[512],
-           dtype=paddle.float32,
+            shape=[512],
+            dtype=paddle.float32,
         )
         self.parameter_1 = self.create_parameter(
-           shape=[512, 320, 3, 3],
-           dtype=paddle.float32,
+            shape=[512, 320, 3, 3],
+            dtype=paddle.float32,
         )
         self.parameter_2 = self.create_parameter(
-           shape=[512],
-           dtype=paddle.float32,
+            shape=[512],
+            dtype=paddle.float32,
         )
         self.parameter_3 = self.create_parameter(
-           shape=[320],
-           dtype=paddle.float32,
+            shape=[320],
+            dtype=paddle.float32,
         )
         self.parameter_4 = self.create_parameter(
-           shape=[320],
-           dtype=paddle.float32,
+            shape=[320],
+            dtype=paddle.float32,
         )
         self.parameter_5 = self.create_parameter(
-           shape=[512],
-           dtype=paddle.float32,
+            shape=[512],
+            dtype=paddle.float32,
         )
+
     def forward(
         self,
-        var_0,    # (shape: [1, 4096, 320], dtype: paddle.float32, stop_gradient: False)
-        var_1,    # (shape: [], dtype: paddle.int32, stop_gradient: True)
-        var_2,    # (shape: [], dtype: paddle.int32, stop_gradient: True)
-        var_3,    # (shape: [], dtype: paddle.int32, stop_gradient: True)
+        var_0,  # (shape: [1, 4096, 320], dtype: paddle.float32, stop_gradient: False)
+        var_1,  # (shape: [], dtype: paddle.int32, stop_gradient: True)
+        var_2,  # (shape: [], dtype: paddle.int32, stop_gradient: True)
+        var_3,  # (shape: [], dtype: paddle.int32, stop_gradient: True)
     ):
-        var_4 = paddle.nn.functional.norm.layer_norm(var_0, normalized_shape=[320], weight=self.parameter_4, bias=self.parameter_3, epsilon=1e-06)
+        var_4 = paddle.nn.functional.norm.layer_norm(
+            var_0, normalized_shape=[320], weight=self.parameter_4, bias=self.parameter_3, epsilon=1e-06
+        )
         var_5 = var_4.reshape([var_1, var_2, var_3, 320])
         var_6 = var_5.transpose([0, 3, 1, 2])
-        var_7 = paddle.nn.functional.conv._conv_nd(var_6, self.parameter_1, bias=self.parameter_0, stride=[2, 2], padding=[1, 1], padding_algorithm='EXPLICIT', dilation=[1, 1], groups=1, data_format='NCHW', channel_dim=1, op_type='conv2d', use_cudnn=True)
+        var_7 = paddle.nn.functional.conv._conv_nd(
+            var_6,
+            self.parameter_1,
+            bias=self.parameter_0,
+            stride=[2, 2],
+            padding=[1, 1],
+            padding_algorithm="EXPLICIT",
+            dilation=[1, 1],
+            groups=1,
+            data_format="NCHW",
+            channel_dim=1,
+            op_type="conv2d",
+            use_cudnn=True,
+        )
         var_8 = var_7.shape
         var_9 = var_8.__getitem__(2)
         var_10 = var_8.__getitem__(3)
         var_11 = var_7.flatten(2)
         var_12 = var_11.transpose([0, 2, 1])
-        var_13 = paddle.nn.functional.norm.layer_norm(var_12, normalized_shape=[512], weight=self.parameter_2, bias=self.parameter_5, epsilon=1e-05)
+        var_13 = paddle.nn.functional.norm.layer_norm(
+            var_12, normalized_shape=[512], weight=self.parameter_2, bias=self.parameter_5, epsilon=1e-05
+        )
         return var_13, var_9, var_10, var_6
 
 
 def create_tensor_inputs():
     inputs = (
         paddle.rand(shape=[1, 4096, 320], dtype=paddle.float32),
-        paddle.randint(low=0, high=10, shape=[1], dtype=paddle.int32),
-        paddle.randint(low=0, high=10, shape=[1], dtype=paddle.int32),
-        paddle.randint(low=0, high=10, shape=[1], dtype=paddle.int32),
+        paddle.to_tensor(4, dtype=paddle.int32),
+        paddle.to_tensor(16, dtype=paddle.int32),
+        paddle.to_tensor(64, dtype=paddle.int32),
     )
     return inputs
 
 
 def create_numpy_inputs():
     inputs = (
-        np.random.random(size=[1, 4096, 320]).astype('float32'),
-        np.random.randint(low=0, high=10, size=[1], dtype='int32'),
-        np.random.randint(low=0, high=10, size=[1], dtype='int32'),
-        np.random.randint(low=0, high=10, size=[1], dtype='int32'),
+        np.random.random(size=[1, 4096, 320]).astype("float32"),
+        np.array(4, dtype="int32"),
+        np.array(16, dtype="int32"),
+        np.array(64, dtype="int32"),
     )
     return inputs
 
@@ -75,9 +93,10 @@ class TestLayer(unittest.TestCase):
     def setUp(self):
         self.inputs = create_tensor_inputs()
         self.net = LayerCase()
+
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.set_flags({"FLAGS_prim_all": with_prim})
             if with_cinn:
                 build_strategy = paddle.static.BuildStrategy()
                 build_strategy.build_cinn_pass = True
@@ -87,6 +106,7 @@ class TestLayer(unittest.TestCase):
         paddle.seed(123)
         outs = net(*self.inputs)
         return outs
+
     def test_ast_prim_cinn(self):
         st_out = self.train(self.net, to_static=True)
         cinn_out = self.train(self.net, to_static=True, with_prim=True, with_cinn=True)
@@ -94,5 +114,5 @@ class TestLayer(unittest.TestCase):
             np.testing.assert_allclose(st.numpy(), cinn.numpy(), atol=1e-8)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/segformer_segformer_b3_cityscapes_1024x1024_160k/SIR_16.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/segformer_segformer_b3_cityscapes_1024x1024_160k/SIR_16.py
@@ -8,65 +8,83 @@ class LayerCase(paddle.nn.Layer):
     def __init__(self):
         super().__init__()
         self.parameter_0 = self.create_parameter(
-           shape=[128],
-           dtype=paddle.float32,
+            shape=[128],
+            dtype=paddle.float32,
         )
         self.parameter_1 = self.create_parameter(
-           shape=[64],
-           dtype=paddle.float32,
+            shape=[64],
+            dtype=paddle.float32,
         )
         self.parameter_2 = self.create_parameter(
-           shape=[64],
-           dtype=paddle.float32,
+            shape=[64],
+            dtype=paddle.float32,
         )
         self.parameter_3 = self.create_parameter(
-           shape=[128],
-           dtype=paddle.float32,
+            shape=[128],
+            dtype=paddle.float32,
         )
         self.parameter_4 = self.create_parameter(
-           shape=[128, 64, 3, 3],
-           dtype=paddle.float32,
+            shape=[128, 64, 3, 3],
+            dtype=paddle.float32,
         )
         self.parameter_5 = self.create_parameter(
-           shape=[128],
-           dtype=paddle.float32,
+            shape=[128],
+            dtype=paddle.float32,
         )
+
     def forward(
         self,
-        var_0,    # (shape: [1, 65536, 64], dtype: paddle.float32, stop_gradient: False)
-        var_1,    # (shape: [], dtype: paddle.int32, stop_gradient: True)
-        var_2,    # (shape: [], dtype: paddle.int32, stop_gradient: True)
-        var_3,    # (shape: [], dtype: paddle.int32, stop_gradient: True)
+        var_0,  # (shape: [1, 65536, 64], dtype: paddle.float32, stop_gradient: False)
+        var_1,  # (shape: [], dtype: paddle.int32, stop_gradient: True)
+        var_2,  # (shape: [], dtype: paddle.int32, stop_gradient: True)
+        var_3,  # (shape: [], dtype: paddle.int32, stop_gradient: True)
     ):
-        var_4 = paddle.nn.functional.norm.layer_norm(var_0, normalized_shape=[64], weight=self.parameter_1, bias=self.parameter_2, epsilon=1e-06)
+        var_4 = paddle.nn.functional.norm.layer_norm(
+            var_0, normalized_shape=[64], weight=self.parameter_1, bias=self.parameter_2, epsilon=1e-06
+        )
         var_5 = var_4.reshape([var_1, var_2, var_3, 64])
         var_6 = var_5.transpose([0, 3, 1, 2])
-        var_7 = paddle.nn.functional.conv._conv_nd(var_6, self.parameter_4, bias=self.parameter_3, stride=[2, 2], padding=[1, 1], padding_algorithm='EXPLICIT', dilation=[1, 1], groups=1, data_format='NCHW', channel_dim=1, op_type='conv2d', use_cudnn=True)
+        var_7 = paddle.nn.functional.conv._conv_nd(
+            var_6,
+            self.parameter_4,
+            bias=self.parameter_3,
+            stride=[2, 2],
+            padding=[1, 1],
+            padding_algorithm="EXPLICIT",
+            dilation=[1, 1],
+            groups=1,
+            data_format="NCHW",
+            channel_dim=1,
+            op_type="conv2d",
+            use_cudnn=True,
+        )
         var_8 = var_7.shape
         var_9 = var_8.__getitem__(2)
         var_10 = var_8.__getitem__(3)
         var_11 = var_7.flatten(2)
         var_12 = var_11.transpose([0, 2, 1])
-        var_13 = paddle.nn.functional.norm.layer_norm(var_12, normalized_shape=[128], weight=self.parameter_0, bias=self.parameter_5, epsilon=1e-05)
+        var_13 = paddle.nn.functional.norm.layer_norm(
+            var_12, normalized_shape=[128], weight=self.parameter_0, bias=self.parameter_5, epsilon=1e-05
+        )
         return var_13, var_9, var_10, var_6
 
 
 def create_tensor_inputs():
     inputs = (
         paddle.rand(shape=[1, 65536, 64], dtype=paddle.float32),
-        paddle.randint(low=0, high=10, shape=[1], dtype=paddle.int32),
-        paddle.randint(low=0, high=10, shape=[1], dtype=paddle.int32),
-        paddle.randint(low=0, high=10, shape=[1], dtype=paddle.int32),
+        paddle.to_tensor(16, dtype=paddle.int32),
+        paddle.to_tensor(32, dtype=paddle.int32),
+        paddle.to_tensor(128, dtype=paddle.int32),
     )
     return inputs
 
 
 def create_numpy_inputs():
     inputs = (
-        np.random.random(size=[1, 65536, 64]).astype('float32'),
-        np.random.randint(low=0, high=10, size=[1], dtype='int32'),
-        np.random.randint(low=0, high=10, size=[1], dtype='int32'),
-        np.random.randint(low=0, high=10, size=[1], dtype='int32'),
+        np.random.random(size=[1, 65536, 64]).astype("float32"),
+        np.array(16, dtype="int32"),
+        np.array(32, dtype="int32"),
+        np.array(128, dtype="int32"),
     )
     return inputs
 
@@ -75,9 +93,10 @@ class TestLayer(unittest.TestCase):
     def setUp(self):
         self.inputs = create_tensor_inputs()
         self.net = LayerCase()
+
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.set_flags({"FLAGS_prim_all": with_prim})
             if with_cinn:
                 build_strategy = paddle.static.BuildStrategy()
                 build_strategy.build_cinn_pass = True
@@ -87,6 +106,7 @@ class TestLayer(unittest.TestCase):
         paddle.seed(123)
         outs = net(*self.inputs)
         return outs
+
     def test_ast_prim_cinn(self):
         st_out = self.train(self.net, to_static=True)
         cinn_out = self.train(self.net, to_static=True, with_prim=True, with_cinn=True)
@@ -94,5 +114,5 @@ class TestLayer(unittest.TestCase):
             np.testing.assert_allclose(st.numpy(), cinn.numpy(), atol=1e-8)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/segformer_segformer_b3_cityscapes_1024x1024_160k/SIR_18.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/segformer_segformer_b3_cityscapes_1024x1024_160k/SIR_18.py
@@ -8,60 +8,63 @@ class LayerCase(paddle.nn.Layer):
     def __init__(self):
         super().__init__()
         self.parameter_0 = self.create_parameter(
-           shape=[128],
-           dtype=paddle.float32,
+            shape=[128],
+            dtype=paddle.float32,
         )
         self.parameter_1 = self.create_parameter(
-           shape=[128, 128],
-           dtype=paddle.float32,
+            shape=[128, 128],
+            dtype=paddle.float32,
         )
         self.parameter_2 = self.create_parameter(
-           shape=[128],
-           dtype=paddle.float32,
+            shape=[128],
+            dtype=paddle.float32,
         )
         self.parameter_3 = self.create_parameter(
-           shape=[128],
-           dtype=paddle.float32,
+            shape=[128],
+            dtype=paddle.float32,
         )
         self.parameter_4 = self.create_parameter(
-           shape=[128],
-           dtype=paddle.float32,
+            shape=[128],
+            dtype=paddle.float32,
         )
         self.parameter_5 = self.create_parameter(
-           shape=[128, 128, 4, 4],
-           dtype=paddle.float32,
+            shape=[128, 128, 4, 4],
+            dtype=paddle.float32,
         )
         self.parameter_6 = self.create_parameter(
-           shape=[128],
-           dtype=paddle.float32,
+            shape=[128],
+            dtype=paddle.float32,
         )
         self.parameter_7 = self.create_parameter(
-           shape=[128, 256],
-           dtype=paddle.float32,
+            shape=[128, 256],
+            dtype=paddle.float32,
         )
         self.parameter_8 = self.create_parameter(
-           shape=[128, 128],
-           dtype=paddle.float32,
+            shape=[128, 128],
+            dtype=paddle.float32,
         )
         self.parameter_9 = self.create_parameter(
-           shape=[128],
-           dtype=paddle.float32,
+            shape=[128],
+            dtype=paddle.float32,
         )
         self.parameter_10 = self.create_parameter(
-           shape=[128],
-           dtype=paddle.float32,
+            shape=[128],
+            dtype=paddle.float32,
         )
         self.parameter_11 = self.create_parameter(
-           shape=[256],
-           dtype=paddle.float32,
+            shape=[256],
+            dtype=paddle.float32,
         )
+
     def forward(
         self,
-        var_0,    # (shape: [1, 16384, 128], dtype: paddle.float32, stop_gradient: False)
-        var_1,    # (shape: [], dtype: paddle.int32, stop_gradient: True)
-        var_2,    # (shape: [], dtype: paddle.int32, stop_gradient: True)
+        var_0,  # (shape: [1, 16384, 128], dtype: paddle.float32, stop_gradient: False)
+        var_1,  # (shape: [], dtype: paddle.int32, stop_gradient: True)
+        var_2,  # (shape: [], dtype: paddle.int32, stop_gradient: True)
     ):
-        var_3 = paddle.nn.functional.norm.layer_norm(var_0, normalized_shape=[128], weight=self.parameter_9, bias=self.parameter_3, epsilon=1e-06)
+        var_3 = paddle.nn.functional.norm.layer_norm(
+            var_0, normalized_shape=[128], weight=self.parameter_9, bias=self.parameter_3, epsilon=1e-06
+        )
         var_4 = var_3.shape
         var_5 = var_4.__getitem__(0)
         var_6 = var_4.__getitem__(1)
@@ -70,11 +73,28 @@ class LayerCase(paddle.nn.Layer):
         var_9 = var_8.transpose([0, 2, 1, 3])
         var_10 = var_3.transpose([0, 2, 1])
         var_11 = var_10.reshape([var_5, 128, var_1, var_2])
-        var_12 = paddle.nn.functional.conv._conv_nd(var_11, self.parameter_5, bias=self.parameter_4, stride=[4, 4], padding=[0, 0], padding_algorithm='EXPLICIT', dilation=[1, 1], groups=1, data_format='NCHW', channel_dim=1, op_type='conv2d', use_cudnn=True)
+        var_12 = paddle.nn.functional.conv._conv_nd(
+            var_11,
+            self.parameter_5,
+            bias=self.parameter_4,
+            stride=[4, 4],
+            padding=[0, 0],
+            padding_algorithm="EXPLICIT",
+            dilation=[1, 1],
+            groups=1,
+            data_format="NCHW",
+            channel_dim=1,
+            op_type="conv2d",
+            use_cudnn=True,
+        )
         var_13 = var_12.reshape([var_5, 128, -1])
         var_14 = var_13.transpose([0, 2, 1])
-        var_15 = paddle.nn.functional.norm.layer_norm(var_14, normalized_shape=[128], weight=self.parameter_0, bias=self.parameter_6, epsilon=1e-05)
-        var_16 = paddle.nn.functional.common.linear(x=var_15, weight=self.parameter_7, bias=self.parameter_11, name=None)
+        var_15 = paddle.nn.functional.norm.layer_norm(
+            var_14, normalized_shape=[128], weight=self.parameter_0, bias=self.parameter_6, epsilon=1e-05
+        )
+        var_16 = paddle.nn.functional.common.linear(
+            x=var_15, weight=self.parameter_7, bias=self.parameter_11, name=None
+        )
         var_17 = var_16.reshape([var_5, -1, 2, 2, 64])
         var_18 = var_17.transpose([2, 0, 3, 1, 4])
         var_19 = var_18.__getitem__(0)
@@ -83,29 +103,35 @@ class LayerCase(paddle.nn.Layer):
         var_22 = var_9.__matmul__(var_21)
         var_23 = var_22.__mul__(0.125)
         var_24 = paddle.nn.functional.activation.softmax(var_23, axis=-1)
-        var_25 = paddle.nn.functional.common.dropout(var_24, p=0.0, axis=None, training=True, mode='upscale_in_train', name=None)
+        var_25 = paddle.nn.functional.common.dropout(
+            var_24, p=0.0, axis=None, training=True, mode="upscale_in_train", name=None
+        )
         var_26 = var_25.__matmul__(var_20)
         var_27 = var_26.transpose([0, 2, 1, 3])
         var_28 = var_27.reshape([var_5, var_6, 128])
-        var_29 = paddle.nn.functional.common.linear(x=var_28, weight=self.parameter_1, bias=self.parameter_10, name=None)
-        var_30 = paddle.nn.functional.common.dropout(var_29, p=0.0, axis=None, training=True, mode='upscale_in_train', name=None)
+        var_29 = paddle.nn.functional.common.linear(
+            x=var_28, weight=self.parameter_1, bias=self.parameter_10, name=None
+        )
+        var_30 = paddle.nn.functional.common.dropout(
+            var_29, p=0.0, axis=None, training=True, mode="upscale_in_train", name=None
+        )
         return var_30
 
 
 def create_tensor_inputs():
     inputs = (
         paddle.rand(shape=[1, 16384, 128], dtype=paddle.float32),
-        paddle.randint(low=0, high=10, shape=[1], dtype=paddle.int32),
-        paddle.randint(low=0, high=10, shape=[1], dtype=paddle.int32),
+        paddle.to_tensor(64, dtype=paddle.int32),
+        paddle.to_tensor(256, dtype=paddle.int32),
     )
     return inputs
 
 
 def create_numpy_inputs():
     inputs = (
-        np.random.random(size=[1, 16384, 128]).astype('float32'),
-        np.random.randint(low=0, high=10, size=[1], dtype='int32'),
-        np.random.randint(low=0, high=10, size=[1], dtype='int32'),
+        np.random.random(size=[1, 16384, 128]).astype("float32"),
+        np.array(64, dtype="int32"),
+        np.array(256, dtype="int32"),
     )
     return inputs
 
@@ -114,9 +140,10 @@ class TestLayer(unittest.TestCase):
     def setUp(self):
         self.inputs = create_tensor_inputs()
         self.net = LayerCase()
+
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.set_flags({"FLAGS_prim_all": with_prim})
             if with_cinn:
                 build_strategy = paddle.static.BuildStrategy()
                 build_strategy.build_cinn_pass = True
@@ -126,6 +153,7 @@ class TestLayer(unittest.TestCase):
         paddle.seed(123)
         outs = net(*self.inputs)
         return outs
+
     def test_ast_prim_cinn(self):
         st_out = self.train(self.net, to_static=True)
         cinn_out = self.train(self.net, to_static=True, with_prim=True, with_cinn=True)
@@ -133,5 +161,5 @@ class TestLayer(unittest.TestCase):
             np.testing.assert_allclose(st.numpy(), cinn.numpy(), atol=1e-8)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/segformer_segformer_b3_cityscapes_1024x1024_160k/SIR_36.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/segformer_segformer_b3_cityscapes_1024x1024_160k/SIR_36.py
@@ -8,65 +8,83 @@ class LayerCase(paddle.nn.Layer):
     def __init__(self):
         super().__init__()
         self.parameter_0 = self.create_parameter(
-           shape=[128],
-           dtype=paddle.float32,
+            shape=[128],
+            dtype=paddle.float32,
         )
         self.parameter_1 = self.create_parameter(
-           shape=[128],
-           dtype=paddle.float32,
+            shape=[128],
+            dtype=paddle.float32,
         )
         self.parameter_2 = self.create_parameter(
-           shape=[320],
-           dtype=paddle.float32,
+            shape=[320],
+            dtype=paddle.float32,
         )
         self.parameter_3 = self.create_parameter(
-           shape=[320],
-           dtype=paddle.float32,
+            shape=[320],
+            dtype=paddle.float32,
         )
         self.parameter_4 = self.create_parameter(
-           shape=[320, 128, 3, 3],
-           dtype=paddle.float32,
+            shape=[320, 128, 3, 3],
+            dtype=paddle.float32,
         )
         self.parameter_5 = self.create_parameter(
-           shape=[320],
-           dtype=paddle.float32,
+            shape=[320],
+            dtype=paddle.float32,
         )
+
     def forward(
         self,
-        var_0,    # (shape: [1, 16384, 128], dtype: paddle.float32, stop_gradient: False)
-        var_1,    # (shape: [], dtype: paddle.int32, stop_gradient: True)
-        var_2,    # (shape: [], dtype: paddle.int32, stop_gradient: True)
-        var_3,    # (shape: [], dtype: paddle.int32, stop_gradient: True)
+        var_0,  # (shape: [1, 16384, 128], dtype: paddle.float32, stop_gradient: False)
+        var_1,  # (shape: [], dtype: paddle.int32, stop_gradient: True)
+        var_2,  # (shape: [], dtype: paddle.int32, stop_gradient: True)
+        var_3,  # (shape: [], dtype: paddle.int32, stop_gradient: True)
     ):
-        var_4 = paddle.nn.functional.norm.layer_norm(var_0, normalized_shape=[128], weight=self.parameter_1, bias=self.parameter_0, epsilon=1e-06)
+        var_4 = paddle.nn.functional.norm.layer_norm(
+            var_0, normalized_shape=[128], weight=self.parameter_1, bias=self.parameter_0, epsilon=1e-06
+        )
         var_5 = var_4.reshape([var_1, var_2, var_3, 128])
         var_6 = var_5.transpose([0, 3, 1, 2])
-        var_7 = paddle.nn.functional.conv._conv_nd(var_6, self.parameter_4, bias=self.parameter_2, stride=[2, 2], padding=[1, 1], padding_algorithm='EXPLICIT', dilation=[1, 1], groups=1, data_format='NCHW', channel_dim=1, op_type='conv2d', use_cudnn=True)
+        var_7 = paddle.nn.functional.conv._conv_nd(
+            var_6,
+            self.parameter_4,
+            bias=self.parameter_2,
+            stride=[2, 2],
+            padding=[1, 1],
+            padding_algorithm="EXPLICIT",
+            dilation=[1, 1],
+            groups=1,
+            data_format="NCHW",
+            channel_dim=1,
+            op_type="conv2d",
+            use_cudnn=True,
+        )
         var_8 = var_7.shape
         var_9 = var_8.__getitem__(2)
         var_10 = var_8.__getitem__(3)
         var_11 = var_7.flatten(2)
         var_12 = var_11.transpose([0, 2, 1])
-        var_13 = paddle.nn.functional.norm.layer_norm(var_12, normalized_shape=[320], weight=self.parameter_3, bias=self.parameter_5, epsilon=1e-05)
+        var_13 = paddle.nn.functional.norm.layer_norm(
+            var_12, normalized_shape=[320], weight=self.parameter_3, bias=self.parameter_5, epsilon=1e-05
+        )
         return var_13, var_9, var_10, var_6
 
 
 def create_tensor_inputs():
     inputs = (
         paddle.rand(shape=[1, 16384, 128], dtype=paddle.float32),
-        paddle.randint(low=0, high=10, shape=[1], dtype=paddle.int32),
-        paddle.randint(low=0, high=10, shape=[1], dtype=paddle.int32),
-        paddle.randint(low=0, high=10, shape=[1], dtype=paddle.int32),
+        paddle.to_tensor(128, dtype=paddle.int32),
+        paddle.to_tensor(16, dtype=paddle.int32),
+        paddle.to_tensor(8, dtype=paddle.int32),
     )
     return inputs
 
 
 def create_numpy_inputs():
     inputs = (
-        np.random.random(size=[1, 16384, 128]).astype('float32'),
-        np.random.randint(low=0, high=10, size=[1], dtype='int32'),
-        np.random.randint(low=0, high=10, size=[1], dtype='int32'),
-        np.random.randint(low=0, high=10, size=[1], dtype='int32'),
+        np.random.random(size=[1, 16384, 128]).astype("float32"),
+        np.array([128], dtype="int32"),
+        np.array([16], dtype="int32"),
+        np.array([8], dtype="int32"),
     )
     return inputs
 
@@ -75,9 +93,10 @@ class TestLayer(unittest.TestCase):
     def setUp(self):
         self.inputs = create_tensor_inputs()
         self.net = LayerCase()
+
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.set_flags({"FLAGS_prim_all": with_prim})
             if with_cinn:
                 build_strategy = paddle.static.BuildStrategy()
                 build_strategy.build_cinn_pass = True
@@ -87,6 +106,7 @@ class TestLayer(unittest.TestCase):
         paddle.seed(123)
         outs = net(*self.inputs)
         return outs
+
     def test_ast_prim_cinn(self):
         st_out = self.train(self.net, to_static=True)
         cinn_out = self.train(self.net, to_static=True, with_prim=True, with_cinn=True)
@@ -94,5 +114,5 @@ class TestLayer(unittest.TestCase):
             np.testing.assert_allclose(st.numpy(), cinn.numpy(), atol=1e-8)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/segformer_segformer_b3_cityscapes_1024x1024_160k/SIR_38.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/segformer_segformer_b3_cityscapes_1024x1024_160k/SIR_38.py
@@ -8,60 +8,63 @@ class LayerCase(paddle.nn.Layer):
     def __init__(self):
         super().__init__()
         self.parameter_0 = self.create_parameter(
-           shape=[320],
-           dtype=paddle.float32,
+            shape=[320],
+            dtype=paddle.float32,
         )
         self.parameter_1 = self.create_parameter(
-           shape=[320, 640],
-           dtype=paddle.float32,
+            shape=[320, 640],
+            dtype=paddle.float32,
         )
         self.parameter_2 = self.create_parameter(
-           shape=[320],
-           dtype=paddle.float32,
+            shape=[320],
+            dtype=paddle.float32,
         )
         self.parameter_3 = self.create_parameter(
-           shape=[320],
-           dtype=paddle.float32,
+            shape=[320],
+            dtype=paddle.float32,
         )
         self.parameter_4 = self.create_parameter(
-           shape=[320],
-           dtype=paddle.float32,
+            shape=[320],
+            dtype=paddle.float32,
         )
         self.parameter_5 = self.create_parameter(
-           shape=[640],
-           dtype=paddle.float32,
+            shape=[640],
+            dtype=paddle.float32,
         )
         self.parameter_6 = self.create_parameter(
-           shape=[320],
-           dtype=paddle.float32,
+            shape=[320],
+            dtype=paddle.float32,
         )
         self.parameter_7 = self.create_parameter(
-           shape=[320],
-           dtype=paddle.float32,
+            shape=[320],
+            dtype=paddle.float32,
         )
         self.parameter_8 = self.create_parameter(
-           shape=[320, 320],
-           dtype=paddle.float32,
+            shape=[320, 320],
+            dtype=paddle.float32,
         )
         self.parameter_9 = self.create_parameter(
-           shape=[320],
-           dtype=paddle.float32,
+            shape=[320],
+            dtype=paddle.float32,
         )
         self.parameter_10 = self.create_parameter(
-           shape=[320, 320, 2, 2],
-           dtype=paddle.float32,
+            shape=[320, 320, 2, 2],
+            dtype=paddle.float32,
         )
         self.parameter_11 = self.create_parameter(
-           shape=[320, 320],
-           dtype=paddle.float32,
+            shape=[320, 320],
+            dtype=paddle.float32,
         )
+
     def forward(
         self,
-        var_0,    # (shape: [1, 4096, 320], dtype: paddle.float32, stop_gradient: False)
-        var_1,    # (shape: [], dtype: paddle.int32, stop_gradient: True)
-        var_2,    # (shape: [], dtype: paddle.int32, stop_gradient: True)
+        var_0,  # (shape: [1, 4096, 320], dtype: paddle.float32, stop_gradient: False)
+        var_1,  # (shape: [], dtype: paddle.int32, stop_gradient: True)
+        var_2,  # (shape: [], dtype: paddle.int32, stop_gradient: True)
     ):
-        var_3 = paddle.nn.functional.norm.layer_norm(var_0, normalized_shape=[320], weight=self.parameter_6, bias=self.parameter_3, epsilon=1e-06)
+        var_3 = paddle.nn.functional.norm.layer_norm(
+            var_0, normalized_shape=[320], weight=self.parameter_6, bias=self.parameter_3, epsilon=1e-06
+        )
         var_4 = var_3.shape
         var_5 = var_4.__getitem__(0)
         var_6 = var_4.__getitem__(1)
@@ -70,10 +73,25 @@ class LayerCase(paddle.nn.Layer):
         var_9 = var_8.transpose([0, 2, 1, 3])
         var_10 = var_3.transpose([0, 2, 1])
         var_11 = var_10.reshape([var_5, 320, var_1, var_2])
-        var_12 = paddle.nn.functional.conv._conv_nd(var_11, self.parameter_10, bias=self.parameter_2, stride=[2, 2], padding=[0, 0], padding_algorithm='EXPLICIT', dilation=[1, 1], groups=1, data_format='NCHW', channel_dim=1, op_type='conv2d', use_cudnn=True)
+        var_12 = paddle.nn.functional.conv._conv_nd(
+            var_11,
+            self.parameter_10,
+            bias=self.parameter_2,
+            stride=[2, 2],
+            padding=[0, 0],
+            padding_algorithm="EXPLICIT",
+            dilation=[1, 1],
+            groups=1,
+            data_format="NCHW",
+            channel_dim=1,
+            op_type="conv2d",
+            use_cudnn=True,
+        )
         var_13 = var_12.reshape([var_5, 320, -1])
         var_14 = var_13.transpose([0, 2, 1])
-        var_15 = paddle.nn.functional.norm.layer_norm(var_14, normalized_shape=[320], weight=self.parameter_0, bias=self.parameter_9, epsilon=1e-05)
+        var_15 = paddle.nn.functional.norm.layer_norm(
+            var_14, normalized_shape=[320], weight=self.parameter_0, bias=self.parameter_9, epsilon=1e-05
+        )
         var_16 = paddle.nn.functional.common.linear(x=var_15, weight=self.parameter_1, bias=self.parameter_5, name=None)
         var_17 = var_16.reshape([var_5, -1, 2, 5, 64])
         var_18 = var_17.transpose([2, 0, 3, 1, 4])
@@ -83,29 +101,33 @@ class LayerCase(paddle.nn.Layer):
         var_22 = var_9.__matmul__(var_21)
         var_23 = var_22.__mul__(0.125)
         var_24 = paddle.nn.functional.activation.softmax(var_23, axis=-1)
-        var_25 = paddle.nn.functional.common.dropout(var_24, p=0.0, axis=None, training=True, mode='upscale_in_train', name=None)
+        var_25 = paddle.nn.functional.common.dropout(
+            var_24, p=0.0, axis=None, training=True, mode="upscale_in_train", name=None
+        )
         var_26 = var_25.__matmul__(var_20)
         var_27 = var_26.transpose([0, 2, 1, 3])
         var_28 = var_27.reshape([var_5, var_6, 320])
         var_29 = paddle.nn.functional.common.linear(x=var_28, weight=self.parameter_8, bias=self.parameter_7, name=None)
-        var_30 = paddle.nn.functional.common.dropout(var_29, p=0.0, axis=None, training=True, mode='upscale_in_train', name=None)
+        var_30 = paddle.nn.functional.common.dropout(
+            var_29, p=0.0, axis=None, training=True, mode="upscale_in_train", name=None
+        )
         return var_30
 
 
 def create_tensor_inputs():
     inputs = (
         paddle.rand(shape=[1, 4096, 320], dtype=paddle.float32),
-        paddle.randint(low=0, high=10, shape=[1], dtype=paddle.int32),
-        paddle.randint(low=0, high=10, shape=[1], dtype=paddle.int32),
+        paddle.to_tensor(32, dtype=paddle.int32),
+        paddle.to_tensor(128, dtype=paddle.int32),
     )
     return inputs
 
 
 def create_numpy_inputs():
     inputs = (
-        np.random.random(size=[1, 4096, 320]).astype('float32'),
-        np.random.randint(low=0, high=10, size=[1], dtype='int32'),
-        np.random.randint(low=0, high=10, size=[1], dtype='int32'),
+        np.random.random(size=[1, 4096, 320]).astype("float32"),
+        np.array(32, dtype="int32"),
+        np.array(128, dtype="int32"),
     )
     return inputs
 
@@ -114,9 +136,10 @@ class TestLayer(unittest.TestCase):
     def setUp(self):
         self.inputs = create_tensor_inputs()
         self.net = LayerCase()
+
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.set_flags({"FLAGS_prim_all": with_prim})
             if with_cinn:
                 build_strategy = paddle.static.BuildStrategy()
                 build_strategy.build_cinn_pass = True
@@ -126,6 +149,7 @@ class TestLayer(unittest.TestCase):
         paddle.seed(123)
         outs = net(*self.inputs)
         return outs
+
     def test_ast_prim_cinn(self):
         st_out = self.train(self.net, to_static=True)
         cinn_out = self.train(self.net, to_static=True, with_prim=True, with_cinn=True)
@@ -133,5 +157,5 @@ class TestLayer(unittest.TestCase):
             np.testing.assert_allclose(st.numpy(), cinn.numpy(), atol=1e-8)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/segformer_segformer_b3_cityscapes_1024x1024_160k/SIR_5.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/segformer_segformer_b3_cityscapes_1024x1024_160k/SIR_5.py
@@ -8,60 +8,63 @@ class LayerCase(paddle.nn.Layer):
     def __init__(self):
         super().__init__()
         self.parameter_0 = self.create_parameter(
-           shape=[64],
-           dtype=paddle.float32,
+            shape=[64],
+            dtype=paddle.float32,
         )
         self.parameter_1 = self.create_parameter(
-           shape=[64, 64, 8, 8],
-           dtype=paddle.float32,
+            shape=[64, 64, 8, 8],
+            dtype=paddle.float32,
         )
         self.parameter_2 = self.create_parameter(
-           shape=[64],
-           dtype=paddle.float32,
+            shape=[64],
+            dtype=paddle.float32,
         )
         self.parameter_3 = self.create_parameter(
-           shape=[64],
-           dtype=paddle.float32,
+            shape=[64],
+            dtype=paddle.float32,
         )
         self.parameter_4 = self.create_parameter(
-           shape=[64],
-           dtype=paddle.float32,
+            shape=[64],
+            dtype=paddle.float32,
         )
         self.parameter_5 = self.create_parameter(
-           shape=[64, 64],
-           dtype=paddle.float32,
+            shape=[64, 64],
+            dtype=paddle.float32,
         )
         self.parameter_6 = self.create_parameter(
-           shape=[64],
-           dtype=paddle.float32,
+            shape=[64],
+            dtype=paddle.float32,
         )
         self.parameter_7 = self.create_parameter(
-           shape=[64, 128],
-           dtype=paddle.float32,
+            shape=[64, 128],
+            dtype=paddle.float32,
         )
         self.parameter_8 = self.create_parameter(
-           shape=[64, 64],
-           dtype=paddle.float32,
+            shape=[64, 64],
+            dtype=paddle.float32,
         )
         self.parameter_9 = self.create_parameter(
-           shape=[64],
-           dtype=paddle.float32,
+            shape=[64],
+            dtype=paddle.float32,
         )
         self.parameter_10 = self.create_parameter(
-           shape=[128],
-           dtype=paddle.float32,
+            shape=[128],
+            dtype=paddle.float32,
         )
         self.parameter_11 = self.create_parameter(
-           shape=[64],
-           dtype=paddle.float32,
+            shape=[64],
+            dtype=paddle.float32,
         )
+
     def forward(
         self,
-        var_0,    # (shape: [1, 65536, 64], dtype: paddle.float32, stop_gradient: False)
-        var_1,    # (shape: [], dtype: paddle.int32, stop_gradient: True)
-        var_2,    # (shape: [], dtype: paddle.int32, stop_gradient: True)
+        var_0,  # (shape: [1, 65536, 64], dtype: paddle.float32, stop_gradient: False)
+        var_1,  # (shape: [], dtype: paddle.int32, stop_gradient: True)
+        var_2,  # (shape: [], dtype: paddle.int32, stop_gradient: True)
     ):
-        var_3 = paddle.nn.functional.norm.layer_norm(var_0, normalized_shape=[64], weight=self.parameter_2, bias=self.parameter_11, epsilon=1e-06)
+        var_3 = paddle.nn.functional.norm.layer_norm(
+            var_0, normalized_shape=[64], weight=self.parameter_2, bias=self.parameter_11, epsilon=1e-06
+        )
         var_4 = var_3.shape
         var_5 = var_4.__getitem__(0)
         var_6 = var_4.__getitem__(1)
@@ -70,11 +73,28 @@ class LayerCase(paddle.nn.Layer):
         var_9 = var_8.transpose([0, 2, 1, 3])
         var_10 = var_3.transpose([0, 2, 1])
         var_11 = var_10.reshape([var_5, 64, var_1, var_2])
-        var_12 = paddle.nn.functional.conv._conv_nd(var_11, self.parameter_1, bias=self.parameter_6, stride=[8, 8], padding=[0, 0], padding_algorithm='EXPLICIT', dilation=[1, 1], groups=1, data_format='NCHW', channel_dim=1, op_type='conv2d', use_cudnn=True)
+        var_12 = paddle.nn.functional.conv._conv_nd(
+            var_11,
+            self.parameter_1,
+            bias=self.parameter_6,
+            stride=[8, 8],
+            padding=[0, 0],
+            padding_algorithm="EXPLICIT",
+            dilation=[1, 1],
+            groups=1,
+            data_format="NCHW",
+            channel_dim=1,
+            op_type="conv2d",
+            use_cudnn=True,
+        )
         var_13 = var_12.reshape([var_5, 64, -1])
         var_14 = var_13.transpose([0, 2, 1])
-        var_15 = paddle.nn.functional.norm.layer_norm(var_14, normalized_shape=[64], weight=self.parameter_9, bias=self.parameter_4, epsilon=1e-05)
-        var_16 = paddle.nn.functional.common.linear(x=var_15, weight=self.parameter_7, bias=self.parameter_10, name=None)
+        var_15 = paddle.nn.functional.norm.layer_norm(
+            var_14, normalized_shape=[64], weight=self.parameter_9, bias=self.parameter_4, epsilon=1e-05
+        )
+        var_16 = paddle.nn.functional.common.linear(
+            x=var_15, weight=self.parameter_7, bias=self.parameter_10, name=None
+        )
         var_17 = var_16.reshape([var_5, -1, 2, 1, 64])
         var_18 = var_17.transpose([2, 0, 3, 1, 4])
         var_19 = var_18.__getitem__(0)
@@ -83,29 +103,33 @@ class LayerCase(paddle.nn.Layer):
         var_22 = var_9.__matmul__(var_21)
         var_23 = var_22.__mul__(0.125)
         var_24 = paddle.nn.functional.activation.softmax(var_23, axis=-1)
-        var_25 = paddle.nn.functional.common.dropout(var_24, p=0.0, axis=None, training=True, mode='upscale_in_train', name=None)
+        var_25 = paddle.nn.functional.common.dropout(
+            var_24, p=0.0, axis=None, training=True, mode="upscale_in_train", name=None
+        )
         var_26 = var_25.__matmul__(var_20)
         var_27 = var_26.transpose([0, 2, 1, 3])
         var_28 = var_27.reshape([var_5, var_6, 64])
         var_29 = paddle.nn.functional.common.linear(x=var_28, weight=self.parameter_8, bias=self.parameter_0, name=None)
-        var_30 = paddle.nn.functional.common.dropout(var_29, p=0.0, axis=None, training=True, mode='upscale_in_train', name=None)
+        var_30 = paddle.nn.functional.common.dropout(
+            var_29, p=0.0, axis=None, training=True, mode="upscale_in_train", name=None
+        )
         return var_30
 
 
 def create_tensor_inputs():
     inputs = (
         paddle.rand(shape=[1, 65536, 64], dtype=paddle.float32),
-        paddle.randint(low=0, high=10, shape=[1], dtype=paddle.int32),
-        paddle.randint(low=0, high=10, shape=[1], dtype=paddle.int32),
+        paddle.to_tensor(128, dtype=paddle.int32),
+        paddle.to_tensor(512, dtype=paddle.int32),
     )
     return inputs
 
 
 def create_numpy_inputs():
     inputs = (
-        np.random.random(size=[1, 65536, 64]).astype('float32'),
-        np.random.randint(low=0, high=10, size=[1], dtype='int32'),
-        np.random.randint(low=0, high=10, size=[1], dtype='int32'),
+        np.random.random(size=[1, 65536, 64]).astype("float32"),
+        np.array(128, dtype="int32"),
+        np.array(512, dtype="int32"),
     )
     return inputs
 
@@ -114,9 +138,10 @@ class TestLayer(unittest.TestCase):
     def setUp(self):
         self.inputs = create_tensor_inputs()
         self.net = LayerCase()
+
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.set_flags({"FLAGS_prim_all": with_prim})
             if with_cinn:
                 build_strategy = paddle.static.BuildStrategy()
                 build_strategy.build_cinn_pass = True
@@ -126,6 +151,7 @@ class TestLayer(unittest.TestCase):
         paddle.seed(123)
         outs = net(*self.inputs)
         return outs
+
     def test_ast_prim_cinn(self):
         st_out = self.train(self.net, to_static=True)
         cinn_out = self.train(self.net, to_static=True, with_prim=True, with_cinn=True)
@@ -133,5 +159,5 @@ class TestLayer(unittest.TestCase):
             np.testing.assert_allclose(st.numpy(), cinn.numpy(), atol=1e-8)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/segformer_segformer_b3_cityscapes_1024x512_160k/SIR_104.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/segformer_segformer_b3_cityscapes_1024x512_160k/SIR_104.py
@@ -8,65 +8,83 @@ class LayerCase(paddle.nn.Layer):
     def __init__(self):
         super().__init__()
         self.parameter_0 = self.create_parameter(
-           shape=[320],
-           dtype=paddle.float32,
+            shape=[320],
+            dtype=paddle.float32,
         )
         self.parameter_1 = self.create_parameter(
-           shape=[512, 320, 3, 3],
-           dtype=paddle.float32,
+            shape=[512, 320, 3, 3],
+            dtype=paddle.float32,
         )
         self.parameter_2 = self.create_parameter(
-           shape=[512],
-           dtype=paddle.float32,
+            shape=[512],
+            dtype=paddle.float32,
         )
         self.parameter_3 = self.create_parameter(
-           shape=[512],
-           dtype=paddle.float32,
+            shape=[512],
+            dtype=paddle.float32,
         )
         self.parameter_4 = self.create_parameter(
-           shape=[320],
-           dtype=paddle.float32,
+            shape=[320],
+            dtype=paddle.float32,
         )
         self.parameter_5 = self.create_parameter(
-           shape=[512],
-           dtype=paddle.float32,
+            shape=[512],
+            dtype=paddle.float32,
         )
+
     def forward(
         self,
-        var_0,    # (shape: [1, 2048, 320], dtype: paddle.float32, stop_gradient: False)
-        var_1,    # (shape: [], dtype: paddle.int32, stop_gradient: True)
-        var_2,    # (shape: [], dtype: paddle.int32, stop_gradient: True)
-        var_3,    # (shape: [], dtype: paddle.int32, stop_gradient: True)
+        var_0,  # (shape: [1, 2048, 320], dtype: paddle.float32, stop_gradient: False)
+        var_1,  # (shape: [], dtype: paddle.int32, stop_gradient: True)
+        var_2,  # (shape: [], dtype: paddle.int32, stop_gradient: True)
+        var_3,  # (shape: [], dtype: paddle.int32, stop_gradient: True)
     ):
-        var_4 = paddle.nn.functional.norm.layer_norm(var_0, normalized_shape=[320], weight=self.parameter_0, bias=self.parameter_4, epsilon=1e-06)
+        var_4 = paddle.nn.functional.norm.layer_norm(
+            var_0, normalized_shape=[320], weight=self.parameter_0, bias=self.parameter_4, epsilon=1e-06
+        )
         var_5 = var_4.reshape([var_1, var_2, var_3, 320])
         var_6 = var_5.transpose([0, 3, 1, 2])
-        var_7 = paddle.nn.functional.conv._conv_nd(var_6, self.parameter_1, bias=self.parameter_2, stride=[2, 2], padding=[1, 1], padding_algorithm='EXPLICIT', dilation=[1, 1], groups=1, data_format='NCHW', channel_dim=1, op_type='conv2d', use_cudnn=True)
+        var_7 = paddle.nn.functional.conv._conv_nd(
+            var_6,
+            self.parameter_1,
+            bias=self.parameter_2,
+            stride=[2, 2],
+            padding=[1, 1],
+            padding_algorithm="EXPLICIT",
+            dilation=[1, 1],
+            groups=1,
+            data_format="NCHW",
+            channel_dim=1,
+            op_type="conv2d",
+            use_cudnn=True,
+        )
         var_8 = var_7.shape
         var_9 = var_8.__getitem__(2)
         var_10 = var_8.__getitem__(3)
         var_11 = var_7.flatten(2)
         var_12 = var_11.transpose([0, 2, 1])
-        var_13 = paddle.nn.functional.norm.layer_norm(var_12, normalized_shape=[512], weight=self.parameter_3, bias=self.parameter_5, epsilon=1e-05)
+        var_13 = paddle.nn.functional.norm.layer_norm(
+            var_12, normalized_shape=[512], weight=self.parameter_3, bias=self.parameter_5, epsilon=1e-05
+        )
         return var_13, var_9, var_10, var_6
 
 
 def create_tensor_inputs():
     inputs = (
         paddle.rand(shape=[1, 2048, 320], dtype=paddle.float32),
-        paddle.randint(low=0, high=10, shape=[1], dtype=paddle.int32),
-        paddle.randint(low=0, high=10, shape=[1], dtype=paddle.int32),
-        paddle.randint(low=0, high=10, shape=[1], dtype=paddle.int32),
+        paddle.to_tensor(4, dtype=paddle.int32),
+        paddle.to_tensor(8, dtype=paddle.int32),
+        paddle.to_tensor(64, dtype=paddle.int32),
     )
     return inputs
 
 
 def create_numpy_inputs():
     inputs = (
-        np.random.random(size=[1, 2048, 320]).astype('float32'),
-        np.random.randint(low=0, high=10, size=[1], dtype='int32'),
-        np.random.randint(low=0, high=10, size=[1], dtype='int32'),
-        np.random.randint(low=0, high=10, size=[1], dtype='int32'),
+        np.random.random(size=[1, 2048, 320]).astype("float32"),
+        np.array(4, dtype="int32"),
+        np.array(8, dtype="int32"),
+        np.array(64, dtype="int32"),
     )
     return inputs
 
@@ -75,9 +93,10 @@ class TestLayer(unittest.TestCase):
     def setUp(self):
         self.inputs = create_tensor_inputs()
         self.net = LayerCase()
+
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.set_flags({"FLAGS_prim_all": with_prim})
             if with_cinn:
                 build_strategy = paddle.static.BuildStrategy()
                 build_strategy.build_cinn_pass = True
@@ -87,6 +106,7 @@ class TestLayer(unittest.TestCase):
         paddle.seed(123)
         outs = net(*self.inputs)
         return outs
+
     def test_ast_prim_cinn(self):
         st_out = self.train(self.net, to_static=True)
         cinn_out = self.train(self.net, to_static=True, with_prim=True, with_cinn=True)
@@ -94,5 +114,5 @@ class TestLayer(unittest.TestCase):
             np.testing.assert_allclose(st.numpy(), cinn.numpy(), atol=1e-8)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/segformer_segformer_b3_cityscapes_1024x512_160k/SIR_16.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/segformer_segformer_b3_cityscapes_1024x512_160k/SIR_16.py
@@ -8,65 +8,83 @@ class LayerCase(paddle.nn.Layer):
     def __init__(self):
         super().__init__()
         self.parameter_0 = self.create_parameter(
-           shape=[128],
-           dtype=paddle.float32,
+            shape=[128],
+            dtype=paddle.float32,
         )
         self.parameter_1 = self.create_parameter(
-           shape=[64],
-           dtype=paddle.float32,
+            shape=[64],
+            dtype=paddle.float32,
         )
         self.parameter_2 = self.create_parameter(
-           shape=[128, 64, 3, 3],
-           dtype=paddle.float32,
+            shape=[128, 64, 3, 3],
+            dtype=paddle.float32,
         )
         self.parameter_3 = self.create_parameter(
-           shape=[128],
-           dtype=paddle.float32,
+            shape=[128],
+            dtype=paddle.float32,
         )
         self.parameter_4 = self.create_parameter(
-           shape=[64],
-           dtype=paddle.float32,
+            shape=[64],
+            dtype=paddle.float32,
         )
         self.parameter_5 = self.create_parameter(
-           shape=[128],
-           dtype=paddle.float32,
+            shape=[128],
+            dtype=paddle.float32,
         )
+
     def forward(
         self,
-        var_0,    # (shape: [1, 32768, 64], dtype: paddle.float32, stop_gradient: False)
-        var_1,    # (shape: [], dtype: paddle.int32, stop_gradient: True)
-        var_2,    # (shape: [], dtype: paddle.int32, stop_gradient: True)
-        var_3,    # (shape: [], dtype: paddle.int32, stop_gradient: True)
+        var_0,  # (shape: [1, 32768, 64], dtype: paddle.float32, stop_gradient: False)
+        var_1,  # (shape: [], dtype: paddle.int32, stop_gradient: True)
+        var_2,  # (shape: [], dtype: paddle.int32, stop_gradient: True)
+        var_3,  # (shape: [], dtype: paddle.int32, stop_gradient: True)
     ):
-        var_4 = paddle.nn.functional.norm.layer_norm(var_0, normalized_shape=[64], weight=self.parameter_4, bias=self.parameter_1, epsilon=1e-06)
+        var_4 = paddle.nn.functional.norm.layer_norm(
+            var_0, normalized_shape=[64], weight=self.parameter_4, bias=self.parameter_1, epsilon=1e-06
+        )
         var_5 = var_4.reshape([var_1, var_2, var_3, 64])
         var_6 = var_5.transpose([0, 3, 1, 2])
-        var_7 = paddle.nn.functional.conv._conv_nd(var_6, self.parameter_2, bias=self.parameter_3, stride=[2, 2], padding=[1, 1], padding_algorithm='EXPLICIT', dilation=[1, 1], groups=1, data_format='NCHW', channel_dim=1, op_type='conv2d', use_cudnn=True)
+        var_7 = paddle.nn.functional.conv._conv_nd(
+            var_6,
+            self.parameter_2,
+            bias=self.parameter_3,
+            stride=[2, 2],
+            padding=[1, 1],
+            padding_algorithm="EXPLICIT",
+            dilation=[1, 1],
+            groups=1,
+            data_format="NCHW",
+            channel_dim=1,
+            op_type="conv2d",
+            use_cudnn=True,
+        )
         var_8 = var_7.shape
         var_9 = var_8.__getitem__(2)
         var_10 = var_8.__getitem__(3)
         var_11 = var_7.flatten(2)
         var_12 = var_11.transpose([0, 2, 1])
-        var_13 = paddle.nn.functional.norm.layer_norm(var_12, normalized_shape=[128], weight=self.parameter_0, bias=self.parameter_5, epsilon=1e-05)
+        var_13 = paddle.nn.functional.norm.layer_norm(
+            var_12, normalized_shape=[128], weight=self.parameter_0, bias=self.parameter_5, epsilon=1e-05
+        )
         return var_13, var_9, var_10, var_6
 
 
 def create_tensor_inputs():
     inputs = (
         paddle.rand(shape=[1, 32768, 64], dtype=paddle.float32),
-        paddle.randint(low=0, high=10, shape=[1], dtype=paddle.int32),
-        paddle.randint(low=0, high=10, shape=[1], dtype=paddle.int32),
-        paddle.randint(low=0, high=10, shape=[1], dtype=paddle.int32),
+        paddle.to_tensor(16, dtype=paddle.int32),
+        paddle.to_tensor(32, dtype=paddle.int32),
+        paddle.to_tensor(64, dtype=paddle.int32),
     )
     return inputs
 
 
 def create_numpy_inputs():
     inputs = (
-        np.random.random(size=[1, 32768, 64]).astype('float32'),
-        np.random.randint(low=0, high=10, size=[1], dtype='int32'),
-        np.random.randint(low=0, high=10, size=[1], dtype='int32'),
-        np.random.randint(low=0, high=10, size=[1], dtype='int32'),
+        np.random.random(size=[1, 32768, 64]).astype("float32"),
+        np.array(16, dtype="int32"),
+        np.array(32, dtype="int32"),
+        np.array(64, dtype="int32"),
     )
     return inputs
 
@@ -75,9 +93,10 @@ class TestLayer(unittest.TestCase):
     def setUp(self):
         self.inputs = create_tensor_inputs()
         self.net = LayerCase()
+
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.set_flags({"FLAGS_prim_all": with_prim})
             if with_cinn:
                 build_strategy = paddle.static.BuildStrategy()
                 build_strategy.build_cinn_pass = True
@@ -87,6 +106,7 @@ class TestLayer(unittest.TestCase):
         paddle.seed(123)
         outs = net(*self.inputs)
         return outs
+
     def test_ast_prim_cinn(self):
         st_out = self.train(self.net, to_static=True)
         cinn_out = self.train(self.net, to_static=True, with_prim=True, with_cinn=True)
@@ -94,5 +114,5 @@ class TestLayer(unittest.TestCase):
             np.testing.assert_allclose(st.numpy(), cinn.numpy(), atol=1e-8)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/segformer_segformer_b3_cityscapes_1024x512_160k/SIR_18.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/segformer_segformer_b3_cityscapes_1024x512_160k/SIR_18.py
@@ -8,60 +8,63 @@ class LayerCase(paddle.nn.Layer):
     def __init__(self):
         super().__init__()
         self.parameter_0 = self.create_parameter(
-           shape=[128],
-           dtype=paddle.float32,
+            shape=[128],
+            dtype=paddle.float32,
         )
         self.parameter_1 = self.create_parameter(
-           shape=[128],
-           dtype=paddle.float32,
+            shape=[128],
+            dtype=paddle.float32,
         )
         self.parameter_2 = self.create_parameter(
-           shape=[128],
-           dtype=paddle.float32,
+            shape=[128],
+            dtype=paddle.float32,
         )
         self.parameter_3 = self.create_parameter(
-           shape=[128, 256],
-           dtype=paddle.float32,
+            shape=[128, 256],
+            dtype=paddle.float32,
         )
         self.parameter_4 = self.create_parameter(
-           shape=[128, 128],
-           dtype=paddle.float32,
+            shape=[128, 128],
+            dtype=paddle.float32,
         )
         self.parameter_5 = self.create_parameter(
-           shape=[128, 128, 4, 4],
-           dtype=paddle.float32,
+            shape=[128, 128, 4, 4],
+            dtype=paddle.float32,
         )
         self.parameter_6 = self.create_parameter(
-           shape=[128],
-           dtype=paddle.float32,
+            shape=[128],
+            dtype=paddle.float32,
         )
         self.parameter_7 = self.create_parameter(
-           shape=[128],
-           dtype=paddle.float32,
+            shape=[128],
+            dtype=paddle.float32,
         )
         self.parameter_8 = self.create_parameter(
-           shape=[128, 128],
-           dtype=paddle.float32,
+            shape=[128, 128],
+            dtype=paddle.float32,
         )
         self.parameter_9 = self.create_parameter(
-           shape=[256],
-           dtype=paddle.float32,
+            shape=[256],
+            dtype=paddle.float32,
         )
         self.parameter_10 = self.create_parameter(
-           shape=[128],
-           dtype=paddle.float32,
+            shape=[128],
+            dtype=paddle.float32,
         )
         self.parameter_11 = self.create_parameter(
-           shape=[128],
-           dtype=paddle.float32,
+            shape=[128],
+            dtype=paddle.float32,
         )
+
     def forward(
         self,
-        var_0,    # (shape: [1, 8192, 128], dtype: paddle.float32, stop_gradient: False)
-        var_1,    # (shape: [], dtype: paddle.int32, stop_gradient: True)
-        var_2,    # (shape: [], dtype: paddle.int32, stop_gradient: True)
+        var_0,  # (shape: [1, 8192, 128], dtype: paddle.float32, stop_gradient: False)
+        var_1,  # (shape: [], dtype: paddle.int32, stop_gradient: True)
+        var_2,  # (shape: [], dtype: paddle.int32, stop_gradient: True)
     ):
-        var_3 = paddle.nn.functional.norm.layer_norm(var_0, normalized_shape=[128], weight=self.parameter_11, bias=self.parameter_6, epsilon=1e-06)
+        var_3 = paddle.nn.functional.norm.layer_norm(
+            var_0, normalized_shape=[128], weight=self.parameter_11, bias=self.parameter_6, epsilon=1e-06
+        )
         var_4 = var_3.shape
         var_5 = var_4.__getitem__(0)
         var_6 = var_4.__getitem__(1)
@@ -70,10 +73,25 @@ class LayerCase(paddle.nn.Layer):
         var_9 = var_8.transpose([0, 2, 1, 3])
         var_10 = var_3.transpose([0, 2, 1])
         var_11 = var_10.reshape([var_5, 128, var_1, var_2])
-        var_12 = paddle.nn.functional.conv._conv_nd(var_11, self.parameter_5, bias=self.parameter_10, stride=[4, 4], padding=[0, 0], padding_algorithm='EXPLICIT', dilation=[1, 1], groups=1, data_format='NCHW', channel_dim=1, op_type='conv2d', use_cudnn=True)
+        var_12 = paddle.nn.functional.conv._conv_nd(
+            var_11,
+            self.parameter_5,
+            bias=self.parameter_10,
+            stride=[4, 4],
+            padding=[0, 0],
+            padding_algorithm="EXPLICIT",
+            dilation=[1, 1],
+            groups=1,
+            data_format="NCHW",
+            channel_dim=1,
+            op_type="conv2d",
+            use_cudnn=True,
+        )
         var_13 = var_12.reshape([var_5, 128, -1])
         var_14 = var_13.transpose([0, 2, 1])
-        var_15 = paddle.nn.functional.norm.layer_norm(var_14, normalized_shape=[128], weight=self.parameter_2, bias=self.parameter_0, epsilon=1e-05)
+        var_15 = paddle.nn.functional.norm.layer_norm(
+            var_14, normalized_shape=[128], weight=self.parameter_2, bias=self.parameter_0, epsilon=1e-05
+        )
         var_16 = paddle.nn.functional.common.linear(x=var_15, weight=self.parameter_3, bias=self.parameter_9, name=None)
         var_17 = var_16.reshape([var_5, -1, 2, 2, 64])
         var_18 = var_17.transpose([2, 0, 3, 1, 4])
@@ -83,29 +101,33 @@ class LayerCase(paddle.nn.Layer):
         var_22 = var_9.__matmul__(var_21)
         var_23 = var_22.__mul__(0.125)
         var_24 = paddle.nn.functional.activation.softmax(var_23, axis=-1)
-        var_25 = paddle.nn.functional.common.dropout(var_24, p=0.0, axis=None, training=True, mode='upscale_in_train', name=None)
+        var_25 = paddle.nn.functional.common.dropout(
+            var_24, p=0.0, axis=None, training=True, mode="upscale_in_train", name=None
+        )
         var_26 = var_25.__matmul__(var_20)
         var_27 = var_26.transpose([0, 2, 1, 3])
         var_28 = var_27.reshape([var_5, var_6, 128])
         var_29 = paddle.nn.functional.common.linear(x=var_28, weight=self.parameter_4, bias=self.parameter_1, name=None)
-        var_30 = paddle.nn.functional.common.dropout(var_29, p=0.0, axis=None, training=True, mode='upscale_in_train', name=None)
+        var_30 = paddle.nn.functional.common.dropout(
+            var_29, p=0.0, axis=None, training=True, mode="upscale_in_train", name=None
+        )
         return var_30
 
 
 def create_tensor_inputs():
     inputs = (
         paddle.rand(shape=[1, 8192, 128], dtype=paddle.float32),
-        paddle.randint(low=0, high=10, shape=[1], dtype=paddle.int32),
-        paddle.randint(low=0, high=10, shape=[1], dtype=paddle.int32),
+        paddle.to_tensor(64, dtype=paddle.int32),
+        paddle.to_tensor(128, dtype=paddle.int32),
     )
     return inputs
 
 
 def create_numpy_inputs():
     inputs = (
-        np.random.random(size=[1, 8192, 128]).astype('float32'),
-        np.random.randint(low=0, high=10, size=[1], dtype='int32'),
-        np.random.randint(low=0, high=10, size=[1], dtype='int32'),
+        np.random.random(size=[1, 8192, 128]).astype("float32"),
+        np.array(64, dtype="int32"),
+        np.array(128, dtype="int32"),
     )
     return inputs
 
@@ -114,9 +136,10 @@ class TestLayer(unittest.TestCase):
     def setUp(self):
         self.inputs = create_tensor_inputs()
         self.net = LayerCase()
+
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.set_flags({"FLAGS_prim_all": with_prim})
             if with_cinn:
                 build_strategy = paddle.static.BuildStrategy()
                 build_strategy.build_cinn_pass = True
@@ -126,6 +149,7 @@ class TestLayer(unittest.TestCase):
         paddle.seed(123)
         outs = net(*self.inputs)
         return outs
+
     def test_ast_prim_cinn(self):
         st_out = self.train(self.net, to_static=True)
         cinn_out = self.train(self.net, to_static=True, with_prim=True, with_cinn=True)
@@ -133,5 +157,5 @@ class TestLayer(unittest.TestCase):
             np.testing.assert_allclose(st.numpy(), cinn.numpy(), atol=1e-8)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/segformer_segformer_b3_cityscapes_1024x512_160k/SIR_36.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/segformer_segformer_b3_cityscapes_1024x512_160k/SIR_36.py
@@ -8,65 +8,83 @@ class LayerCase(paddle.nn.Layer):
     def __init__(self):
         super().__init__()
         self.parameter_0 = self.create_parameter(
-           shape=[320, 128, 3, 3],
-           dtype=paddle.float32,
+            shape=[320, 128, 3, 3],
+            dtype=paddle.float32,
         )
         self.parameter_1 = self.create_parameter(
-           shape=[320],
-           dtype=paddle.float32,
+            shape=[320],
+            dtype=paddle.float32,
         )
         self.parameter_2 = self.create_parameter(
-           shape=[128],
-           dtype=paddle.float32,
+            shape=[128],
+            dtype=paddle.float32,
         )
         self.parameter_3 = self.create_parameter(
-           shape=[128],
-           dtype=paddle.float32,
+            shape=[128],
+            dtype=paddle.float32,
         )
         self.parameter_4 = self.create_parameter(
-           shape=[320],
-           dtype=paddle.float32,
+            shape=[320],
+            dtype=paddle.float32,
         )
         self.parameter_5 = self.create_parameter(
-           shape=[320],
-           dtype=paddle.float32,
+            shape=[320],
+            dtype=paddle.float32,
         )
+
     def forward(
         self,
-        var_0,    # (shape: [1, 8192, 128], dtype: paddle.float32, stop_gradient: False)
-        var_1,    # (shape: [], dtype: paddle.int32, stop_gradient: True)
-        var_2,    # (shape: [], dtype: paddle.int32, stop_gradient: True)
-        var_3,    # (shape: [], dtype: paddle.int32, stop_gradient: True)
+        var_0,  # (shape: [1, 8192, 128], dtype: paddle.float32, stop_gradient: False)
+        var_1,  # (shape: [], dtype: paddle.int32, stop_gradient: True)
+        var_2,  # (shape: [], dtype: paddle.int32, stop_gradient: True)
+        var_3,  # (shape: [], dtype: paddle.int32, stop_gradient: True)
     ):
-        var_4 = paddle.nn.functional.norm.layer_norm(var_0, normalized_shape=[128], weight=self.parameter_2, bias=self.parameter_3, epsilon=1e-06)
+        var_4 = paddle.nn.functional.norm.layer_norm(
+            var_0, normalized_shape=[128], weight=self.parameter_2, bias=self.parameter_3, epsilon=1e-06
+        )
         var_5 = var_4.reshape([var_1, var_2, var_3, 128])
         var_6 = var_5.transpose([0, 3, 1, 2])
-        var_7 = paddle.nn.functional.conv._conv_nd(var_6, self.parameter_0, bias=self.parameter_4, stride=[2, 2], padding=[1, 1], padding_algorithm='EXPLICIT', dilation=[1, 1], groups=1, data_format='NCHW', channel_dim=1, op_type='conv2d', use_cudnn=True)
+        var_7 = paddle.nn.functional.conv._conv_nd(
+            var_6,
+            self.parameter_0,
+            bias=self.parameter_4,
+            stride=[2, 2],
+            padding=[1, 1],
+            padding_algorithm="EXPLICIT",
+            dilation=[1, 1],
+            groups=1,
+            data_format="NCHW",
+            channel_dim=1,
+            op_type="conv2d",
+            use_cudnn=True,
+        )
         var_8 = var_7.shape
         var_9 = var_8.__getitem__(2)
         var_10 = var_8.__getitem__(3)
         var_11 = var_7.flatten(2)
         var_12 = var_11.transpose([0, 2, 1])
-        var_13 = paddle.nn.functional.norm.layer_norm(var_12, normalized_shape=[320], weight=self.parameter_5, bias=self.parameter_1, epsilon=1e-05)
+        var_13 = paddle.nn.functional.norm.layer_norm(
+            var_12, normalized_shape=[320], weight=self.parameter_5, bias=self.parameter_1, epsilon=1e-05
+        )
         return var_13, var_9, var_10, var_6
 
 
 def create_tensor_inputs():
     inputs = (
         paddle.rand(shape=[1, 8192, 128], dtype=paddle.float32),
-        paddle.randint(low=0, high=10, shape=[1], dtype=paddle.int32),
-        paddle.randint(low=0, high=10, shape=[1], dtype=paddle.int32),
-        paddle.randint(low=0, high=10, shape=[1], dtype=paddle.int32),
+        paddle.to_tensor(8, dtype=paddle.int32),
+        paddle.to_tensor(16, dtype=paddle.int32),
+        paddle.to_tensor(64, dtype=paddle.int32),
     )
     return inputs
 
 
 def create_numpy_inputs():
     inputs = (
-        np.random.random(size=[1, 8192, 128]).astype('float32'),
-        np.random.randint(low=0, high=10, size=[1], dtype='int32'),
-        np.random.randint(low=0, high=10, size=[1], dtype='int32'),
-        np.random.randint(low=0, high=10, size=[1], dtype='int32'),
+        np.random.random(size=[1, 8192, 128]).astype("float32"),
+        np.array(8, dtype="int32"),
+        np.array(16, dtype="int32"),
+        np.array(64, dtype="int32"),
     )
     return inputs
 
@@ -75,9 +93,10 @@ class TestLayer(unittest.TestCase):
     def setUp(self):
         self.inputs = create_tensor_inputs()
         self.net = LayerCase()
+
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.set_flags({"FLAGS_prim_all": with_prim})
             if with_cinn:
                 build_strategy = paddle.static.BuildStrategy()
                 build_strategy.build_cinn_pass = True
@@ -87,6 +106,7 @@ class TestLayer(unittest.TestCase):
         paddle.seed(123)
         outs = net(*self.inputs)
         return outs
+
     def test_ast_prim_cinn(self):
         st_out = self.train(self.net, to_static=True)
         cinn_out = self.train(self.net, to_static=True, with_prim=True, with_cinn=True)
@@ -94,5 +114,5 @@ class TestLayer(unittest.TestCase):
             np.testing.assert_allclose(st.numpy(), cinn.numpy(), atol=1e-8)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/segformer_segformer_b3_cityscapes_1024x512_160k/SIR_38.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/segformer_segformer_b3_cityscapes_1024x512_160k/SIR_38.py
@@ -8,60 +8,63 @@ class LayerCase(paddle.nn.Layer):
     def __init__(self):
         super().__init__()
         self.parameter_0 = self.create_parameter(
-           shape=[320],
-           dtype=paddle.float32,
+            shape=[320],
+            dtype=paddle.float32,
         )
         self.parameter_1 = self.create_parameter(
-           shape=[320],
-           dtype=paddle.float32,
+            shape=[320],
+            dtype=paddle.float32,
         )
         self.parameter_2 = self.create_parameter(
-           shape=[320, 320],
-           dtype=paddle.float32,
+            shape=[320, 320],
+            dtype=paddle.float32,
         )
         self.parameter_3 = self.create_parameter(
-           shape=[320, 320, 2, 2],
-           dtype=paddle.float32,
+            shape=[320, 320, 2, 2],
+            dtype=paddle.float32,
         )
         self.parameter_4 = self.create_parameter(
-           shape=[320],
-           dtype=paddle.float32,
+            shape=[320],
+            dtype=paddle.float32,
         )
         self.parameter_5 = self.create_parameter(
-           shape=[320],
-           dtype=paddle.float32,
+            shape=[320],
+            dtype=paddle.float32,
         )
         self.parameter_6 = self.create_parameter(
-           shape=[320],
-           dtype=paddle.float32,
+            shape=[320],
+            dtype=paddle.float32,
         )
         self.parameter_7 = self.create_parameter(
-           shape=[320],
-           dtype=paddle.float32,
+            shape=[320],
+            dtype=paddle.float32,
         )
         self.parameter_8 = self.create_parameter(
-           shape=[320, 320],
-           dtype=paddle.float32,
+            shape=[320, 320],
+            dtype=paddle.float32,
         )
         self.parameter_9 = self.create_parameter(
-           shape=[640],
-           dtype=paddle.float32,
+            shape=[640],
+            dtype=paddle.float32,
         )
         self.parameter_10 = self.create_parameter(
-           shape=[320],
-           dtype=paddle.float32,
+            shape=[320],
+            dtype=paddle.float32,
         )
         self.parameter_11 = self.create_parameter(
-           shape=[320, 640],
-           dtype=paddle.float32,
+            shape=[320, 640],
+            dtype=paddle.float32,
         )
+
     def forward(
         self,
-        var_0,    # (shape: [1, 2048, 320], dtype: paddle.float32, stop_gradient: False)
-        var_1,    # (shape: [], dtype: paddle.int32, stop_gradient: True)
-        var_2,    # (shape: [], dtype: paddle.int32, stop_gradient: True)
+        var_0,  # (shape: [1, 2048, 320], dtype: paddle.float32, stop_gradient: False)
+        var_1,  # (shape: [], dtype: paddle.int32, stop_gradient: True)
+        var_2,  # (shape: [], dtype: paddle.int32, stop_gradient: True)
     ):
-        var_3 = paddle.nn.functional.norm.layer_norm(var_0, normalized_shape=[320], weight=self.parameter_1, bias=self.parameter_0, epsilon=1e-06)
+        var_3 = paddle.nn.functional.norm.layer_norm(
+            var_0, normalized_shape=[320], weight=self.parameter_1, bias=self.parameter_0, epsilon=1e-06
+        )
         var_4 = var_3.shape
         var_5 = var_4.__getitem__(0)
         var_6 = var_4.__getitem__(1)
@@ -70,11 +73,28 @@ class LayerCase(paddle.nn.Layer):
         var_9 = var_8.transpose([0, 2, 1, 3])
         var_10 = var_3.transpose([0, 2, 1])
         var_11 = var_10.reshape([var_5, 320, var_1, var_2])
-        var_12 = paddle.nn.functional.conv._conv_nd(var_11, self.parameter_3, bias=self.parameter_7, stride=[2, 2], padding=[0, 0], padding_algorithm='EXPLICIT', dilation=[1, 1], groups=1, data_format='NCHW', channel_dim=1, op_type='conv2d', use_cudnn=True)
+        var_12 = paddle.nn.functional.conv._conv_nd(
+            var_11,
+            self.parameter_3,
+            bias=self.parameter_7,
+            stride=[2, 2],
+            padding=[0, 0],
+            padding_algorithm="EXPLICIT",
+            dilation=[1, 1],
+            groups=1,
+            data_format="NCHW",
+            channel_dim=1,
+            op_type="conv2d",
+            use_cudnn=True,
+        )
         var_13 = var_12.reshape([var_5, 320, -1])
         var_14 = var_13.transpose([0, 2, 1])
-        var_15 = paddle.nn.functional.norm.layer_norm(var_14, normalized_shape=[320], weight=self.parameter_10, bias=self.parameter_5, epsilon=1e-05)
-        var_16 = paddle.nn.functional.common.linear(x=var_15, weight=self.parameter_11, bias=self.parameter_9, name=None)
+        var_15 = paddle.nn.functional.norm.layer_norm(
+            var_14, normalized_shape=[320], weight=self.parameter_10, bias=self.parameter_5, epsilon=1e-05
+        )
+        var_16 = paddle.nn.functional.common.linear(
+            x=var_15, weight=self.parameter_11, bias=self.parameter_9, name=None
+        )
         var_17 = var_16.reshape([var_5, -1, 2, 5, 64])
         var_18 = var_17.transpose([2, 0, 3, 1, 4])
         var_19 = var_18.__getitem__(0)
@@ -83,29 +103,33 @@ class LayerCase(paddle.nn.Layer):
         var_22 = var_9.__matmul__(var_21)
         var_23 = var_22.__mul__(0.125)
         var_24 = paddle.nn.functional.activation.softmax(var_23, axis=-1)
-        var_25 = paddle.nn.functional.common.dropout(var_24, p=0.0, axis=None, training=True, mode='upscale_in_train', name=None)
+        var_25 = paddle.nn.functional.common.dropout(
+            var_24, p=0.0, axis=None, training=True, mode="upscale_in_train", name=None
+        )
         var_26 = var_25.__matmul__(var_20)
         var_27 = var_26.transpose([0, 2, 1, 3])
         var_28 = var_27.reshape([var_5, var_6, 320])
         var_29 = paddle.nn.functional.common.linear(x=var_28, weight=self.parameter_8, bias=self.parameter_4, name=None)
-        var_30 = paddle.nn.functional.common.dropout(var_29, p=0.0, axis=None, training=True, mode='upscale_in_train', name=None)
+        var_30 = paddle.nn.functional.common.dropout(
+            var_29, p=0.0, axis=None, training=True, mode="upscale_in_train", name=None
+        )
         return var_30
 
 
 def create_tensor_inputs():
     inputs = (
         paddle.rand(shape=[1, 2048, 320], dtype=paddle.float32),
-        paddle.randint(low=0, high=10, shape=[1], dtype=paddle.int32),
-        paddle.randint(low=0, high=10, shape=[1], dtype=paddle.int32),
+        paddle.to_tensor(32, dtype=paddle.int32),
+        paddle.to_tensor(64, dtype=paddle.int32),
     )
     return inputs
 
 
 def create_numpy_inputs():
     inputs = (
-        np.random.random(size=[1, 2048, 320]).astype('float32'),
-        np.random.randint(low=0, high=10, size=[1], dtype='int32'),
-        np.random.randint(low=0, high=10, size=[1], dtype='int32'),
+        np.random.random(size=[1, 2048, 320]).astype("float32"),
+        np.array(32, dtype="int32"),
+        np.array(64, dtype="int32"),
     )
     return inputs
 
@@ -114,9 +138,10 @@ class TestLayer(unittest.TestCase):
     def setUp(self):
         self.inputs = create_tensor_inputs()
         self.net = LayerCase()
+
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.set_flags({"FLAGS_prim_all": with_prim})
             if with_cinn:
                 build_strategy = paddle.static.BuildStrategy()
                 build_strategy.build_cinn_pass = True
@@ -126,6 +151,7 @@ class TestLayer(unittest.TestCase):
         paddle.seed(123)
         outs = net(*self.inputs)
         return outs
+
     def test_ast_prim_cinn(self):
         st_out = self.train(self.net, to_static=True)
         cinn_out = self.train(self.net, to_static=True, with_prim=True, with_cinn=True)
@@ -133,5 +159,5 @@ class TestLayer(unittest.TestCase):
             np.testing.assert_allclose(st.numpy(), cinn.numpy(), atol=1e-8)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/segformer_segformer_b3_cityscapes_1024x512_160k/SIR_5.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/segformer_segformer_b3_cityscapes_1024x512_160k/SIR_5.py
@@ -8,60 +8,63 @@ class LayerCase(paddle.nn.Layer):
     def __init__(self):
         super().__init__()
         self.parameter_0 = self.create_parameter(
-           shape=[64],
-           dtype=paddle.float32,
+            shape=[64],
+            dtype=paddle.float32,
         )
         self.parameter_1 = self.create_parameter(
-           shape=[64, 64, 8, 8],
-           dtype=paddle.float32,
+            shape=[64, 64, 8, 8],
+            dtype=paddle.float32,
         )
         self.parameter_2 = self.create_parameter(
-           shape=[64],
-           dtype=paddle.float32,
+            shape=[64],
+            dtype=paddle.float32,
         )
         self.parameter_3 = self.create_parameter(
-           shape=[64],
-           dtype=paddle.float32,
+            shape=[64],
+            dtype=paddle.float32,
         )
         self.parameter_4 = self.create_parameter(
-           shape=[64],
-           dtype=paddle.float32,
+            shape=[64],
+            dtype=paddle.float32,
         )
         self.parameter_5 = self.create_parameter(
-           shape=[64, 64],
-           dtype=paddle.float32,
+            shape=[64, 64],
+            dtype=paddle.float32,
         )
         self.parameter_6 = self.create_parameter(
-           shape=[64, 64],
-           dtype=paddle.float32,
+            shape=[64, 64],
+            dtype=paddle.float32,
         )
         self.parameter_7 = self.create_parameter(
-           shape=[64],
-           dtype=paddle.float32,
+            shape=[64],
+            dtype=paddle.float32,
         )
         self.parameter_8 = self.create_parameter(
-           shape=[64],
-           dtype=paddle.float32,
+            shape=[64],
+            dtype=paddle.float32,
         )
         self.parameter_9 = self.create_parameter(
-           shape=[128],
-           dtype=paddle.float32,
+            shape=[128],
+            dtype=paddle.float32,
         )
         self.parameter_10 = self.create_parameter(
-           shape=[64, 128],
-           dtype=paddle.float32,
+            shape=[64, 128],
+            dtype=paddle.float32,
         )
         self.parameter_11 = self.create_parameter(
-           shape=[64],
-           dtype=paddle.float32,
+            shape=[64],
+            dtype=paddle.float32,
         )
+
     def forward(
         self,
-        var_0,    # (shape: [1, 32768, 64], dtype: paddle.float32, stop_gradient: False)
-        var_1,    # (shape: [], dtype: paddle.int32, stop_gradient: True)
-        var_2,    # (shape: [], dtype: paddle.int32, stop_gradient: True)
+        var_0,  # (shape: [1, 32768, 64], dtype: paddle.float32, stop_gradient: False)
+        var_1,  # (shape: [], dtype: paddle.int32, stop_gradient: True)
+        var_2,  # (shape: [], dtype: paddle.int32, stop_gradient: True)
     ):
-        var_3 = paddle.nn.functional.norm.layer_norm(var_0, normalized_shape=[64], weight=self.parameter_4, bias=self.parameter_2, epsilon=1e-06)
+        var_3 = paddle.nn.functional.norm.layer_norm(
+            var_0, normalized_shape=[64], weight=self.parameter_4, bias=self.parameter_2, epsilon=1e-06
+        )
         var_4 = var_3.shape
         var_5 = var_4.__getitem__(0)
         var_6 = var_4.__getitem__(1)
@@ -70,11 +73,28 @@ class LayerCase(paddle.nn.Layer):
         var_9 = var_8.transpose([0, 2, 1, 3])
         var_10 = var_3.transpose([0, 2, 1])
         var_11 = var_10.reshape([var_5, 64, var_1, var_2])
-        var_12 = paddle.nn.functional.conv._conv_nd(var_11, self.parameter_1, bias=self.parameter_3, stride=[8, 8], padding=[0, 0], padding_algorithm='EXPLICIT', dilation=[1, 1], groups=1, data_format='NCHW', channel_dim=1, op_type='conv2d', use_cudnn=True)
+        var_12 = paddle.nn.functional.conv._conv_nd(
+            var_11,
+            self.parameter_1,
+            bias=self.parameter_3,
+            stride=[8, 8],
+            padding=[0, 0],
+            padding_algorithm="EXPLICIT",
+            dilation=[1, 1],
+            groups=1,
+            data_format="NCHW",
+            channel_dim=1,
+            op_type="conv2d",
+            use_cudnn=True,
+        )
         var_13 = var_12.reshape([var_5, 64, -1])
         var_14 = var_13.transpose([0, 2, 1])
-        var_15 = paddle.nn.functional.norm.layer_norm(var_14, normalized_shape=[64], weight=self.parameter_7, bias=self.parameter_8, epsilon=1e-05)
-        var_16 = paddle.nn.functional.common.linear(x=var_15, weight=self.parameter_10, bias=self.parameter_9, name=None)
+        var_15 = paddle.nn.functional.norm.layer_norm(
+            var_14, normalized_shape=[64], weight=self.parameter_7, bias=self.parameter_8, epsilon=1e-05
+        )
+        var_16 = paddle.nn.functional.common.linear(
+            x=var_15, weight=self.parameter_10, bias=self.parameter_9, name=None
+        )
         var_17 = var_16.reshape([var_5, -1, 2, 1, 64])
         var_18 = var_17.transpose([2, 0, 3, 1, 4])
         var_19 = var_18.__getitem__(0)
@@ -83,29 +103,35 @@ class LayerCase(paddle.nn.Layer):
         var_22 = var_9.__matmul__(var_21)
         var_23 = var_22.__mul__(0.125)
         var_24 = paddle.nn.functional.activation.softmax(var_23, axis=-1)
-        var_25 = paddle.nn.functional.common.dropout(var_24, p=0.0, axis=None, training=True, mode='upscale_in_train', name=None)
+        var_25 = paddle.nn.functional.common.dropout(
+            var_24, p=0.0, axis=None, training=True, mode="upscale_in_train", name=None
+        )
         var_26 = var_25.__matmul__(var_20)
         var_27 = var_26.transpose([0, 2, 1, 3])
         var_28 = var_27.reshape([var_5, var_6, 64])
-        var_29 = paddle.nn.functional.common.linear(x=var_28, weight=self.parameter_6, bias=self.parameter_11, name=None)
-        var_30 = paddle.nn.functional.common.dropout(var_29, p=0.0, axis=None, training=True, mode='upscale_in_train', name=None)
+        var_29 = paddle.nn.functional.common.linear(
+            x=var_28, weight=self.parameter_6, bias=self.parameter_11, name=None
+        )
+        var_30 = paddle.nn.functional.common.dropout(
+            var_29, p=0.0, axis=None, training=True, mode="upscale_in_train", name=None
+        )
         return var_30
 
 
 def create_tensor_inputs():
     inputs = (
         paddle.rand(shape=[1, 32768, 64], dtype=paddle.float32),
-        paddle.randint(low=0, high=10, shape=[1], dtype=paddle.int32),
-        paddle.randint(low=0, high=10, shape=[1], dtype=paddle.int32),
+        paddle.to_tensor(128, dtype=paddle.int32),
+        paddle.to_tensor(256, dtype=paddle.int32),
     )
     return inputs
 
 
 def create_numpy_inputs():
     inputs = (
-        np.random.random(size=[1, 32768, 64]).astype('float32'),
-        np.random.randint(low=0, high=10, size=[1], dtype='int32'),
-        np.random.randint(low=0, high=10, size=[1], dtype='int32'),
+        np.random.random(size=[1, 32768, 64]).astype("float32"),
+        np.array(128, dtype="int32"),
+        np.array(256, dtype="int32"),
     )
     return inputs
 
@@ -114,9 +140,10 @@ class TestLayer(unittest.TestCase):
     def setUp(self):
         self.inputs = create_tensor_inputs()
         self.net = LayerCase()
+
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.set_flags({"FLAGS_prim_all": with_prim})
             if with_cinn:
                 build_strategy = paddle.static.BuildStrategy()
                 build_strategy.build_cinn_pass = True
@@ -126,6 +153,7 @@ class TestLayer(unittest.TestCase):
         paddle.seed(123)
         outs = net(*self.inputs)
         return outs
+
     def test_ast_prim_cinn(self):
         st_out = self.train(self.net, to_static=True)
         cinn_out = self.train(self.net, to_static=True, with_prim=True, with_cinn=True)
@@ -133,5 +161,5 @@ class TestLayer(unittest.TestCase):
             np.testing.assert_allclose(st.numpy(), cinn.numpy(), atol=1e-8)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/segformer_segformer_b4_cityscapes_1024x1024_160k/SIR_152.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/segformer_segformer_b4_cityscapes_1024x1024_160k/SIR_152.py
@@ -8,25 +8,39 @@ class LayerCase(paddle.nn.Layer):
     def __init__(self):
         super().__init__()
         self.parameter_0 = self.create_parameter(
-           shape=[1280],
-           dtype=paddle.float32,
+            shape=[1280],
+            dtype=paddle.float32,
         )
         self.parameter_1 = self.create_parameter(
-           shape=[1280, 1, 3, 3],
-           dtype=paddle.float32,
+            shape=[1280, 1, 3, 3],
+            dtype=paddle.float32,
         )
+
     def forward(
         self,
-        var_0,    # (shape: [1, 4096, 1280], dtype: paddle.float32, stop_gradient: False)
-        var_1,    # (shape: [], dtype: paddle.int32, stop_gradient: True)
-        var_2,    # (shape: [], dtype: paddle.int32, stop_gradient: True)
+        var_0,  # (shape: [1, 4096, 1280], dtype: paddle.float32, stop_gradient: False)
+        var_1,  # (shape: [], dtype: paddle.int32, stop_gradient: True)
+        var_2,  # (shape: [], dtype: paddle.int32, stop_gradient: True)
     ):
         var_3 = var_0.shape
         var_4 = var_3.__getitem__(0)
         var_5 = var_3.__getitem__(1)
         var_6 = var_0.transpose([0, 2, 1])
         var_7 = var_6.reshape([var_4, 1280, var_1, var_2])
-        var_8 = paddle.nn.functional.conv._conv_nd(var_7, self.parameter_1, bias=self.parameter_0, stride=[1, 1], padding=[1, 1], padding_algorithm='EXPLICIT', dilation=[1, 1], groups=1280, data_format='NCHW', channel_dim=1, op_type='depthwise_conv2d', use_cudnn=False)
+        var_8 = paddle.nn.functional.conv._conv_nd(
+            var_7,
+            self.parameter_1,
+            bias=self.parameter_0,
+            stride=[1, 1],
+            padding=[1, 1],
+            padding_algorithm="EXPLICIT",
+            dilation=[1, 1],
+            groups=1280,
+            data_format="NCHW",
+            channel_dim=1,
+            op_type="depthwise_conv2d",
+            use_cudnn=False,
+        )
         var_9 = var_8.flatten(2)
         var_10 = var_9.transpose([0, 2, 1])
         return var_10
@@ -35,17 +49,17 @@ class LayerCase(paddle.nn.Layer):
 def create_tensor_inputs():
     inputs = (
         paddle.rand(shape=[1, 4096, 1280], dtype=paddle.float32),
-        paddle.randint(low=0, high=10, shape=[1], dtype=paddle.int32),
-        paddle.randint(low=0, high=10, shape=[1], dtype=paddle.int32),
+        paddle.to_tensor(32, dtype=paddle.int32),
+        paddle.to_tensor(128, dtype=paddle.int32),
     )
     return inputs
 
 
 def create_numpy_inputs():
     inputs = (
-        np.random.random(size=[1, 4096, 1280]).astype('float32'),
-        np.random.randint(low=0, high=10, size=[1], dtype='int32'),
-        np.random.randint(low=0, high=10, size=[1], dtype='int32'),
+        np.random.random(size=[1, 4096, 1280]).astype("float32"),
+        np.array(32, dtype="int32"),
+        np.array(128, dtype="int32"),
     )
     return inputs
 
@@ -54,9 +68,10 @@ class TestLayer(unittest.TestCase):
     def setUp(self):
         self.inputs = create_tensor_inputs()
         self.net = LayerCase()
+
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.set_flags({"FLAGS_prim_all": with_prim})
             if with_cinn:
                 build_strategy = paddle.static.BuildStrategy()
                 build_strategy.build_cinn_pass = True
@@ -66,6 +81,7 @@ class TestLayer(unittest.TestCase):
         paddle.seed(123)
         outs = net(*self.inputs)
         return outs
+
     def test_ast_prim_cinn(self):
         st_out = self.train(self.net, to_static=True)
         cinn_out = self.train(self.net, to_static=True, with_prim=True, with_cinn=True)
@@ -73,5 +89,5 @@ class TestLayer(unittest.TestCase):
             np.testing.assert_allclose(st.numpy(), cinn.numpy(), atol=1e-8)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/segformer_segformer_b5_cityscapes_1024x512_160k/SIR_148.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/segformer_segformer_b5_cityscapes_1024x512_160k/SIR_148.py
@@ -8,25 +8,39 @@ class LayerCase(paddle.nn.Layer):
     def __init__(self):
         super().__init__()
         self.parameter_0 = self.create_parameter(
-           shape=[1280],
-           dtype=paddle.float32,
+            shape=[1280],
+            dtype=paddle.float32,
         )
         self.parameter_1 = self.create_parameter(
-           shape=[1280, 1, 3, 3],
-           dtype=paddle.float32,
+            shape=[1280, 1, 3, 3],
+            dtype=paddle.float32,
         )
+
     def forward(
         self,
-        var_0,    # (shape: [1, 2048, 1280], dtype: paddle.float32, stop_gradient: False)
-        var_1,    # (shape: [], dtype: paddle.int32, stop_gradient: True)
-        var_2,    # (shape: [], dtype: paddle.int32, stop_gradient: True)
+        var_0,  # (shape: [1, 2048, 1280], dtype: paddle.float32, stop_gradient: False)
+        var_1,  # (shape: [], dtype: paddle.int32, stop_gradient: True)
+        var_2,  # (shape: [], dtype: paddle.int32, stop_gradient: True)
     ):
         var_3 = var_0.shape
         var_4 = var_3.__getitem__(0)
         var_5 = var_3.__getitem__(1)
         var_6 = var_0.transpose([0, 2, 1])
         var_7 = var_6.reshape([var_4, 1280, var_1, var_2])
-        var_8 = paddle.nn.functional.conv._conv_nd(var_7, self.parameter_1, bias=self.parameter_0, stride=[1, 1], padding=[1, 1], padding_algorithm='EXPLICIT', dilation=[1, 1], groups=1280, data_format='NCHW', channel_dim=1, op_type='depthwise_conv2d', use_cudnn=False)
+        var_8 = paddle.nn.functional.conv._conv_nd(
+            var_7,
+            self.parameter_1,
+            bias=self.parameter_0,
+            stride=[1, 1],
+            padding=[1, 1],
+            padding_algorithm="EXPLICIT",
+            dilation=[1, 1],
+            groups=1280,
+            data_format="NCHW",
+            channel_dim=1,
+            op_type="depthwise_conv2d",
+            use_cudnn=False,
+        )
         var_9 = var_8.flatten(2)
         var_10 = var_9.transpose([0, 2, 1])
         return var_10
@@ -35,17 +49,17 @@ class LayerCase(paddle.nn.Layer):
 def create_tensor_inputs():
     inputs = (
         paddle.rand(shape=[1, 2048, 1280], dtype=paddle.float32),
-        paddle.randint(low=0, high=10, shape=[1], dtype=paddle.int32),
-        paddle.randint(low=0, high=10, shape=[1], dtype=paddle.int32),
+        paddle.to_tensor(32, dtype=paddle.int32),
+        paddle.to_tensor(64, dtype=paddle.int32),
     )
     return inputs
 
 
 def create_numpy_inputs():
     inputs = (
-        np.random.random(size=[1, 2048, 1280]).astype('float32'),
-        np.random.randint(low=0, high=10, size=[1], dtype='int32'),
-        np.random.randint(low=0, high=10, size=[1], dtype='int32'),
+        np.random.random(size=[1, 2048, 1280]).astype("float32"),
+        np.array(32, dtype="int32"),
+        np.array(64, dtype="int32"),
     )
     return inputs
 
@@ -54,9 +68,10 @@ class TestLayer(unittest.TestCase):
     def setUp(self):
         self.inputs = create_tensor_inputs()
         self.net = LayerCase()
+
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.set_flags({"FLAGS_prim_all": with_prim})
             if with_cinn:
                 build_strategy = paddle.static.BuildStrategy()
                 build_strategy.build_cinn_pass = True
@@ -66,6 +81,7 @@ class TestLayer(unittest.TestCase):
         paddle.seed(123)
         outs = net(*self.inputs)
         return outs
+
     def test_ast_prim_cinn(self):
         st_out = self.train(self.net, to_static=True)
         cinn_out = self.train(self.net, to_static=True, with_prim=True, with_cinn=True)
@@ -73,5 +89,5 @@ class TestLayer(unittest.TestCase):
             np.testing.assert_allclose(st.numpy(), cinn.numpy(), atol=1e-8)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/segmenter_segmenter_vit_base_linear_ade20k_512x512_160k/SIR_63.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/segmenter_segmenter_vit_base_linear_ade20k_512x512_160k/SIR_63.py
@@ -8,40 +8,55 @@ class LayerCase(paddle.nn.Layer):
     def __init__(self):
         super().__init__()
         self.parameter_0 = self.create_parameter(
-           shape=[768, 150],
-           dtype=paddle.float32,
+            shape=[768, 150],
+            dtype=paddle.float32,
         )
         self.parameter_1 = self.create_parameter(
-           shape=[150],
-           dtype=paddle.float32,
+            shape=[150],
+            dtype=paddle.float32,
         )
+
     def forward(
         self,
-        var_0,    # (shape: [1, 1024, 768], dtype: paddle.float32, stop_gradient: False)
-        var_1,    # (shape: [2], dtype: paddle.int32, stop_gradient: True)
+        var_0,  # (shape: [1, 1024, 768], dtype: paddle.float32, stop_gradient: False)
+        var_1,  # (shape: [2], dtype: paddle.int32, stop_gradient: True)
     ):
         var_2 = paddle.nn.functional.common.linear(x=var_0, weight=self.parameter_0, bias=self.parameter_1, name=None)
         var_3 = var_1.__getitem__(0)
         var_4 = var_1.__getitem__(1)
         var_5 = var_2.shape
         var_6 = var_5.__getitem__(-1)
-        var_7 = var_2.reshape((0, var_3, var_4, var_6,))
-        var_8 = var_7.transpose((0, 3, 1, 2,))
+        var_7 = var_2.reshape(
+            (
+                0,
+                var_3,
+                var_4,
+                var_6,
+            )
+        )
+        var_8 = var_7.transpose(
+            (
+                0,
+                3,
+                1,
+                2,
+            )
+        )
         return var_8
 
 
 def create_tensor_inputs():
     inputs = (
         paddle.rand(shape=[1, 1024, 768], dtype=paddle.float32),
-        paddle.randint(low=0, high=10, shape=[2], dtype=paddle.int32),
+        paddle.to_tensor([16, 64], dtype=paddle.int32),
     )
     return inputs
 
 
 def create_numpy_inputs():
     inputs = (
-        np.random.random(size=[1, 1024, 768]).astype('float32'),
-        np.random.randint(low=0, high=10, size=[2], dtype='int32'),
+        np.random.random(size=[1, 1024, 768]).astype("float32"),
+        np.array([16, 64], dtype="int32"),
     )
     return inputs
 
@@ -50,9 +65,10 @@ class TestLayer(unittest.TestCase):
     def setUp(self):
         self.inputs = create_tensor_inputs()
         self.net = LayerCase()
+
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.set_flags({"FLAGS_prim_all": with_prim})
             if with_cinn:
                 build_strategy = paddle.static.BuildStrategy()
                 build_strategy.build_cinn_pass = True
@@ -62,6 +78,7 @@ class TestLayer(unittest.TestCase):
         paddle.seed(123)
         outs = net(*self.inputs)
         return outs
+
     def test_ast_prim_cinn(self):
         st_out = self.train(self.net, to_static=True)
         cinn_out = self.train(self.net, to_static=True, with_prim=True, with_cinn=True)
@@ -69,5 +86,5 @@ class TestLayer(unittest.TestCase):
             np.testing.assert_allclose(st.numpy(), cinn.numpy(), atol=1e-8)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/segmenter_segmenter_vit_small_linear_ade20k_512x512_160k/SIR_63.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/segmenter_segmenter_vit_small_linear_ade20k_512x512_160k/SIR_63.py
@@ -8,40 +8,55 @@ class LayerCase(paddle.nn.Layer):
     def __init__(self):
         super().__init__()
         self.parameter_0 = self.create_parameter(
-           shape=[384, 150],
-           dtype=paddle.float32,
+            shape=[384, 150],
+            dtype=paddle.float32,
         )
         self.parameter_1 = self.create_parameter(
-           shape=[150],
-           dtype=paddle.float32,
+            shape=[150],
+            dtype=paddle.float32,
         )
+
     def forward(
         self,
-        var_0,    # (shape: [1, 1024, 384], dtype: paddle.float32, stop_gradient: False)
-        var_1,    # (shape: [2], dtype: paddle.int32, stop_gradient: True)
+        var_0,  # (shape: [1, 1024, 384], dtype: paddle.float32, stop_gradient: False)
+        var_1,  # (shape: [2], dtype: paddle.int32, stop_gradient: True)
     ):
         var_2 = paddle.nn.functional.common.linear(x=var_0, weight=self.parameter_0, bias=self.parameter_1, name=None)
         var_3 = var_1.__getitem__(0)
         var_4 = var_1.__getitem__(1)
         var_5 = var_2.shape
         var_6 = var_5.__getitem__(-1)
-        var_7 = var_2.reshape((0, var_3, var_4, var_6,))
-        var_8 = var_7.transpose((0, 3, 1, 2,))
+        var_7 = var_2.reshape(
+            (
+                0,
+                var_3,
+                var_4,
+                var_6,
+            )
+        )
+        var_8 = var_7.transpose(
+            (
+                0,
+                3,
+                1,
+                2,
+            )
+        )
         return var_8
 
 
 def create_tensor_inputs():
     inputs = (
         paddle.rand(shape=[1, 1024, 384], dtype=paddle.float32),
-        paddle.randint(low=0, high=10, shape=[2], dtype=paddle.int32),
+        paddle.to_tensor([16, 64], dtype=paddle.int32),
     )
     return inputs
 
 
 def create_numpy_inputs():
     inputs = (
-        np.random.random(size=[1, 1024, 384]).astype('float32'),
-        np.random.randint(low=0, high=10, size=[2], dtype='int32'),
+        np.random.random(size=[1, 1024, 384]).astype("float32"),
+        np.array([16, 64], dtype="int32"),
     )
     return inputs
 
@@ -50,9 +65,10 @@ class TestLayer(unittest.TestCase):
     def setUp(self):
         self.inputs = create_tensor_inputs()
         self.net = LayerCase()
+
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.set_flags({"FLAGS_prim_all": with_prim})
             if with_cinn:
                 build_strategy = paddle.static.BuildStrategy()
                 build_strategy.build_cinn_pass = True
@@ -62,6 +78,7 @@ class TestLayer(unittest.TestCase):
         paddle.seed(123)
         outs = net(*self.inputs)
         return outs
+
     def test_ast_prim_cinn(self):
         st_out = self.train(self.net, to_static=True)
         cinn_out = self.train(self.net, to_static=True, with_prim=True, with_cinn=True)
@@ -69,5 +86,5 @@ class TestLayer(unittest.TestCase):
             np.testing.assert_allclose(st.numpy(), cinn.numpy(), atol=1e-8)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
修复了部分单测下，因为与shape相关的输入需要满足一定的数学约束，不能使用randint，否则会触发原生动态图测试跑挂。