### PR TITLE
[CINN] Change perf summary method

### DIFF
--- a/framework/e2e/PaddleLT_new/engine/paddle_eval_bm.py
+++ b/framework/e2e/PaddleLT_new/engine/paddle_eval_bm.py
@@ -7,6 +7,7 @@ eval 方法
 """
 import os
 import timeit
+import time
 import numpy as np
 import paddle
 from engine.paddle_xtools import reset
@@ -155,8 +156,12 @@ class LayerEvalBM(object):
         timeit.timeit(lambda: _perf(self.data), number=10)
         # timeit.timeit(lambda: _perf(self.data), number=int(self.perf_repeat * self.timeit_num * 0.2))
         for i in range(self.perf_repeat):
-            total_time = timeit.timeit(lambda: _perf(self.data), number=self.timeit_num)
+            start_time = time.time()
+            for _ in range(self.timeit_num):
+                _perf(self.data)
             paddle.core._cuda_synchronize(paddle.CUDAPlace(0))
+            end_time = time.time()
+            total_time = end_time - start_time
             total_time_list.append(total_time)
 
         save_pickle(data=total_time_list, filename="dy_eval_perf_" + self.layerfile)
@@ -190,7 +195,12 @@ class LayerEvalBM(object):
         timeit.timeit(lambda: _perf(self.data), number=10)
         # timeit.timeit(lambda: _perf(self.data), number=int(self.perf_repeat * self.timeit_num * 0.2))
         for i in range(self.perf_repeat):
-            total_time = timeit.timeit(lambda: _perf(self.data), number=self.timeit_num)
+            start_time = time.time()
+            for _ in range(self.timeit_num):
+                _perf(self.data)
+            paddle.core._cuda_synchronize(paddle.CUDAPlace(0))
+            end_time = time.time()
+            total_time = end_time - start_time
             total_time_list.append(total_time)
 
         save_pickle(data=total_time_list, filename="dy2st_eval_perf_" + self.layerfile)
@@ -228,7 +238,12 @@ class LayerEvalBM(object):
         timeit.timeit(lambda: _perf(self.data), number=10)
         # timeit.timeit(lambda: _perf(self.data), number=int(self.perf_repeat * self.timeit_num * 0.2))
         for i in range(self.perf_repeat):
-            total_time = timeit.timeit(lambda: _perf(self.data), number=self.timeit_num)
+            start_time = time.time()
+            for _ in range(self.timeit_num):
+                _perf(self.data)
+            paddle.core._cuda_synchronize(paddle.CUDAPlace(0))
+            end_time = time.time()
+            total_time = end_time - start_time
             total_time_list.append(total_time)
 
         save_pickle(data=total_time_list, filename="dy2st_eval_cinn_perf_" + self.layerfile + "_total_time_list")


### PR DESCRIPTION
动态图的 total_time 并没有将 synchronize 的时间统计进去，导致统计出来的性能指标会有问题
```
total_time = timeit.timeit(lambda: _perf(self.data), number=self.timeit_num)
paddle.core._cuda_synchronize(paddle.CUDAPlace(0))
```
由于 timeit 不支持 post process 处理，似乎无法处理这种 case，因此修改为使用 time 模块统计时间
并且出于一致性的考虑，将动转静和 CINN 的统计逻辑，也添加上了 _cuda_synchronize 语句