### PR TITLE
Fix test for SIR_32 and SIR_35

### DIFF
--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Seg_cases/isanet_isanet_resnet50_os8_cityscapes_769x769_80k/SIR_32.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Seg_cases/isanet_isanet_resnet50_os8_cityscapes_769x769_80k/SIR_32.py
@@ -7,14 +7,15 @@ import numpy as np
 class LayerCase(paddle.nn.Layer):
     def __init__(self):
         super().__init__()
+
     def forward(
         self,
-        var_0,    # (shape: [1], dtype: paddle.int32, stop_gradient: True)
-        var_1,    # (shape: [1], dtype: paddle.int32, stop_gradient: True)
-        var_2,    # (shape: [1, 512, 97, 97], dtype: paddle.float32, stop_gradient: False)
-        var_3,    # (shape: [4], dtype: paddle.int32, stop_gradient: True)
-        var_4,    # (shape: [1], dtype: paddle.int32, stop_gradient: True)
-        var_5,    # (shape: [1], dtype: paddle.int32, stop_gradient: True)
+        var_0,  # (shape: [1], dtype: paddle.int32, stop_gradient: True)
+        var_1,  # (shape: [1], dtype: paddle.int32, stop_gradient: True)
+        var_2,  # (shape: [1, 512, 97, 97], dtype: paddle.float32, stop_gradient: False)
+        var_3,  # (shape: [4], dtype: paddle.int32, stop_gradient: True)
+        var_4,  # (shape: [1], dtype: paddle.int32, stop_gradient: True)
+        var_5,  # (shape: [1], dtype: paddle.int32, stop_gradient: True)
     ):
         var_6 = var_0.__floordiv__(2)
         var_7 = var_0.__floordiv__(2)
@@ -33,24 +34,24 @@ class LayerCase(paddle.nn.Layer):
 
 def create_tensor_inputs():
     inputs = (
-        paddle.randint(low=0, high=10, shape=[1], dtype=paddle.int32),
-        paddle.randint(low=0, high=10, shape=[1], dtype=paddle.int32),
+        paddle.to_tensor([1], dtype=paddle.int32),
+        paddle.to_tensor([1], dtype=paddle.int32),
         paddle.rand(shape=[1, 512, 97, 97], dtype=paddle.float32),
-        paddle.randint(low=0, high=10, shape=[4], dtype=paddle.int32),
-        paddle.randint(low=0, high=10, shape=[1], dtype=paddle.int32),
-        paddle.randint(low=0, high=10, shape=[1], dtype=paddle.int32),
+        paddle.to_tensor([3, 8, 9, 9], dtype=paddle.int32),
+        paddle.to_tensor([98], dtype=paddle.int32),
+        paddle.to_tensor([98], dtype=paddle.int32),
     )
     return inputs
 
 
 def create_numpy_inputs():
     inputs = (
-        np.random.randint(low=0, high=10, size=[1], dtype='int32'),
-        np.random.randint(low=0, high=10, size=[1], dtype='int32'),
-        np.random.random(size=[1, 512, 97, 97]).astype('float32'),
-        np.random.randint(low=0, high=10, size=[4], dtype='int32'),
-        np.random.randint(low=0, high=10, size=[1], dtype='int32'),
-        np.random.randint(low=0, high=10, size=[1], dtype='int32'),
+        np.array([1], dtype="int32"),
+        np.array([1], dtype="int32"),
+        np.random.random(size=[1, 512, 97, 97]).astype("float32"),
+        np.array([3, 8, 9, 9], dtype="int32"),
+        np.array([98], dtype="int32"),
+        np.array([98], dtype="int32"),
     )
     return inputs
 
@@ -59,9 +60,10 @@ class TestLayer(unittest.TestCase):
     def setUp(self):
         self.inputs = create_tensor_inputs()
         self.net = LayerCase()
+
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.set_flags({"FLAGS_prim_all": with_prim})
             if with_cinn:
                 build_strategy = paddle.static.BuildStrategy()
                 build_strategy.build_cinn_pass = True
@@ -71,6 +73,7 @@ class TestLayer(unittest.TestCase):
         paddle.seed(123)
         outs = net(*self.inputs)
         return outs
+
     def test_ast_prim_cinn(self):
         st_out = self.train(self.net, to_static=True)
         cinn_out = self.train(self.net, to_static=True, with_prim=True, with_cinn=True)
@@ -78,5 +81,5 @@ class TestLayer(unittest.TestCase):
             np.testing.assert_allclose(st.numpy(), cinn.numpy(), atol=1e-8)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Seg_cases/isanet_isanet_resnet50_os8_cityscapes_769x769_80k/SIR_35.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Seg_cases/isanet_isanet_resnet50_os8_cityscapes_769x769_80k/SIR_35.py
@@ -7,13 +7,14 @@ import numpy as np
 class LayerCase(paddle.nn.Layer):
     def __init__(self):
         super().__init__()
