### PR TITLE
fix some pir ut with ` not paddle.framework.use_pir_api():`

### DIFF
--- a/framework/api/nn/test_spectral_norm.py
+++ b/framework/api/nn/test_spectral_norm.py
@@ -96,8 +96,9 @@ def test_spectralnorm0():
         spectral_norm._parameters["weight_v"].set_value(paddle.to_tensor(weight_v))
         spectral_norm_out = spectral_norm(x)
 
-        static_res = cal_specal_norm_static(x_data, place, w0=weight_u, w1=weight_v)
-        assert np.allclose(static_res, spectral_norm_out.numpy())
+        if not paddle.framework.use_pir_api():
+            static_res = cal_specal_norm_static(x_data, place, w0=weight_u, w1=weight_v)
+            assert np.allclose(static_res, spectral_norm_out.numpy())
         assert np.allclose(spectral_norm_out.numpy(), expect, atol=1e-4)
 
 
@@ -120,8 +121,10 @@ def test_spectralnorm1():
         spectral_norm._parameters["weight_v"].set_value(paddle.to_tensor(weight_v))
         spectral_norm_out = spectral_norm(x)
 
-        static_res = cal_specal_norm_static(x_data, place, w0=weight_u, w1=weight_v)
-        assert np.allclose(static_res, spectral_norm_out.numpy())
+        if not paddle.framework.use_pir_api():
+            # Don't test feed the parameter in pir.
+            static_res = cal_specal_norm_static(x_data, place, w0=weight_u, w1=weight_v)
+            assert np.allclose(static_res, spectral_norm_out.numpy())
         assert np.allclose(spectral_norm_out.numpy(), expect, atol=1e-4)
 
 
@@ -144,8 +147,9 @@ def test_spectralnorm2():
         spectral_norm._parameters["weight_v"].set_value(paddle.to_tensor(weight_v))
         spectral_norm_out = spectral_norm(x)
 
-        static_res = cal_specal_norm_static(x_data, place, w0=weight_u, w1=weight_v)
-        assert np.allclose(static_res, spectral_norm_out.numpy())
+        if not paddle.framework.use_pir_api():
+            static_res = cal_specal_norm_static(x_data, place, w0=weight_u, w1=weight_v)
+            assert np.allclose(static_res, spectral_norm_out.numpy())
         assert np.allclose(spectral_norm_out.numpy(), expect, atol=1e-4)
 
 
@@ -168,8 +172,9 @@ def test_spectralnorm3():
         spectral_norm._parameters["weight_v"].set_value(paddle.to_tensor(weight_v))
         spectral_norm_out = spectral_norm(x)
 
-        static_res = cal_specal_norm_static(x_data, place, w0=weight_u, w1=weight_v)
-        assert np.allclose(static_res, spectral_norm_out.numpy())
+        if not paddle.framework.use_pir_api():
+            static_res = cal_specal_norm_static(x_data, place, w0=weight_u, w1=weight_v)
+            assert np.allclose(static_res, spectral_norm_out.numpy())
         assert np.allclose(spectral_norm_out.numpy(), expect, atol=1e-4)
 
 
@@ -192,8 +197,9 @@ def test_spectralnorm4():
         spectral_norm._parameters["weight_v"].set_value(paddle.to_tensor(weight_v))
         spectral_norm_out = spectral_norm(x)
 
-        static_res = cal_specal_norm_static(x_data, place, w0=weight_u, w1=weight_v)
-        assert np.allclose(static_res, spectral_norm_out.numpy())
+        if not paddle.framework.use_pir_api():
+            static_res = cal_specal_norm_static(x_data, place, w0=weight_u, w1=weight_v)
+            assert np.allclose(static_res, spectral_norm_out.numpy())
         assert np.allclose(spectral_norm_out.numpy(), expect, atol=1e-4)
 
 
@@ -216,8 +222,9 @@ def test_spectralnorm5():
         spectral_norm._parameters["weight_v"].set_value(paddle.to_tensor(weight_v))
         spectral_norm_out = spectral_norm(x)
 
