### PR TITLE
[CINN]Fix topk indices no grad problem

### DIFF
--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/cascade_rcnn_cascade_mask_rcnn_r50_vd_fpn_ssld_1x_coco/SIR_85.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/cascade_rcnn_cascade_mask_rcnn_r50_vd_fpn_ssld_1x_coco/SIR_85.py
@@ -25,6 +25,9 @@ class LayerCase(paddle.nn.Layer):
         var_11 = paddle.tensor.search.where(var_9, var_10, var_8)
         var_12 = var_2.flatten()
         var_13 = var_11.flatten()
+        # bool/int tensors has no grad
+        var_12.stop_gradient = True
+        var_13.stop_gradient = True
         return var_12, var_13
 
 

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/dcn_faster_rcnn_dcn_r101_vd_fpn_1x_coco/SIR_49.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/dcn_faster_rcnn_dcn_r101_vd_fpn_1x_coco/SIR_49.py
@@ -34,6 +34,9 @@ class LayerCase(paddle.nn.Layer):
         var_20 = paddle.tensor.search.where(var_18, var_19, var_11)
         var_21 = var_2.flatten()
         var_22 = var_20.flatten()
+        # bool/int tensors has no grad
+        var_21.stop_gradient = True
+        var_22.stop_gradient = True
         return var_21, var_22
 
 

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/faster_rcnn_faster_rcnn_r101_fpn_2x_coco/SIR_47.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/faster_rcnn_faster_rcnn_r101_fpn_2x_coco/SIR_47.py
@@ -34,6 +34,9 @@ class LayerCase(paddle.nn.Layer):
         var_20 = paddle.tensor.search.where(var_18, var_19, var_11)
         var_21 = var_2.flatten()
         var_22 = var_20.flatten()
+        # bool/int tensors has no grad
+        var_21.stop_gradient = True
+        var_22.stop_gradient = True
         return var_21, var_22
 
 

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/faster_rcnn_faster_rcnn_r101_vd_fpn_1x_coco/SIR_49.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/faster_rcnn_faster_rcnn_r101_vd_fpn_1x_coco/SIR_49.py
@@ -34,6 +34,9 @@ class LayerCase(paddle.nn.Layer):
         var_20 = paddle.tensor.search.where(var_18, var_19, var_11)
         var_21 = var_2.flatten()
         var_22 = var_20.flatten()
+        # bool/int tensors has no grad
+        var_21.stop_gradient = True
+        var_22.stop_gradient = True
         return var_21, var_22
 
 

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/faster_rcnn_faster_rcnn_r50_vd_fpn_2x_coco/SIR_49.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/faster_rcnn_faster_rcnn_r50_vd_fpn_2x_coco/SIR_49.py
@@ -34,6 +34,9 @@ class LayerCase(paddle.nn.Layer):
         var_20 = paddle.tensor.search.where(var_18, var_19, var_11)
         var_21 = var_2.flatten()
         var_22 = var_20.flatten()
+        # bool/int tensors has no grad
+        var_21.stop_gradient = True
+        var_22.stop_gradient = True
         return var_21, var_22
 
 

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/faster_rcnn_faster_rcnn_r50_vd_fpn_ssld_1x_coco/SIR_49.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/faster_rcnn_faster_rcnn_r50_vd_fpn_ssld_1x_coco/SIR_49.py
@@ -34,6 +34,9 @@ class LayerCase(paddle.nn.Layer):
         var_20 = paddle.tensor.search.where(var_18, var_19, var_11)
         var_21 = var_2.flatten()
         var_22 = var_20.flatten()
+        # bool/int tensors has no grad
+        var_21.stop_gradient = True
+        var_22.stop_gradient = True
         return var_21, var_22
 
 

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/faster_rcnn_faster_rcnn_swin_tiny_fpn_2x_coco/SIR_114.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/faster_rcnn_faster_rcnn_swin_tiny_fpn_2x_coco/SIR_114.py
@@ -25,6 +25,9 @@ class LayerCase(paddle.nn.Layer):
         var_11 = paddle.tensor.search.where(var_9, var_10, var_8)
         var_12 = var_2.flatten()
         var_13 = var_11.flatten()
+        # bool/int tensors has no grad
+        var_12.stop_gradient = True
+        var_13.stop_gradient = True
         return var_12, var_13
 
 

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/faster_rcnn_faster_rcnn_swin_tiny_fpn_2x_coco/SIR_99.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/faster_rcnn_faster_rcnn_swin_tiny_fpn_2x_coco/SIR_99.py
@@ -34,6 +34,9 @@ class LayerCase(paddle.nn.Layer):
         var_20 = paddle.tensor.search.where(var_18, var_19, var_11)
         var_21 = var_2.flatten()
         var_22 = var_20.flatten()
+        # bool/int tensors has no grad
+        var_21.stop_gradient = True
+        var_22.stop_gradient = True
         return var_21, var_22
 
 

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/hrnet_faster_rcnn_hrnetv2p_w18_1x_coco/SIR_43.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/hrnet_faster_rcnn_hrnetv2p_w18_1x_coco/SIR_43.py
@@ -34,6 +34,9 @@ class LayerCase(paddle.nn.Layer):
         var_20 = paddle.tensor.search.where(var_18, var_19, var_11)
         var_21 = var_2.flatten()
         var_22 = var_20.flatten()
