### PR TITLE
fix pir ut in `test_TransformerDecoderLayer.py`

### DIFF
--- a/framework/api/nn/test_Transformer.py
+++ b/framework/api/nn/test_Transformer.py
@@ -17,7 +17,14 @@ source_length, target_length = 20, 30  # 3, 3
 num_encoder_layers, num_decoder_layers = 2, 2
 np.random.seed(123)
 paddle.seed(123)
-paddle.framework.random._manual_program_seed(123)
+if paddle.framework.use_pir_api():
+    with paddle.pir_utils.OldIrGuard():
+        # Note: dygraph use self.main_program.global_block().create_parameter(),
+        # it's need manual seed to old Program
+        paddle.framework.random._manual_program_seed(123)
+    paddle.framework.random._manual_program_seed(123)
+else:
+    paddle.framework.random._manual_program_seed(123)
 
 
 @pytest.mark.api_nn_Transformer_parameters
@@ -53,7 +60,14 @@ def test2():
     """
     np.random.seed(123)
     paddle.seed(123)
-    paddle.framework.random._manual_program_seed(123)
+    if paddle.framework.use_pir_api():
+        with paddle.pir_utils.OldIrGuard():
+            # Note: dygraph use self.main_program.global_block().create_parameter(),
+            # it's need manual seed to old Program
+            paddle.framework.random._manual_program_seed(123)
+        paddle.framework.random._manual_program_seed(123)
+    else:
+        paddle.framework.random._manual_program_seed(123)
     paddle.disable_static()
     # src: [batch_size, tgt_len, d_model]
     enc_input = paddle.rand((2, 4, 128))

--- a/framework/api/nn/test_TransformerDecoderLayer.py
+++ b/framework/api/nn/test_TransformerDecoderLayer.py
@@ -27,9 +27,10 @@ class Test(unittest.TestCase):
             with paddle.pir_utils.OldIrGuard():
                 # Note: dygraph use self.main_program.global_block().create_parameter(),
                 # it's need manual seed to old Program
-                paddle.framework.random._manual_program_seed(self.seed)
+                paddle.framework.random._manual_program_seed(2020)
+            paddle.framework.random._manual_program_seed(2020)
         else:
-            paddle.framework.random._manual_program_seed(self.seed)
+            paddle.framework.random._manual_program_seed(2020)
         activation = "relu"
         normalize_before = False
         batch_size, d_model, n_head, dim_feedforward, dropout = generate_basic_params(mode="decoder_layer")[:5]

--- a/framework/api/nn/test_TransformerDecoderLayer.py
+++ b/framework/api/nn/test_TransformerDecoderLayer.py
@@ -23,8 +23,13 @@ class Test(unittest.TestCase):
         test_transformer_decoder_layer
         """
         paddle.seed(2020)
-        with paddle.pir_utils.OldIrGuard():
-            paddle.framework.random._manual_program_seed(2020)
+        if paddle.framework.use_pir_api():
+            with paddle.pir_utils.OldIrGuard():
+                # Note: dygraph use self.main_program.global_block().create_parameter(),
+                # it's need manual seed to old Program
+                paddle.framework.random._manual_program_seed(self.seed)
+        else:
+            paddle.framework.random._manual_program_seed(self.seed)
         activation = "relu"
         normalize_before = False
         batch_size, d_model, n_head, dim_feedforward, dropout = generate_basic_params(mode="decoder_layer")[:5]

--- a/framework/api/nn/test_TransformerDecoderLayer.py
+++ b/framework/api/nn/test_TransformerDecoderLayer.py
@@ -23,7 +23,8 @@ class Test(unittest.TestCase):
         test_transformer_decoder_layer
         """
         paddle.seed(2020)
-        paddle.framework.random._manual_program_seed(2020)
+        with paddle.pir_utils.OldIrGuard():
+            paddle.framework.random._manual_program_seed(2020)
         activation = "relu"
         normalize_before = False
         batch_size, d_model, n_head, dim_feedforward, dropout = generate_basic_params(mode="decoder_layer")[:5]

--- a/framework/custom_device/nn/test_Transformer.py
+++ b/framework/custom_device/nn/test_Transformer.py
@@ -17,7 +17,14 @@ source_length, target_length = 20, 30  # 3, 3
 num_encoder_layers, num_decoder_layers = 2, 2
 np.random.seed(123)
 paddle.seed(123)
-paddle.framework.random._manual_program_seed(123)
+if paddle.framework.use_pir_api():
+    with paddle.pir_utils.OldIrGuard():
+        # Note: dygraph use self.main_program.global_block().create_parameter(),
+        # it's need manual seed to old Program
+        paddle.framework.random._manual_program_seed(123)
+    paddle.framework.random._manual_program_seed(123)
+else:
+    paddle.framework.random._manual_program_seed(123)
 
 
 @pytest.mark.api_nn_Transformer_parameters
@@ -53,7 +60,14 @@ def test2():
     """
     np.random.seed(123)
     paddle.seed(123)
-    paddle.framework.random._manual_program_seed(123)
+    if paddle.framework.use_pir_api():
+        with paddle.pir_utils.OldIrGuard():
+            # Note: dygraph use self.main_program.global_block().create_parameter(),
+            # it's need manual seed to old Program
+            paddle.framework.random._manual_program_seed(123)
+        paddle.framework.random._manual_program_seed(123)
+    else:
+        paddle.framework.random._manual_program_seed(123)
     paddle.disable_static()
     # src: [batch_size, tgt_len, d_model]
     enc_input = paddle.rand((2, 4, 128))

--- a/framework/custom_device/nn/test_TransformerDecoderLayer.py
+++ b/framework/custom_device/nn/test_TransformerDecoderLayer.py
@@ -23,7 +23,14 @@ class Test(unittest.TestCase):
         test_transformer_decoder_layer
         """
         paddle.seed(2020)
-        paddle.framework.random._manual_program_seed(2020)
+        if paddle.framework.use_pir_api():
+            with paddle.pir_utils.OldIrGuard():
+                # Note: dygraph use self.main_program.global_block().create_parameter(),
+                # it's need manual seed to old Program
+                paddle.framework.random._manual_program_seed(2020)
+            paddle.framework.random._manual_program_seed(2020)
+        else:
+            paddle.framework.random._manual_program_seed(2020)
         activation = "relu"
         normalize_before = False
         batch_size, d_model, n_head, dim_feedforward, dropout = generate_basic_params(mode="decoder_layer")[:5]


### PR DESCRIPTION
> Note: dygraph use self.main_program.global_block().create_parameter(), it's need manual seed to old Program

打开 FLAGS_enable_pir_api = True 时, 动态图需要用这个种子,需要加with paddle.pir_utils.OldlrGuard()

link https://github.com/PaddlePaddle/Paddle/issues/65943