-        static_res = cal_specal_norm_static(x_data, place, w0=weight_u, w1=weight_v, dim=1)
-        assert np.allclose(static_res, spectral_norm_out.numpy())
+        if not paddle.framework.use_pir_api():
+            static_res = cal_specal_norm_static(x_data, place, w0=weight_u, w1=weight_v, dim=1)
+            assert np.allclose(static_res, spectral_norm_out.numpy())
         assert np.allclose(spectral_norm_out.numpy(), expect, atol=1e-4)
 
 
@@ -241,8 +248,9 @@ def test_spectralnorm6():
         spectral_norm._parameters["weight_v"].set_value(paddle.to_tensor(weight_v))
         spectral_norm_out = spectral_norm(x)
 
-        static_res = cal_specal_norm_static(x_data, place, w0=weight_u, w1=weight_v, dim=1, power_iters=10)
-        assert np.allclose(static_res, spectral_norm_out.numpy())
+        if not paddle.framework.use_pir_api():
+            static_res = cal_specal_norm_static(x_data, place, w0=weight_u, w1=weight_v, dim=1, power_iters=10)
+            assert np.allclose(static_res, spectral_norm_out.numpy())
         assert np.allclose(spectral_norm_out.numpy(), expect, atol=1e-4)
 
 
@@ -267,8 +275,9 @@ def test_spectralnorm7():
         spectral_norm._parameters["weight_v"].set_value(paddle.to_tensor(weight_v))
         spectral_norm_out = spectral_norm(x)
 
-        static_res = cal_specal_norm_static(
-            x_data, place, w0=weight_u, w1=weight_v, dim=1, power_iters=10, dtype="float64"
-        )
-        assert np.allclose(static_res, spectral_norm_out.numpy())
+        if not paddle.framework.use_pir_api():
+            static_res = cal_specal_norm_static(
+                x_data, place, w0=weight_u, w1=weight_v, dim=1, power_iters=10, dtype="float64"
+            )
+            assert np.allclose(static_res, spectral_norm_out.numpy())
         assert np.allclose(spectral_norm_out.numpy(), expect, atol=1e-4)

--- a/framework/api/paddlebase/apibase.py
+++ b/framework/api/paddlebase/apibase.py
@@ -13,6 +13,21 @@ import paddle
 from paddle import to_tensor
 
 
+class TestWithoutPIR:
+    """A context manager to test the static graph without pir mode."""
+
+    def __init__(self, obj) -> None:
+        self.obj = obj
+        self.flag = obj.support_pir
+
+    def __enter__(self):
+        self.obj.change(False)
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.obj.change(self.flag)
+
+
 class APIBase(object):
     """
     API test base object
@@ -32,6 +47,8 @@ class APIBase(object):
     def __init__(self, func):
         self.seed = 33
         np.random.seed(self.seed)
+        # pir mode supportion
+        self.support_pir = True
         # debug mode
         self.debug = False
         # if debug mode=True choose whether test dygrpah or static
@@ -70,6 +87,12 @@ class APIBase(object):
             logging.basicConfig(level=logging.DEBUG, format="%(asctime)s - %(levelname)s - %(message)s")
         else:
             logging.basicConfig(level=logging.ERROR, format="%(asctime)s - %(levelname)s - %(message)s")
+
+    def change(self, support_pir: bool) -> None:
+        """
+        Change support_pir to control whether test with pir mode.
+        """
+        self.support_pir = support_pir
 
     def hook(self):
         """
@@ -152,7 +175,7 @@ class APIBase(object):
                         logging.info("[dygraph grad]")
                         logging.info(dygraph_backward_res)
                     paddle.enable_static()
-                if self.static:
+                if self.static and self.support_pir:
                     # start run paddle static
                     logging.info("[start] run " + self.__class__.__name__ + " static")
                     if self.enable_backward:
@@ -171,7 +194,7 @@ class APIBase(object):
                     grad = self.compute_grad(res, data, **kwargs)
                     logging.info("[numeric grad]")
                     logging.info(grad)