+        # bool/int tensors has no grad
+        var_21.stop_gradient = True
+        var_22.stop_gradient = True
         return var_21, var_22
 
 

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/hrnet_faster_rcnn_hrnetv2p_w18_2x_coco/SIR_58.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/hrnet_faster_rcnn_hrnetv2p_w18_2x_coco/SIR_58.py
@@ -25,6 +25,9 @@ class LayerCase(paddle.nn.Layer):
         var_11 = paddle.tensor.search.where(var_9, var_10, var_8)
         var_12 = var_2.flatten()
         var_13 = var_11.flatten()
+        # bool/int tensors has no grad
+        var_12.stop_gradient = True
+        var_13.stop_gradient = True
         return var_12, var_13
 
 

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/mask_rcnn_mask_rcnn_x101_vd_64x4d_fpn_2x_coco/SIR_49.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/mask_rcnn_mask_rcnn_x101_vd_64x4d_fpn_2x_coco/SIR_49.py
@@ -34,6 +34,9 @@ class LayerCase(paddle.nn.Layer):
         var_20 = paddle.tensor.search.where(var_18, var_19, var_11)
         var_21 = var_2.flatten()
         var_22 = var_20.flatten()
+        # bool/int tensors has no grad
+        var_21.stop_gradient = True
+        var_22.stop_gradient = True
         return var_21, var_22
 
 

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rcnn_enhance_faster_rcnn_enhance_3x_coco/SIR_49.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rcnn_enhance_faster_rcnn_enhance_3x_coco/SIR_49.py
@@ -34,6 +34,9 @@ class LayerCase(paddle.nn.Layer):
         var_20 = paddle.tensor.search.where(var_18, var_19, var_11)
         var_21 = var_2.flatten()
         var_22 = var_20.flatten()
+        # bool/int tensors has no grad
+        var_21.stop_gradient = True
+        var_22.stop_gradient = True
         return var_21, var_22
 
 

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/sniper_faster_rcnn_r50_fpn_1x_sniper_visdrone/SIR_47.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/sniper_faster_rcnn_r50_fpn_1x_sniper_visdrone/SIR_47.py
@@ -34,6 +34,9 @@ class LayerCase(paddle.nn.Layer):
         var_20 = paddle.tensor.search.where(var_18, var_19, var_11)
         var_21 = var_2.flatten()
         var_22 = var_20.flatten()
+        # bool/int tensors has no grad
+        var_21.stop_gradient = True
+        var_22.stop_gradient = True
         return var_21, var_22
 
 

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/sniper_faster_rcnn_r50_fpn_1x_sniper_visdrone/SIR_62.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/sniper_faster_rcnn_r50_fpn_1x_sniper_visdrone/SIR_62.py
@@ -25,6 +25,9 @@ class LayerCase(paddle.nn.Layer):
         var_11 = paddle.tensor.search.where(var_9, var_10, var_8)
         var_12 = var_2.flatten()
         var_13 = var_11.flatten()
+        # bool/int tensors has no grad
+        var_12.stop_gradient = True
+        var_13.stop_gradient = True
         return var_12, var_13
 
 

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/sniper_faster_rcnn_r50_fpn_1x_visdrone/SIR_47.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/sniper_faster_rcnn_r50_fpn_1x_visdrone/SIR_47.py
@@ -34,6 +34,9 @@ class LayerCase(paddle.nn.Layer):
         var_20 = paddle.tensor.search.where(var_18, var_19, var_11)
         var_21 = var_2.flatten()
         var_22 = var_20.flatten()
+        # bool/int tensors has no grad
+        var_21.stop_gradient = True
+        var_22.stop_gradient = True
         return var_21, var_22
 
 

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/sniper_faster_rcnn_r50_fpn_1x_visdrone/SIR_62.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/sniper_faster_rcnn_r50_fpn_1x_visdrone/SIR_62.py
@@ -25,6 +25,9 @@ class LayerCase(paddle.nn.Layer):
         var_11 = paddle.tensor.search.where(var_9, var_10, var_8)
         var_12 = var_2.flatten()
         var_13 = var_11.flatten()
+        # bool/int tensors has no grad
+        var_12.stop_gradient = True
+        var_13.stop_gradient = True
         return var_12, var_13
 
 


### PR DESCRIPTION
### 原因
out, indices = topk(x)。下游基于输出out得到的是bool类型的mask，以及indices flatten后的int，都是无法计算梯度的，导致在topk_grad调用时发现out_grad为未初始化的Tensor

### 竞品
torch也会报错，实验脚本如下：
```python
import torch

x = torch.randn([4,10])
x.requires_grad=True
out, index = torch.topk(x, k=1, dim=0)
# y1 = out > 1
y2 = index.flatten()
loss = y2.sum()
loss.backward()

print(x.grad)
```