### PR TITLE
fix  pir ut in `test_beamsearchdecoder.py`

### DIFF
--- a/framework/api/nn/test_beamsearchdecoder.py
+++ b/framework/api/nn/test_beamsearchdecoder.py
@@ -591,6 +591,8 @@ def test_beamsearchdecoder8():
         # print(e)
         if "invalid literal for int()" in e.args[0]:
             pass
+        elif "must be double" in e.args[0] and paddle.framework.in_pir_mode():
+            pass
         else:
             raise Exception
     paddle.disable_static()


### PR DESCRIPTION
PIR 下抛出异常信息为 `(InvalidType) full(): argument (position 2) must be double, but got str (at ..\paddle\fluid\pybind\op_function_common.cc:384)`

link https://github.com/PaddlePaddle/Paddle/issues/65943

> 对异常的信息是否需要判别类型