+
     def forward(
         self,
-        var_0,    # (shape: [1, 512, 104, 104], dtype: paddle.float32, stop_gradient: False)
-        var_1,    # (shape: [1], dtype: paddle.int32, stop_gradient: True)
-        var_2,    # (shape: [1], dtype: paddle.int32, stop_gradient: True)
-        var_3,    # (shape: [4], dtype: paddle.int32, stop_gradient: True)
-        var_4,    # (shape: [1, 512, 97, 97], dtype: paddle.float32, stop_gradient: False)
+        var_0,  # (shape: [1, 512, 104, 104], dtype: paddle.float32, stop_gradient: False)
+        var_1,  # (shape: [1], dtype: paddle.int32, stop_gradient: True)
+        var_2,  # (shape: [1], dtype: paddle.int32, stop_gradient: True)
+        var_3,  # (shape: [4], dtype: paddle.int32, stop_gradient: True)
+        var_4,  # (shape: [1, 512, 97, 97], dtype: paddle.float32, stop_gradient: False)
     ):
         var_5 = var_1.__floordiv__(2)
         var_6 = var_2.__floordiv__(2)
@@ -31,9 +32,9 @@ class LayerCase(paddle.nn.Layer):
 def create_tensor_inputs():
     inputs = (
         paddle.rand(shape=[1, 512, 104, 104], dtype=paddle.float32),
-        paddle.randint(low=0, high=10, shape=[1], dtype=paddle.int32),
-        paddle.randint(low=0, high=10, shape=[1], dtype=paddle.int32),
-        paddle.randint(low=0, high=10, shape=[4], dtype=paddle.int32),
+        paddle.to_tensor([1], dtype=paddle.int32),
+        paddle.to_tensor([1], dtype=paddle.int32),
+        paddle.to_tensor([8, 8, 97, 97], dtype=paddle.int32),
         paddle.rand(shape=[1, 512, 97, 97], dtype=paddle.float32),
     )
     return inputs
@@ -41,11 +42,11 @@ def create_tensor_inputs():
 
 def create_numpy_inputs():
     inputs = (
-        np.random.random(size=[1, 512, 104, 104]).astype('float32'),
-        np.random.randint(low=0, high=10, size=[1], dtype='int32'),
-        np.random.randint(low=0, high=10, size=[1], dtype='int32'),
-        np.random.randint(low=0, high=10, size=[4], dtype='int32'),
-        np.random.random(size=[1, 512, 97, 97]).astype('float32'),
+        np.random.random(size=[1, 512, 104, 104]).astype("float32"),
+        np.array([1], dtype="int32"),
+        np.array([1], dtype="int32"),
+        np.array([8, 8, 97, 97], dtype="int32"),
+        np.random.random(size=[1, 512, 97, 97]).astype("float32"),
     )
     return inputs
 
@@ -54,9 +55,10 @@ class TestLayer(unittest.TestCase):
     def setUp(self):
         self.inputs = create_tensor_inputs()
         self.net = LayerCase()
+
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.set_flags({"FLAGS_prim_all": with_prim})
             if with_cinn:
                 build_strategy = paddle.static.BuildStrategy()
                 build_strategy.build_cinn_pass = True
@@ -66,6 +68,7 @@ class TestLayer(unittest.TestCase):
         paddle.seed(123)
         outs = net(*self.inputs)
         return outs
+
     def test_ast_prim_cinn(self):
         st_out = self.train(self.net, to_static=True)
         cinn_out = self.train(self.net, to_static=True, with_prim=True, with_cinn=True)
@@ -73,5 +76,5 @@ class TestLayer(unittest.TestCase):
             np.testing.assert_allclose(st.numpy(), cinn.numpy(), atol=1e-8)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
- 主要修改了 create_tensor_inputs 和 create_numpy_inputs 函数，设定特定输入的值，否则随机生成的数据可能无法满足动态图下模型的正常运行。
- 其余修改应该是一开始使用了 pre-commit 自动修改的。另外检查出来一些建议，没有进行修改

<details>

<summary> 代码建议 </summary>

