### PR TITLE
fix coredump error

### DIFF
--- a/framework/e2e/PaddleLT_new/layerApicase/nn_sublayer/MaxUnPool2D_0_class.py
+++ b/framework/e2e/PaddleLT_new/layerApicase/nn_sublayer/MaxUnPool2D_0_class.py
@@ -26,8 +26,8 @@ class LayerCase(paddle.nn.Layer):
 
 def create_inputspec(): 
     inputspec = ( 
-        paddle.static.InputSpec(shape=(-1, -1, -1, -1), dtype=paddle.float32, stop_gradient=False), 
-        paddle.static.InputSpec(shape=(-1, -1, -1, -1), dtype=paddle.int32, stop_gradient=True), 
+        paddle.static.InputSpec(shape=(-1, -1, 40, 40), dtype=paddle.float32, stop_gradient=False), 
+        paddle.static.InputSpec(shape=(-1, -1, 40, 40), dtype=paddle.int32, stop_gradient=True), 
     )
     return inputspec
 

--- a/framework/e2e/PaddleLT_new/layerApicase/nn_sublayer/MaxUnPool2D_1_class.py
+++ b/framework/e2e/PaddleLT_new/layerApicase/nn_sublayer/MaxUnPool2D_1_class.py
@@ -26,8 +26,8 @@ class LayerCase(paddle.nn.Layer):
 
 def create_inputspec(): 
     inputspec = ( 
-        paddle.static.InputSpec(shape=(-1, -1, -1, -1), dtype=paddle.float32, stop_gradient=False), 
-        paddle.static.InputSpec(shape=(-1, -1, -1, -1), dtype=paddle.int32, stop_gradient=True), 
+        paddle.static.InputSpec(shape=(-1, -1, 40, 40), dtype=paddle.float32, stop_gradient=False), 
+        paddle.static.InputSpec(shape=(-1, -1, 40, 40), dtype=paddle.int32, stop_gradient=True), 
     )
     return inputspec
 

--- a/framework/e2e/PaddleLT_new/layerApicase/nn_sublayer/MaxUnPool2D_2_class.py
+++ b/framework/e2e/PaddleLT_new/layerApicase/nn_sublayer/MaxUnPool2D_2_class.py
@@ -26,8 +26,8 @@ class LayerCase(paddle.nn.Layer):
 
 def create_inputspec(): 
     inputspec = ( 
-        paddle.static.InputSpec(shape=(-1, -1, -1, -1), dtype=paddle.float32, stop_gradient=False), 
-        paddle.static.InputSpec(shape=(-1, -1, -1, -1), dtype=paddle.int32, stop_gradient=True), 
+        paddle.static.InputSpec(shape=(-1, -1, 40, 40), dtype=paddle.float32, stop_gradient=False), 
+        paddle.static.InputSpec(shape=(-1, -1, 40, 40), dtype=paddle.int32, stop_gradient=True), 
     )
     return inputspec
 

--- a/framework/e2e/PaddleLT_new/layerApicase/nn_sublayer/MaxUnPool2D_3_class.py
+++ b/framework/e2e/PaddleLT_new/layerApicase/nn_sublayer/MaxUnPool2D_3_class.py
@@ -26,8 +26,8 @@ class LayerCase(paddle.nn.Layer):
 
 def create_inputspec(): 
     inputspec = ( 
-        paddle.static.InputSpec(shape=(-1, -1, -1, -1), dtype=paddle.float32, stop_gradient=False), 
-        paddle.static.InputSpec(shape=(-1, -1, -1, -1), dtype=paddle.int32, stop_gradient=True), 
+        paddle.static.InputSpec(shape=(-1, -1, 40, 40), dtype=paddle.float32, stop_gradient=False), 
+        paddle.static.InputSpec(shape=(-1, -1, 40, 40), dtype=paddle.int32, stop_gradient=True), 
     )
     return inputspec
 

--- a/framework/e2e/PaddleLT_new/layerApicase/nn_sublayer/MaxUnPool2D_base_class.py
+++ b/framework/e2e/PaddleLT_new/layerApicase/nn_sublayer/MaxUnPool2D_base_class.py
@@ -26,8 +26,8 @@ class LayerCase(paddle.nn.Layer):
 
 def create_inputspec(): 
     inputspec = ( 
-        paddle.static.InputSpec(shape=(-1, -1, -1, -1), dtype=paddle.float32, stop_gradient=False), 
-        paddle.static.InputSpec(shape=(-1, -1, -1, -1), dtype=paddle.int32, stop_gradient=True), 
+        paddle.static.InputSpec(shape=(-1, -1, 5, 5), dtype=paddle.float32, stop_gradient=False), 
+        paddle.static.InputSpec(shape=(-1, -1, 5, 5), dtype=paddle.int32, stop_gradient=True), 
     )
     return inputspec
 


### PR DESCRIPTION
1. 修复动转静下 PIR 以及开 CINN 时的 coredump
  - PIR 下 MaxUnPool2D 未支持 DHW 为动态 -1 的情况：出现 -1 时，会计算出没有意义的 output_size 传入 pd_op.unpool 算子，GPU 计算出 `[2, 3, -2, -2](cpu会直接报错)`，PaddleTest 框架比较精度时，使用 tensor.numpy() 导致 coredump.
  - 所以 NC 之外的 DHW 维度使用静态维度进行设置
3. 现存精度问题
  - 在 **GPU** 下动态图前向连续跑两次也存在精度对不齐的情况
  - 在 **GPU** 下现在还存在精度问题，动态图和 PIR(CINN开组合算子没拆分出来算子，跑的和PIR一样的 phi 算子) 精度问题