### PR TITLE
fix pir ut in `test_squeeze.py` & `test_functional_transpose_conv2d.py` & `test_functional_pad.py`

### DIFF
--- a/framework/api/nn/apibase.py
+++ b/framework/api/nn/apibase.py
@@ -631,7 +631,11 @@ class APIBase(object):
                         # print(list(grad_var.values()))
                         # print([output] + list(grad_var.values()))
                         res = exe.run(
-                            main_program, feed=kwargs, fetch_list=[output] + list(grad_var.values()), return_numpy=True
+                            main_program,
+                            feed=kwargs,
+                            fetch_list=[output]
+                            + [value for (key, value) in grad_var.items() if key not in self.no_grad_var],
+                            return_numpy=True,
                         )
                         # combine grad
                         grad = dict(zip(xyz, res[1:]))

--- a/framework/api/paddlebase/apibase.py
+++ b/framework/api/paddlebase/apibase.py
@@ -642,7 +642,11 @@ class APIBase(object):
                         # print(list(grad_var.values()))
                         # print([output] + list(grad_var.values()))
                         res = exe.run(
-                            main_program, feed=kwargs, fetch_list=[output] + list(grad_var.values()), return_numpy=True
+                            main_program,
+                            feed=kwargs,
+                            fetch_list=[output]
+                            + [value for (key, value) in grad_var.items() if key not in self.no_grad_var],
+                            return_numpy=True,
                         )
                         # combine grad
                         grad = dict(zip(xyz, res[1:]))

--- a/framework/api/paddlebase/test_meshgrid.py
+++ b/framework/api/paddlebase/test_meshgrid.py
@@ -29,10 +29,9 @@ def test_meshgrid_base():
         for place in places:
             paddle.disable_static(place)
             res = paddle.meshgrid(paddle.to_tensor(x), paddle.to_tensor(y))
-            expect = list(np.meshgrid(x, y))
-            for i, exp in enumerate(expect):
-                expect[i] = exp.transpose(1, 0)
-            compare(res, expect)
+            expect = np.meshgrid(x, y)
+            expect_list = [exp.transpose(1, 0) for exp in expect]
+            compare(res, expect_list)
             paddle.enable_static()
 
 
@@ -49,8 +48,7 @@ def test_meshgrid():
         for place in places:
             paddle.disable_static(place)
             res = paddle.meshgrid(paddle.to_tensor(x), paddle.to_tensor(y), paddle.to_tensor(z))
-            expect = list(np.meshgrid(x, y, z))
-            for i, exp in enumerate(expect):
-                expect[i] = exp.transpose(1, 0, 2)
-            compare(res, expect)
+            expect = np.meshgrid(x, y, z)
+            expect_list = [exp.transpose(1, 0, 2) for exp in expect]
+            compare(res, expect_list)
             paddle.enable_static()


### PR DESCRIPTION
- 这里静态图下，通过 paddle.static.gradients 获取反向梯度op，对于无关输出的单个input 梯度，旧IR下返回[],PIR下返回[None]。fetch_list 只支持 Value 和 str。(旧IR返回的[],fetch_list=[[]]，exe.run之后得到[])。因为设置有 self.no_grad_var，这里直接不传入其中的 Var

- numpy2.0时， np.meshgrid返回的是tuple，` ‘tuple’ object does not support item assignment`，顺便修改一下~