```
************* Module layercase.sublayer160.Seg_cases.isanet_isanet_resnet50_os8_cityscapes_769x769_80k.SIR_32
framework/e2e/PaddleLT_new/layercase/sublayer160/Seg_cases/isanet_isanet_resnet50_os8_cityscapes_769x769_80k/SIR_32.py:1:0: C0301: Line too long (262/120) (line-too-long)
framework/e2e/PaddleLT_new/layercase/sublayer160/Seg_cases/isanet_isanet_resnet50_os8_cityscapes_769x769_80k/SIR_32.py:1:0: C0114: Missing module docstring (missing-module-docstring)
framework/e2e/PaddleLT_new/layercase/sublayer160/Seg_cases/isanet_isanet_resnet50_os8_cityscapes_769x769_80k/SIR_32.py:7:0: C0115: Missing class docstring (missing-class-docstring)
framework/e2e/PaddleLT_new/layercase/sublayer160/Seg_cases/isanet_isanet_resnet50_os8_cityscapes_769x769_80k/SIR_32.py:11:4: C0116: Missing function or method docstring (missing-function-docstring)
framework/e2e/PaddleLT_new/layercase/sublayer160/Seg_cases/isanet_isanet_resnet50_os8_cityscapes_769x769_80k/SIR_32.py:35:0: C0116: Missing function or method docstring (missing-function-docstring)
framework/e2e/PaddleLT_new/layercase/sublayer160/Seg_cases/isanet_isanet_resnet50_os8_cityscapes_769x769_80k/SIR_32.py:47:0: C0116: Missing function or method docstring (missing-function-docstring)
framework/e2e/PaddleLT_new/layercase/sublayer160/Seg_cases/isanet_isanet_resnet50_os8_cityscapes_769x769_80k/SIR_32.py:59:0: C0115: Missing class docstring (missing-class-docstring)
framework/e2e/PaddleLT_new/layercase/sublayer160/Seg_cases/isanet_isanet_resnet50_os8_cityscapes_769x769_80k/SIR_32.py:64:4: C0116: Missing function or method docstring (missing-function-docstring)
framework/e2e/PaddleLT_new/layercase/sublayer160/Seg_cases/isanet_isanet_resnet50_os8_cityscapes_769x769_80k/SIR_32.py:77:4: C0116: Missing function or method docstring (missing-function-docstring)
framework/e2e/PaddleLT_new/layercase/sublayer160/Seg_cases/isanet_isanet_resnet50_os8_cityscapes_769x769_80k/SIR_32.py:3:0: C0411: standard import "import unittest" should be placed before "import paddle" (wrong-import-order)
************* Module layercase.sublayer160.Seg_cases.isanet_isanet_resnet50_os8_cityscapes_769x769_80k.SIR_35
framework/e2e/PaddleLT_new/layercase/sublayer160/Seg_cases/isanet_isanet_resnet50_os8_cityscapes_769x769_80k/SIR_35.py:1:0: C0301: Line too long (233/120) (line-too-long)
framework/e2e/PaddleLT_new/layercase/sublayer160/Seg_cases/isanet_isanet_resnet50_os8_cityscapes_769x769_80k/SIR_35.py:1:0: C0114: Missing module docstring (missing-module-docstring)
framework/e2e/PaddleLT_new/layercase/sublayer160/Seg_cases/isanet_isanet_resnet50_os8_cityscapes_769x769_80k/SIR_35.py:7:0: C0115: Missing class docstring (missing-class-docstring)
framework/e2e/PaddleLT_new/layercase/sublayer160/Seg_cases/isanet_isanet_resnet50_os8_cityscapes_769x769_80k/SIR_35.py:11:4: C0116: Missing function or method docstring (missing-function-docstring)
framework/e2e/PaddleLT_new/layercase/sublayer160/Seg_cases/isanet_isanet_resnet50_os8_cityscapes_769x769_80k/SIR_35.py:32:0: C0116: Missing function or method docstring (missing-function-docstring)
framework/e2e/PaddleLT_new/layercase/sublayer160/Seg_cases/isanet_isanet_resnet50_os8_cityscapes_769x769_80k/SIR_35.py:43:0: C0116: Missing function or method docstring (missing-function-docstring)
framework/e2e/PaddleLT_new/layercase/sublayer160/Seg_cases/isanet_isanet_resnet50_os8_cityscapes_769x769_80k/SIR_35.py:54:0: C0115: Missing class docstring (missing-class-docstring)
framework/e2e/PaddleLT_new/layercase/sublayer160/Seg_cases/isanet_isanet_resnet50_os8_cityscapes_769x769_80k/SIR_35.py:59:4: C0116: Missing function or method docstring (missing-function-docstring)
framework/e2e/PaddleLT_new/layercase/sublayer160/Seg_cases/isanet_isanet_resnet50_os8_cityscapes_769x769_80k/SIR_35.py:72:4: C0116: Missing function or method docstring (missing-function-docstring)
framework/e2e/PaddleLT_new/layercase/sublayer160/Seg_cases/isanet_isanet_resnet50_os8_cityscapes_769x769_80k/SIR_35.py:3:0: C0411: standard import "import unittest" should be placed before "import paddle" (wrong-import-order)

-----------------------------------
Your code has been rated at 7.87/10
```
</details>

## 本地测试

1. 此 pr 与 https://github.com/PaddlePaddle/Paddle/pull/69167 相关联，此 pr 主要使得 dy_eval 成功运行，后者使得 dy2st_cinn_eval 成功运行
2. 本地测试附件
  - 命令
```layertest.py
if __name__ == "__main__":
    # # 精度调试逻辑
    # layerfile = "layercase/sublayer160/Seg_cases/isanet_isanet_resnet50_os8_cityscapes_769x769_80k/SIR_35.py"
    layerfile = "layercase/sublayer160/Seg_cases/isanet_isanet_resnet50_os8_cityscapes_769x769_80k/SIR_32.py"
    testing = "yaml/dy^dy2stcinn_eval.yml"
    single_test = LayerTest(title="ooooo", layerfile=layerfile, testing=testing)
    single_test._case_run()
```
  - python layertest.py > SIR_35.txt 2>&1
在 https://github.com/ooooo-create/Public/blob/main/SIR_32.txt 和 https://github.com/ooooo-create/Public/blob/main/SIR_35.txt

@gongshaotian