-                    if self.static and self.dygraph:
+                    if self.static and self.support_pir and self.dygraph:
                         compare_grad(
                             static_backward_res, dygraph_backward_res, mode="both", no_grad_var=self.no_grad_var
                         )
@@ -184,7 +207,7 @@ class APIBase(object):
                             rtol=self.rtol,
                             no_grad_var=self.no_grad_var,
                         )
-                    if self.static:
+                    if self.static and self.support_pir:
                         compare_grad(
                             static_backward_res,
                             grad,
@@ -222,7 +245,7 @@ class APIBase(object):
                         dygraph_backward_res = self._dygraph_backward(dygraph_forward_res)
 
                 # (2) start run paddle static
-                if self.static:
+                if self.static and self.support_pir:
                     paddle.enable_static()
                     logging.info("[start] run " + self.__class__.__name__ + " static")
                     # ① calculate forward and backward result
@@ -238,7 +261,7 @@ class APIBase(object):
                     # ① calculate numerical gradient
                     grad = self.compute_grad(res, data, **kwargs)
                     # ② compare  gradient
-                    if self.static and self.dygraph:
+                    if self.static and self.support_pir and self.dygraph:
                         compare_grad(
                             static_backward_res, dygraph_backward_res, mode="both", no_grad_var=self.no_grad_var
                         )
@@ -251,7 +274,7 @@ class APIBase(object):
                             rtol=self.rtol,
                             no_grad_var=self.no_grad_var,
                         )
-                    if self.static:
+                    if self.static and self.support_pir:
                         compare_grad(
                             static_backward_res,
                             grad,
@@ -295,7 +318,7 @@ class APIBase(object):
                     logging.info("[dygraph grad]")
                     logging.info(dygraph_backward_res)
                 paddle.enable_static()
-            if self.static:
+            if self.static and self.support_pir:
                 # start run paddle static
                 logging.info("[start] run " + self.__class__.__name__ + " static")
                 if self.enable_backward:
@@ -314,7 +337,7 @@ class APIBase(object):
                 grad = self.compute_grad(res, data, **kwargs)
                 logging.info("[numeric grad]")
                 logging.info(grad)
-                if self.static and self.dygraph:
+                if self.static and self.support_pir and self.dygraph:
                     compare_grad(static_backward_res, dygraph_backward_res, mode="both", no_grad_var=self.no_grad_var)
                 if self.dygraph:
                     compare_grad(
@@ -325,7 +348,7 @@ class APIBase(object):
                         rtol=self.rtol,
                         no_grad_var=self.no_grad_var,
                     )
-                if self.static:
+                if self.static and self.support_pir:
                     compare_grad(
                         static_backward_res,
                         grad,
@@ -358,7 +381,7 @@ class APIBase(object):
                     dygraph_backward_res = self._dygraph_backward(dygraph_forward_res)
 
             # (2) start run paddle static
-            if self.static:
+            if self.static and self.support_pir:
                 paddle.enable_static()
                 logging.info("[start] run " + self.__class__.__name__ + " static")
                 # ① calculate forward and backward result
@@ -374,7 +397,7 @@ class APIBase(object):
                 # ① calculate numerical gradient
                 grad = self.compute_grad(res, data, **kwargs)
                 # ② compare gradient
-                if self.dygraph and self.static:
+                if self.dygraph and self.static and self.support_pir:
                     compare_grad(static_backward_res, dygraph_backward_res, mode="both", no_grad_var=self.no_grad_var)
                 if self.dygraph:
                     compare_grad(
@@ -385,7 +408,7 @@ class APIBase(object):
                         rtol=self.rtol,
                         no_grad_var=self.no_grad_var,
                     )
-                if self.static:
+                if self.static and self.support_pir:
                     compare_grad(
                         static_backward_res,
                         grad,

--- a/framework/api/paddlebase/test_allclose.py
+++ b/framework/api/paddlebase/test_allclose.py
@@ -4,7 +4,7 @@
 """
 test allclose
 """
-from apibase import APIBase
+from apibase import APIBase, TestWithoutPIR
 import paddle
 import pytest
 import numpy as np
@@ -60,15 +60,14 @@ def test_allclose1():
     """
     paddle.allclose() returns False when the difference equals threshold,it's a bug
     """
-    if paddle.framework.use_pir_api():
-        return
     x = np.array([10.1])
     y = np.array([10])
     a = 0.0
     r = 0.01
     res = np.allclose(x, y, rtol=r, atol=a, equal_nan=False)
     res = np.array(res)
-    obj2.run(res=res, x=x, y=y, rtol=r, atol=a, equal_nan=False)
+    with TestWithoutPIR(obj2):
+        obj2.run(res=res, x=x, y=y, rtol=r, atol=a, equal_nan=False)
 
 
 @pytest.mark.api_base_allclose_parameters

--- a/framework/api/paddlebase/test_allclose.py
+++ b/framework/api/paddlebase/test_allclose.py
@@ -60,6 +60,8 @@ def test_allclose1():
     """
     paddle.allclose() returns False when the difference equals threshold,it's a bug
     """
+    if paddle.framework.use_pir_api():
+        return
     x = np.array([10.1])
     y = np.array([10])
     a = 0.0

--- a/framework/api/paddlebase/test_kthvalue.py
+++ b/framework/api/paddlebase/test_kthvalue.py
@@ -120,8 +120,9 @@ def test_kthvalue3():
     axis = 2
     keepdims = True
     x = np.arange(1, 25).reshape(3, 2, 4).astype(np.float32)
-    # res = np.array([[[4. ], [8. ]],
-    #                  [[12.], [16.]],
-    #                  [[20.], [24.]]])
-    res = np.array([[4.0, 8.0], [12.0, 16.0], [20.0, 24.0]])
+    if paddle.framework.use_pir_api():
+        res = np.array([[[4.0], [8.0]], [[12.0], [16.0]], [[20.0], [24.0]]])
+    else:
+        # It's a bug for old static program, reslut is same with `keepdims = False` setting.
+        res = np.array([[4.0, 8.0], [12.0, 16.0], [20.0, 24.0]])
     obj1.run(res=res, x=x, k=k, axis=axis, keepdim=keepdims)

--- a/framework/api/paddlebase/test_mean.py
+++ b/framework/api/paddlebase/test_mean.py
@@ -181,6 +181,9 @@ def test_mean13():
     run axis is Tensor, axis=Tensor([0,1]), res should [1, 1, 3],
     :return:
     """
+    if paddle.framework.use_pir_api():
+        # The axis cant't be Tensor.
+        return
     x = np.array([[[2.0, 3.0, 4.0]], [[4.0, 3.0, 4.0]]]).astype("float32")
     axis = np.array([0, 1])
     res = np.mean(x, axis=(0, 1))

--- a/framework/api/paddlebase/test_mean.py
+++ b/framework/api/paddlebase/test_mean.py
@@ -1,7 +1,7 @@
 """
 test mean
 """
-from apibase import APIBase
+from apibase import APIBase, TestWithoutPIR
 
 import paddle
 import pytest
@@ -181,10 +181,8 @@ def test_mean13():
     run axis is Tensor, axis=Tensor([0,1]), res should [1, 1, 3],
     :return:
     """
-    if paddle.framework.use_pir_api():
-        # The axis cant't be Tensor.
-        return
     x = np.array([[[2.0, 3.0, 4.0]], [[4.0, 3.0, 4.0]]]).astype("float32")
     axis = np.array([0, 1])
     res = np.mean(x, axis=(0, 1))
-    obj.run(res=res, x=x, axis=axis)
+    with TestWithoutPIR(obj):
+        obj.run(res=res, x=x, axis=axis)


### PR DESCRIPTION
## overview
- `framework/api/nn/test_spectral_norm.py`。PIR不支持feed parameter的写法。
- `framework/api/paddlebase/test_allclose.py`。属于旧静态图的bug，PIR下不测试。
- `framework/api/paddlebase/test_mean.py`。PIR 下 axis 不能是 Tensor。
- `framework/api/paddlebase/test_kthvalue.py`.属于旧静态图的bug，似乎是对应的 `keepdims `参数无效。

## todo
