### PR TITLE
[Prim][CINN] Use API to instead of set prim all cpp flag

### DIFF
--- a/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_builtin_combine.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_builtin_combine.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_builtin_split.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_builtin_split.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_abs.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_abs.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_add.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_add.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_add_n.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_add_n.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_all.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_all.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_arange.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_arange.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_argmax.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_argmax.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_assign.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_assign.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_atan.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_atan.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_bce_loss.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_bce_loss.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_bilinear_interp.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_bilinear_interp.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_bmm.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_bmm.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_cast.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_cast.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_clip.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_clip.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_concat.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_concat.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_conv2d.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_conv2d.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_cross_entropy_with_softmax.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_cross_entropy_with_softmax.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_deformable_conv.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_deformable_conv.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_depthwise_conv2d.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_depthwise_conv2d.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_distribute_fpn_proposals.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_distribute_fpn_proposals.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_divide.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_divide.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_dropout.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_dropout.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_elementwise_pow.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_elementwise_pow.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_elu.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_elu.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_equal.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_equal.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_exp.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_exp.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_expand.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_expand.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_expand_as.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_expand_as.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_flatten.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_flatten.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_floor.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_floor.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_floor_divide.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_floor_divide.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_full.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_full.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_full_int_array.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_full_int_array.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_full_like.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_full_like.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_full_with_tensor.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_full_with_tensor.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_gather.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_gather.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_gather_nd.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_gather_nd.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_gelu.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_gelu.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_greater_equal.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_greater_equal.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_greater_than.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_greater_than.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_grid_sample.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_grid_sample.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_hardsigmoid.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_hardsigmoid.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_huber_loss.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_huber_loss.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_index_select.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_index_select.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_layer_norm.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_layer_norm.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_less_than.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_less_than.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_linspace.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_linspace.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_log.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_log.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_logical_and.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_logical_and.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_masked_select.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_masked_select.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_matmul.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_matmul.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_max.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_max.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_maximum.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_maximum.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_mean.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_mean.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_mean_all.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_mean_all.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_meshgrid.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_meshgrid.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_min.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_min.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_minimum.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_minimum.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_multiply.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_multiply.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_nearest_interp.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_nearest_interp.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_nonzero.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_nonzero.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_not_equal.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_not_equal.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_one_hot.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_one_hot.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_p_norm.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_p_norm.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_pad3d.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_pad3d.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_pool2d.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_pool2d.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_pool3d.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_pool3d.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_pow.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_pow.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_reciprocal.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_reciprocal.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_relu.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_relu.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_reshape.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_reshape.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_roi_align.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_roi_align.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_roll.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_roll.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_scale.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_scale.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_shape.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_shape.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_share_data_.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_share_data_.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_sigmoid.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_sigmoid.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_sigmoid_cross_entropy_with_logits.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_sigmoid_cross_entropy_with_logits.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_sign.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_sign.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_slice.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_slice.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_softmax.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_softmax.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_split.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_split.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_split_with_num.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_split_with_num.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_sqrt.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_sqrt.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_squeeze.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_squeeze.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_stack.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_stack.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_subtract.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_subtract.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_sum.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_sum.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_swish.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_swish.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_tile.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_tile.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_topk.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_topk.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_transpose.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_transpose.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_unbind.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_unbind.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_unfold.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_unfold.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_uniform.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_uniform.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_unsqueeze.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_unsqueeze.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_where.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/1000-subgraph-ops/all/test_all_pd_op_where.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-bug-inplace-ops/test_all_pd_op_batch_norm_.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-bug-inplace-ops/test_all_pd_op_batch_norm_.py
@@ -177,6 +177,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-bug-inplace-ops/test_all_pd_op_rnn_.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-bug-inplace-ops/test_all_pd_op_rnn_.py
@@ -177,6 +177,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_builtin_combine.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_builtin_combine.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_builtin_slice.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_builtin_slice.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_add.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_add.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_add_.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_add_.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_add_n.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_add_n.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_any.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_any.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_arange.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_arange.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_argmax.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_argmax.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_assign.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_assign.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_assign_.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_assign_.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_assign_out_.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_assign_out_.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_assign_value.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_assign_value.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_batch_norm_.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_batch_norm_.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_bilinear_interp.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_bilinear_interp.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_bitwise_and_.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_bitwise_and_.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_bmm.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_bmm.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_cast.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_cast.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_cast_.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_cast_.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_clip.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_clip.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_clip_.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_clip_.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_concat.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_concat.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_conv2d.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_conv2d.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_conv2d_transpose.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_conv2d_transpose.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_conv3d.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_conv3d.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_cumsum_.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_cumsum_.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_deformable_conv.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_deformable_conv.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_depthwise_conv2d.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_depthwise_conv2d.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_diag.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_diag.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_divide.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_divide.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_divide_.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_divide_.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_dropout.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_dropout.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_elementwise_pow.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_elementwise_pow.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_embedding.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_embedding.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_equal.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_equal.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_equal_all.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_equal_all.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_expand.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_expand.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_eye.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_eye.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_flatten.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_flatten.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_flatten_.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_flatten_.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_flip.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_flip.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_floor_divide_.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_floor_divide_.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_fold.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_fold.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_frobenius_norm.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_frobenius_norm.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_full.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_full.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_full_batch_size_like.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_full_batch_size_like.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_full_int_array.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_full_int_array.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_full_like.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_full_like.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_full_with_tensor.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_full_with_tensor.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_gather.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_gather.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_gelu.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_gelu.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_greater_equal.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_greater_equal.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_grid_sample.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_grid_sample.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_group_norm.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_group_norm.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_hardsigmoid.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_hardsigmoid.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_hardswish.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_hardswish.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_index_select.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_index_select.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_instance_norm.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_instance_norm.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_inverse.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_inverse.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_layer_norm.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_layer_norm.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_leaky_relu.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_leaky_relu.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_leaky_relu_.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_leaky_relu_.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_less_than.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_less_than.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_linspace.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_linspace.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_log_.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_log_.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_logical_and_.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_logical_and_.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_logical_not.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_logical_not.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_matmul.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_matmul.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_matrix_nms.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_matrix_nms.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_max.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_max.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_max_pool2d_with_index.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_max_pool2d_with_index.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_maximum.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_maximum.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_mean.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_mean.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_memcpy_d2h.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_memcpy_d2h.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_memcpy_h2d.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_memcpy_h2d.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_meshgrid.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_meshgrid.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_mish.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_mish.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_multiclass_nms3.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_multiclass_nms3.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_multiply.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_multiply.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_multiply_.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_multiply_.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_nearest_interp.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_nearest_interp.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_one_hot.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_one_hot.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_p_norm.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_p_norm.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_pad3d.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_pad3d.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_pixel_shuffle.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_pixel_shuffle.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_pool2d.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_pool2d.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_pool3d.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_pool3d.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_pow.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_pow.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_pow_.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_pow_.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_prelu.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_prelu.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_relu.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_relu.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_relu6.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_relu6.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_relu_.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_relu_.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_reshape.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_reshape.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_reshape_.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_reshape_.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_rnn_.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_rnn_.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_roll.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_roll.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_scale.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_scale.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_scale_.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_scale_.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_select_input.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_select_input.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_set_value.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_set_value.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_set_value_.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_set_value_.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_set_value_with_tensor.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_set_value_with_tensor.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_set_value_with_tensor_.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_set_value_with_tensor_.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_shape.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_shape.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_share_data_.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_share_data_.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_sigmoid.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_sigmoid.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_sigmoid_.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_sigmoid_.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_silu.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_silu.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_slice.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_slice.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_softmax.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_softmax.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_softmax_.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_softmax_.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_split.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_split.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_split_with_num.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_split_with_num.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_square.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_square.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_squeeze.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_squeeze.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_squeeze_.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_squeeze_.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_stack.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_stack.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_strided_slice.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_strided_slice.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_subtract.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_subtract.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_subtract_.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_subtract_.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_sum.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_sum.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_swish.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_swish.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_tanh.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_tanh.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_tanh_.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_tanh_.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_temporal_shift.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_temporal_shift.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_tile.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_tile.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_transpose.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_transpose.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_triu.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_triu.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_unfold.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_unfold.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_unpool.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_unpool.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_unsqueeze.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_unsqueeze.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_unsqueeze_.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_unsqueeze_.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_where.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_where.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_where_.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_where_.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_yolo_box.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models-ops/all/test_all_pd_op_yolo_box.py
@@ -176,6 +176,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_012433d6626b795d7d54ef229fcedc96_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_012433d6626b795d7d54ef229fcedc96_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_028645708c77257c7ee56917e7409420_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_028645708c77257c7ee56917e7409420_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_03d4830c6408238bcd9eaede6706f78d_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_03d4830c6408238bcd9eaede6706f78d_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_045d3fde8a7d65ee4d7ee9747e82ee3e_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_045d3fde8a7d65ee4d7ee9747e82ee3e_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_04daf6e4b6b8a4fc988fd381c174a49a_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_04daf6e4b6b8a4fc988fd381c174a49a_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_05257f1f7e6d7f3bfa6d15b3001b30ea_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_05257f1f7e6d7f3bfa6d15b3001b30ea_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_05257f1f7e6d7f3bfa6d15b3001b30ea_1.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_05257f1f7e6d7f3bfa6d15b3001b30ea_1.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_05257f1f7e6d7f3bfa6d15b3001b30ea_2.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_05257f1f7e6d7f3bfa6d15b3001b30ea_2.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_05257f1f7e6d7f3bfa6d15b3001b30ea_3.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_05257f1f7e6d7f3bfa6d15b3001b30ea_3.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_05af38cc50d2025022b5e05fa4a2b3e9_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_05af38cc50d2025022b5e05fa4a2b3e9_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_0a63120830680d11d4b9b34f9475b93f_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_0a63120830680d11d4b9b34f9475b93f_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_0ca4fb43197554478997a80b5e4470e3_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_0ca4fb43197554478997a80b5e4470e3_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_0d97999bb596f21f4bfdfb1a0bff1965_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_0d97999bb596f21f4bfdfb1a0bff1965_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_0dae378831617c65cd155633dae2fd02_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_0dae378831617c65cd155633dae2fd02_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_0e1b43a377c36c386c6faf435e6f7ce2_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_0e1b43a377c36c386c6faf435e6f7ce2_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_0e856c3fc90f003f3507399b35bd1d6a_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_0e856c3fc90f003f3507399b35bd1d6a_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_0ec351a9756f7a090eed0e4dcfe3a135_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_0ec351a9756f7a090eed0e4dcfe3a135_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_0ee8fd845ba97c3fc2db83bff4f5e951_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_0ee8fd845ba97c3fc2db83bff4f5e951_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_0f6d89bdcc490eec8bb60818111b28dc_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_0f6d89bdcc490eec8bb60818111b28dc_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_1003a5599cbc325cf163a707bfa45fce_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_1003a5599cbc325cf163a707bfa45fce_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_12e19f6975af2eb172113e44cde61b69_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_12e19f6975af2eb172113e44cde61b69_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_13da44ef3249519f70e5087a45e6c1f2_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_13da44ef3249519f70e5087a45e6c1f2_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_14fc7320bb9d83f1e89ae961f33e90ff_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_14fc7320bb9d83f1e89ae961f33e90ff_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_199b39939e02287b808269541296c427_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_199b39939e02287b808269541296c427_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_1a416ac949513290da72ff81b2f957f4_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_1a416ac949513290da72ff81b2f957f4_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_1ac18b659144dc479a0d90ee8c23229a_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_1ac18b659144dc479a0d90ee8c23229a_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_1d171f061f0b4d1a52333853bb841008_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_1d171f061f0b4d1a52333853bb841008_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_1e39f428bd490a2f9a66812f7a287e9f_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_1e39f428bd490a2f9a66812f7a287e9f_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_1eac8106cbc5eafa1b4e7b280e2c0e24_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_1eac8106cbc5eafa1b4e7b280e2c0e24_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_1ec55dde933653510b88165f76452eae_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_1ec55dde933653510b88165f76452eae_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_225f403b170848d118201ef4a1de5535_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_225f403b170848d118201ef4a1de5535_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_2391126ea0cae80e624e8aa4d88b2ceb_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_2391126ea0cae80e624e8aa4d88b2ceb_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_260412340a8f8fc06e7a0056a4d1455b_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_260412340a8f8fc06e7a0056a4d1455b_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_26d402a49f7c3c3b7f89ddd54da16c58_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_26d402a49f7c3c3b7f89ddd54da16c58_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_28cd04564e51717e8a80e3eded5e357f_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_28cd04564e51717e8a80e3eded5e357f_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_295214c4019b746a66c1a42a3d1a0cbf_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_295214c4019b746a66c1a42a3d1a0cbf_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_29c2e2e1753dd5f67bf2400c8a970d8f_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_29c2e2e1753dd5f67bf2400c8a970d8f_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_2a973ce8da8e24b651bf944830962a25_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_2a973ce8da8e24b651bf944830962a25_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_2b3a10dcd0425071c57d85270f9261a5_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_2b3a10dcd0425071c57d85270f9261a5_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_2b90b9d06d125c75841da94557521daf_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_2b90b9d06d125c75841da94557521daf_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_2cba695e29328f22c2e3a2361780d7da_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_2cba695e29328f22c2e3a2361780d7da_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_2de7ed8b8d9bccfdfe46cad966870387_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_2de7ed8b8d9bccfdfe46cad966870387_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_2e0277edbff54d0eeaa48dbc2489e4b8_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_2e0277edbff54d0eeaa48dbc2489e4b8_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_2f27d3bbb584b095c5bddf64b74cadb5_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_2f27d3bbb584b095c5bddf64b74cadb5_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_2f8358b70df6976219747d7a4e6e82d1_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_2f8358b70df6976219747d7a4e6e82d1_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_37a117553c1370003926ad19da49c055_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_37a117553c1370003926ad19da49c055_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_39a94db1b837375be0b6a97050b53628_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_39a94db1b837375be0b6a97050b53628_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_3a91db9f893119559904b3fb5c64c73e_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_3a91db9f893119559904b3fb5c64c73e_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_3c744a3e491f792c53ae66336d4fe947_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_3c744a3e491f792c53ae66336d4fe947_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_3ed929f7c1dc7194c9ca22abb18d35ff_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_3ed929f7c1dc7194c9ca22abb18d35ff_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_3ee4dda9d815f205aa3018a35e011f59_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_3ee4dda9d815f205aa3018a35e011f59_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_3f290fdfe4fcb9774f40207870bd00cf_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_3f290fdfe4fcb9774f40207870bd00cf_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_40822c6c8b9c03defd611cde839ac1e7_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_40822c6c8b9c03defd611cde839ac1e7_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_42913e0f9fd0975874bfabed726d9bef_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_42913e0f9fd0975874bfabed726d9bef_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_43ba4fef534e1969df117b37b2730051_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_43ba4fef534e1969df117b37b2730051_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_48f4dbe4891895b70d78fce271e7fae7_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_48f4dbe4891895b70d78fce271e7fae7_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_4a9a59e4b154b6d2c0f212349a8bbe00_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_4a9a59e4b154b6d2c0f212349a8bbe00_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_4bb3927b2b40185343ac5a06ecf73d3a_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_4bb3927b2b40185343ac5a06ecf73d3a_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_4c69b537d0d70a6a973ed24281b5ea45_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_4c69b537d0d70a6a973ed24281b5ea45_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_4cd390dc62878c4940644532003b70ec_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_4cd390dc62878c4940644532003b70ec_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_4d430df08a7296d131724a208ecae60c_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_4d430df08a7296d131724a208ecae60c_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_4d985bdc05337da40f4c6adc9ef8d5a3_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_4d985bdc05337da40f4c6adc9ef8d5a3_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_4f6b76ca9728a0c585e8678703271cd6_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_4f6b76ca9728a0c585e8678703271cd6_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_50cda8d202e4d29cf8c7d89dbc4a415e_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_50cda8d202e4d29cf8c7d89dbc4a415e_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_5270384535a086da6c8b51b6b837845b_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_5270384535a086da6c8b51b6b837845b_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_529aa21f11f9d433e2d4094629ca347a_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_529aa21f11f9d433e2d4094629ca347a_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_556bdc63ae1f09641e9a5c26c14d2ee3_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_556bdc63ae1f09641e9a5c26c14d2ee3_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_55f3a66e3073a8aab6b1622d7a9802a9_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_55f3a66e3073a8aab6b1622d7a9802a9_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_57902e5e6f6f6edf4d31ea38d37b2a72_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_57902e5e6f6f6edf4d31ea38d37b2a72_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_58ba9f1dd302d22e8cf1b1a9b642b79a_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_58ba9f1dd302d22e8cf1b1a9b642b79a_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_5be4a89ba1cb19724f528b554015e86b_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_5be4a89ba1cb19724f528b554015e86b_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_5eca5eace8a549caf9c80b9a1671d0d6_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_5eca5eace8a549caf9c80b9a1671d0d6_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_5ffd3830b3014a77380b098422b447b1_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_5ffd3830b3014a77380b098422b447b1_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_625679997f873559d2d334ab9762adcc_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_625679997f873559d2d334ab9762adcc_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_625679997f873559d2d334ab9762adcc_1.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_625679997f873559d2d334ab9762adcc_1.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_63807089c0647e5a2f811b686abb3da8_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_63807089c0647e5a2f811b686abb3da8_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_68d287e572c49330bd7574cda20c6fc4_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_68d287e572c49330bd7574cda20c6fc4_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_68f19ddbb311976c9097f5eec5bc641e_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_68f19ddbb311976c9097f5eec5bc641e_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_692a771a85549a30078658dcc2c20350_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_692a771a85549a30078658dcc2c20350_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_6a3d6b0a57c37d986883d0da6c2aa57e_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_6a3d6b0a57c37d986883d0da6c2aa57e_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_6e1d09313a1054970dd0ebfb7ff88f95_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_6e1d09313a1054970dd0ebfb7ff88f95_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_6f44804316f98d9fb4b4f5999c95f6c0_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_6f44804316f98d9fb4b4f5999c95f6c0_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_6feaea192a1f35032661f5b6f71e4628_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_6feaea192a1f35032661f5b6f71e4628_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_727bf5a3cd18b88043f527d15c37f86d_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_727bf5a3cd18b88043f527d15c37f86d_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_75709feb8a4e1aba1604b0435d7ddf4e_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_75709feb8a4e1aba1604b0435d7ddf4e_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_75889ae31570ac6a03468b123644018d_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_75889ae31570ac6a03468b123644018d_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_75889ae31570ac6a03468b123644018d_1.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_75889ae31570ac6a03468b123644018d_1.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_7593878da45cc0c4fa43b11fc42b770a_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_7593878da45cc0c4fa43b11fc42b770a_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_7a1507406200488578a6c19675e0d2ff_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_7a1507406200488578a6c19675e0d2ff_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_7bd579e0da6cf4801d85c02b06845e5d_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_7bd579e0da6cf4801d85c02b06845e5d_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_7c858e2f43c30bff72a9dcb09b322275_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_7c858e2f43c30bff72a9dcb09b322275_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_7ccceca2a39c687fd9552bdd9771ce4b_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_7ccceca2a39c687fd9552bdd9771ce4b_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_7d061ae0553412fe808407b903be59c2_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_7d061ae0553412fe808407b903be59c2_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_7dc9148f879a7637036329401d35a7af_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_7dc9148f879a7637036329401d35a7af_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_7e70427686afabaff0fb440f5a3dfee7_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_7e70427686afabaff0fb440f5a3dfee7_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_7ee5169b560b8aa77a3ad64f2f782f69_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_7ee5169b560b8aa77a3ad64f2f782f69_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_7f9d1f99ac5cf99b1fc69a046e4fae3f_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_7f9d1f99ac5cf99b1fc69a046e4fae3f_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_7fc684fc1894cfccc7686273a47aa7fd_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_7fc684fc1894cfccc7686273a47aa7fd_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_86b1f4f1e9d0595462a8cef9dd46e96d_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_86b1f4f1e9d0595462a8cef9dd46e96d_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_87a410f7a83c33df90312ae82a6ce263_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_87a410f7a83c33df90312ae82a6ce263_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_87a6a7afcb5313ad4bcf046970d6c716_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_87a6a7afcb5313ad4bcf046970d6c716_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_8830a7e569380c1b0c28db0aa0868741_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_8830a7e569380c1b0c28db0aa0868741_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_8830a7e569380c1b0c28db0aa0868741_1.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_8830a7e569380c1b0c28db0aa0868741_1.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_8a029a66a62424dfdd43b3ef3372752c_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_8a029a66a62424dfdd43b3ef3372752c_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_8a029a66a62424dfdd43b3ef3372752c_1.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_8a029a66a62424dfdd43b3ef3372752c_1.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_8a029a66a62424dfdd43b3ef3372752c_2.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_8a029a66a62424dfdd43b3ef3372752c_2.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_8a029a66a62424dfdd43b3ef3372752c_3.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_8a029a66a62424dfdd43b3ef3372752c_3.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_8a1c3f821d9a12b3d327df0850117b4d_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_8a1c3f821d9a12b3d327df0850117b4d_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_8aaeab4c688c9ce4b0c485cfc804e52f_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_8aaeab4c688c9ce4b0c485cfc804e52f_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_8b0f76bb19e64cf3583d15a7fd314b19_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_8b0f76bb19e64cf3583d15a7fd314b19_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_8b911b828dfdb53bb71e384682ecbe9e_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_8b911b828dfdb53bb71e384682ecbe9e_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_8d3d003beb0f2c8699ae56e67a03eca8_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_8d3d003beb0f2c8699ae56e67a03eca8_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_8ef5c848f73638509d162146ee297f32_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_8ef5c848f73638509d162146ee297f32_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_8f2038982aae187268acc1def41de24f_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_8f2038982aae187268acc1def41de24f_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_92d8ffbb226107149141b567cfec1ddf_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_92d8ffbb226107149141b567cfec1ddf_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_96a2ddf895024ec8bf0c51c2a0eae6e7_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_96a2ddf895024ec8bf0c51c2a0eae6e7_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_96da15ff3c49a1c9e3765b194954b005_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_96da15ff3c49a1c9e3765b194954b005_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_9b62df0be2c3594968af24033a2a5584_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_9b62df0be2c3594968af24033a2a5584_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_9ba8c2dd391a197c76fbcc92cab6e6b3_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_9ba8c2dd391a197c76fbcc92cab6e6b3_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_9cace9413c16feaa1c8d20e92c0a7fa8_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_9cace9413c16feaa1c8d20e92c0a7fa8_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_9d4419107d3092f88d0b768a5df00547_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_9d4419107d3092f88d0b768a5df00547_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_9f6695dc593db7db8b39459c09a59b5a_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_9f6695dc593db7db8b39459c09a59b5a_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_a20b01b2afcb3dde2f4786d8fb590322_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_a20b01b2afcb3dde2f4786d8fb590322_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_a2daa9b446173d66368e5c8c8ae678fd_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_a2daa9b446173d66368e5c8c8ae678fd_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_a4eee3365fd1d7f8701900ed5e698ce8_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_a4eee3365fd1d7f8701900ed5e698ce8_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_a57b0a483d1d0b1d5b93d076ce11f8cc_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_a57b0a483d1d0b1d5b93d076ce11f8cc_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_a74f65029aac6dd95431a12f3891ad9d_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_a74f65029aac6dd95431a12f3891ad9d_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_a81d6ef66e71470d9ff8abcd4b1cce36_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_a81d6ef66e71470d9ff8abcd4b1cce36_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_ab474295340b49f42835394fad1d50ac_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_ab474295340b49f42835394fad1d50ac_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_ab474295340b49f42835394fad1d50ac_1.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_ab474295340b49f42835394fad1d50ac_1.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_ab95a5f688030fdd85e2f6a2b6e47994_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_ab95a5f688030fdd85e2f6a2b6e47994_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_abd5d7be7084a7068f0543aae30ad996_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_abd5d7be7084a7068f0543aae30ad996_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_ad476cb07e32c0eb1b4a32b16fe24d61_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_ad476cb07e32c0eb1b4a32b16fe24d61_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_adf396f3413cb8f43892dce21189d5ba_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_adf396f3413cb8f43892dce21189d5ba_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_ae4439a4303997494318243572765292_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_ae4439a4303997494318243572765292_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_af872926a347366396f6098cd8df7c98_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_af872926a347366396f6098cd8df7c98_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_aff1e7ca9b9d3203ca3d04abd3f751a9_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_aff1e7ca9b9d3203ca3d04abd3f751a9_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_b248b8c45a582ec3737e163d162015c4_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_b248b8c45a582ec3737e163d162015c4_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_b2a6aebbc70720270b8c094a01ed21ff_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_b2a6aebbc70720270b8c094a01ed21ff_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_b494752894611a795a66720bb847c0d6_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_b494752894611a795a66720bb847c0d6_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_b514303d19fe77dcff1e6b2ae0d63187_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_b514303d19fe77dcff1e6b2ae0d63187_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_b64e23ccae3fae5d1d13db5bd18a43d2_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_b64e23ccae3fae5d1d13db5bd18a43d2_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_b875954a1205d32e75ae4f3f2814bcf1_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_b875954a1205d32e75ae4f3f2814bcf1_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_b889394a406841de685a0e4591fa9475_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_b889394a406841de685a0e4591fa9475_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_b9eedef58cb486a717676af595a0f1e8_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_b9eedef58cb486a717676af595a0f1e8_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_bb2fb6dfa92ff4836d7f59ea4901dd5d_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_bb2fb6dfa92ff4836d7f59ea4901dd5d_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_bc0af27e8f4b09060f917eb32a73d561_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_bc0af27e8f4b09060f917eb32a73d561_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_bcaa023d8acd5d185ac1ada40aa3de9f_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_bcaa023d8acd5d185ac1ada40aa3de9f_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_be58b23f726e383e19135e67b0cbfe8e_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_be58b23f726e383e19135e67b0cbfe8e_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_be7a5e378985aab7b96b334bfcaf8432_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_be7a5e378985aab7b96b334bfcaf8432_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_c0c763e6934a110843c0d4928102b737_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_c0c763e6934a110843c0d4928102b737_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_c0c763e6934a110843c0d4928102b737_1.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_c0c763e6934a110843c0d4928102b737_1.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_c0d80629db8797761891ea6de99eb6ce_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_c0d80629db8797761891ea6de99eb6ce_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_c0d80ef8f9e5918559cda22376bc2d13_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_c0d80ef8f9e5918559cda22376bc2d13_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_c1fb838dffd6dcf0ca3a1ae1a4073eab_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_c1fb838dffd6dcf0ca3a1ae1a4073eab_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_c459100b1a6bd6d38ff362fdf6b8c19a_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_c459100b1a6bd6d38ff362fdf6b8c19a_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_c459100b1a6bd6d38ff362fdf6b8c19a_1.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_c459100b1a6bd6d38ff362fdf6b8c19a_1.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_c973b7b3ed2deeb501c3fc148bfceda2_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_c973b7b3ed2deeb501c3fc148bfceda2_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_ca11d406343c9e057692c3c5abcc7ecd_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_ca11d406343c9e057692c3c5abcc7ecd_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_cd2da79e91e8ad3f1b362222928de0ce_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_cd2da79e91e8ad3f1b362222928de0ce_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_ce53cde5ec50250be9aff6062786e41b_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_ce53cde5ec50250be9aff6062786e41b_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_ced46a37cb16417bac8e79a801d6c763_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_ced46a37cb16417bac8e79a801d6c763_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_d0a2e3e809efda74f3ae083c3a620130_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_d0a2e3e809efda74f3ae083c3a620130_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_d0a5d0a78b5e9e796494763695374313_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_d0a5d0a78b5e9e796494763695374313_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_d118e91cac20cdaff9eff9a7c7d232e7_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_d118e91cac20cdaff9eff9a7c7d232e7_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_d3aea0e1a9d3d6ba1781508ab660a900_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_d3aea0e1a9d3d6ba1781508ab660a900_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_d4126365c0c284058db9f16743d9db4b_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_d4126365c0c284058db9f16743d9db4b_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_d672da2baa03a5a89fd628259d52de44_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_d672da2baa03a5a89fd628259d52de44_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_d6c20ea18dcf60324462700156084348_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_d6c20ea18dcf60324462700156084348_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_d743468b271afebbea22bd2639b75d33_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_d743468b271afebbea22bd2639b75d33_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_d90a3c6c167ef5fc4a826bbfc2946587_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_d90a3c6c167ef5fc4a826bbfc2946587_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_d9da712fb4727a77c8ffce1853ebe4a3_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_d9da712fb4727a77c8ffce1853ebe4a3_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_daaf46c678e5c8b863c5f4d0a922e2a3_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_daaf46c678e5c8b863c5f4d0a922e2a3_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_deff7de22add76165a576f2f6d8c3568_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_deff7de22add76165a576f2f6d8c3568_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_dfcb8670bbe2deabdfccb492fcc98394_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_dfcb8670bbe2deabdfccb492fcc98394_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_e0fcf46c4825e5b93f80ce3b9795af90_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_e0fcf46c4825e5b93f80ce3b9795af90_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_e1cb6b9350bf14c82fa52142ed237fbf_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_e1cb6b9350bf14c82fa52142ed237fbf_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_e3c18bf3354e05d402cdbbe93d3c2cfb_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_e3c18bf3354e05d402cdbbe93d3c2cfb_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_e726be3a7290fc3d991112cda3eeb043_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_e726be3a7290fc3d991112cda3eeb043_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_e7be3138aceff53772c4135cbbca0832_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_e7be3138aceff53772c4135cbbca0832_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_e7be3138aceff53772c4135cbbca0832_1.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_e7be3138aceff53772c4135cbbca0832_1.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_e93de3d0ad5d0810d50316068d1ec4e7_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_e93de3d0ad5d0810d50316068d1ec4e7_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_e9ade6c0325c0722a7fd5f6ac2f61528_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_e9ade6c0325c0722a7fd5f6ac2f61528_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_eaae688cb1caeca62fc8cf50b1d7bbcf_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_eaae688cb1caeca62fc8cf50b1d7bbcf_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_eabdd30d97a7c81b9aa649ab5562076b_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_eabdd30d97a7c81b9aa649ab5562076b_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_ef1e2bfe0664bd82f49408572a930ef0_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_ef1e2bfe0664bd82f49408572a930ef0_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_efecc23aeec22e124a9c6e9eddba5f13_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_efecc23aeec22e124a9c6e9eddba5f13_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_f056c33d8383483aac16f3bb2e9ca0bd_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_f056c33d8383483aac16f3bb2e9ca0bd_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_f06a66369a97ee063a9980a3089a4b50_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_f06a66369a97ee063a9980a3089a4b50_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_f14311a520e67a8e366e4315e91fc22f_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_f14311a520e67a8e366e4315e91fc22f_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_f1a69ce9baca1f217f7676c7c9a5729e_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_f1a69ce9baca1f217f7676c7c9a5729e_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_f219a5ce26b84ff204427602608199c3_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_f219a5ce26b84ff204427602608199c3_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_f5544c46af0cb4ff69230ec24e91cdb5_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_f5544c46af0cb4ff69230ec24e91cdb5_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_f5544c46af0cb4ff69230ec24e91cdb5_1.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_f5544c46af0cb4ff69230ec24e91cdb5_1.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_f78d7db5c9512df6ad81ec885770373e_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_f78d7db5c9512df6ad81ec885770373e_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_f850e216abd009f7f07811cad0cd371a_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_f850e216abd009f7f07811cad0cd371a_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_f9a4d24163f3d5c6850926bc82f8c3ad_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_f9a4d24163f3d5c6850926bc82f8c3ad_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_fc741f2496e84a36a88604fa5d1bb63e_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/200-inference-models/test_module_op_fc741f2496e84a36a88604fa5d1bb63e_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_014a71df5ead2b139ca8eb5bd479bfea_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_014a71df5ead2b139ca8eb5bd479bfea_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_014a71df5ead2b139ca8eb5bd479bfea_1.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_014a71df5ead2b139ca8eb5bd479bfea_1.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_014a71df5ead2b139ca8eb5bd479bfea_2.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_014a71df5ead2b139ca8eb5bd479bfea_2.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_014a71df5ead2b139ca8eb5bd479bfea_3.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_014a71df5ead2b139ca8eb5bd479bfea_3.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_01a76566eed823950a079dedb53ed6f4_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_01a76566eed823950a079dedb53ed6f4_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_01a76566eed823950a079dedb53ed6f4_1.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_01a76566eed823950a079dedb53ed6f4_1.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_01a76566eed823950a079dedb53ed6f4_10.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_01a76566eed823950a079dedb53ed6f4_10.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_01a76566eed823950a079dedb53ed6f4_11.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_01a76566eed823950a079dedb53ed6f4_11.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_01a76566eed823950a079dedb53ed6f4_2.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_01a76566eed823950a079dedb53ed6f4_2.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_01a76566eed823950a079dedb53ed6f4_3.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_01a76566eed823950a079dedb53ed6f4_3.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_01a76566eed823950a079dedb53ed6f4_4.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_01a76566eed823950a079dedb53ed6f4_4.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_01a76566eed823950a079dedb53ed6f4_5.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_01a76566eed823950a079dedb53ed6f4_5.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_01a76566eed823950a079dedb53ed6f4_6.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_01a76566eed823950a079dedb53ed6f4_6.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_01a76566eed823950a079dedb53ed6f4_7.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_01a76566eed823950a079dedb53ed6f4_7.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_01a76566eed823950a079dedb53ed6f4_8.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_01a76566eed823950a079dedb53ed6f4_8.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_01a76566eed823950a079dedb53ed6f4_9.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_01a76566eed823950a079dedb53ed6f4_9.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_01fce0f077df87e13be3c85859d60e98_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_01fce0f077df87e13be3c85859d60e98_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_020f7de1cfa43b6a8b0f7ac8b170b244_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_020f7de1cfa43b6a8b0f7ac8b170b244_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_02f17e059be4cceebc1225129db2604b_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_02f17e059be4cceebc1225129db2604b_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_02f17e059be4cceebc1225129db2604b_1.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_02f17e059be4cceebc1225129db2604b_1.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_02f17e059be4cceebc1225129db2604b_2.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_02f17e059be4cceebc1225129db2604b_2.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_02f17e059be4cceebc1225129db2604b_3.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_02f17e059be4cceebc1225129db2604b_3.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_0513e47231cd6f4d64c7a9d81dde0677_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_0513e47231cd6f4d64c7a9d81dde0677_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_089f1d31bc36d3414a0888b030d75312_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_089f1d31bc36d3414a0888b030d75312_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_089f1d31bc36d3414a0888b030d75312_1.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_089f1d31bc36d3414a0888b030d75312_1.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_0a95b193f9ac111ba77f7e9df6d258d9_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_0a95b193f9ac111ba77f7e9df6d258d9_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_0ca2b91825dfeb2740dd80dcc7fc7c9a_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_0ca2b91825dfeb2740dd80dcc7fc7c9a_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_0ca2b91825dfeb2740dd80dcc7fc7c9a_1.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_0ca2b91825dfeb2740dd80dcc7fc7c9a_1.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_0df533beec9d365d8d70032299b29e2e_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_0df533beec9d365d8d70032299b29e2e_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_0df533beec9d365d8d70032299b29e2e_1.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_0df533beec9d365d8d70032299b29e2e_1.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_0df533beec9d365d8d70032299b29e2e_10.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_0df533beec9d365d8d70032299b29e2e_10.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_0df533beec9d365d8d70032299b29e2e_2.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_0df533beec9d365d8d70032299b29e2e_2.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_0df533beec9d365d8d70032299b29e2e_3.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_0df533beec9d365d8d70032299b29e2e_3.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_0df533beec9d365d8d70032299b29e2e_4.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_0df533beec9d365d8d70032299b29e2e_4.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_0df533beec9d365d8d70032299b29e2e_5.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_0df533beec9d365d8d70032299b29e2e_5.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_0df533beec9d365d8d70032299b29e2e_6.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_0df533beec9d365d8d70032299b29e2e_6.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_0df533beec9d365d8d70032299b29e2e_7.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_0df533beec9d365d8d70032299b29e2e_7.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_0df533beec9d365d8d70032299b29e2e_8.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_0df533beec9d365d8d70032299b29e2e_8.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_0df533beec9d365d8d70032299b29e2e_9.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_0df533beec9d365d8d70032299b29e2e_9.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_0e92fea3b6dd07c187865db63737b4bd_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_0e92fea3b6dd07c187865db63737b4bd_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_0f55d51e04fef2329c6d3700f0e7252f_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_0f55d51e04fef2329c6d3700f0e7252f_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_0f55d51e04fef2329c6d3700f0e7252f_1.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_0f55d51e04fef2329c6d3700f0e7252f_1.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_0f55d51e04fef2329c6d3700f0e7252f_2.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_0f55d51e04fef2329c6d3700f0e7252f_2.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_0f55d51e04fef2329c6d3700f0e7252f_3.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_0f55d51e04fef2329c6d3700f0e7252f_3.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_102c70f4ca0db2a9d804c76d9949c7c0_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_102c70f4ca0db2a9d804c76d9949c7c0_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_102c70f4ca0db2a9d804c76d9949c7c0_1.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_102c70f4ca0db2a9d804c76d9949c7c0_1.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_102c70f4ca0db2a9d804c76d9949c7c0_10.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_102c70f4ca0db2a9d804c76d9949c7c0_10.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_102c70f4ca0db2a9d804c76d9949c7c0_11.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_102c70f4ca0db2a9d804c76d9949c7c0_11.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_102c70f4ca0db2a9d804c76d9949c7c0_12.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_102c70f4ca0db2a9d804c76d9949c7c0_12.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_102c70f4ca0db2a9d804c76d9949c7c0_13.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_102c70f4ca0db2a9d804c76d9949c7c0_13.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_102c70f4ca0db2a9d804c76d9949c7c0_14.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_102c70f4ca0db2a9d804c76d9949c7c0_14.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_102c70f4ca0db2a9d804c76d9949c7c0_15.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_102c70f4ca0db2a9d804c76d9949c7c0_15.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_102c70f4ca0db2a9d804c76d9949c7c0_16.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_102c70f4ca0db2a9d804c76d9949c7c0_16.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_102c70f4ca0db2a9d804c76d9949c7c0_17.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_102c70f4ca0db2a9d804c76d9949c7c0_17.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_102c70f4ca0db2a9d804c76d9949c7c0_18.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_102c70f4ca0db2a9d804c76d9949c7c0_18.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_102c70f4ca0db2a9d804c76d9949c7c0_19.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_102c70f4ca0db2a9d804c76d9949c7c0_19.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_102c70f4ca0db2a9d804c76d9949c7c0_2.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_102c70f4ca0db2a9d804c76d9949c7c0_2.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_102c70f4ca0db2a9d804c76d9949c7c0_20.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_102c70f4ca0db2a9d804c76d9949c7c0_20.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_102c70f4ca0db2a9d804c76d9949c7c0_21.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_102c70f4ca0db2a9d804c76d9949c7c0_21.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_102c70f4ca0db2a9d804c76d9949c7c0_22.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_102c70f4ca0db2a9d804c76d9949c7c0_22.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_102c70f4ca0db2a9d804c76d9949c7c0_3.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_102c70f4ca0db2a9d804c76d9949c7c0_3.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_102c70f4ca0db2a9d804c76d9949c7c0_4.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_102c70f4ca0db2a9d804c76d9949c7c0_4.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_102c70f4ca0db2a9d804c76d9949c7c0_5.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_102c70f4ca0db2a9d804c76d9949c7c0_5.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_102c70f4ca0db2a9d804c76d9949c7c0_6.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_102c70f4ca0db2a9d804c76d9949c7c0_6.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_102c70f4ca0db2a9d804c76d9949c7c0_7.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_102c70f4ca0db2a9d804c76d9949c7c0_7.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_102c70f4ca0db2a9d804c76d9949c7c0_8.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_102c70f4ca0db2a9d804c76d9949c7c0_8.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_102c70f4ca0db2a9d804c76d9949c7c0_9.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_102c70f4ca0db2a9d804c76d9949c7c0_9.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_1174b5498f716ea8a1479805ab12cb19_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_1174b5498f716ea8a1479805ab12cb19_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_140fbbdc741eabf57fd0c6b08120f452_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_140fbbdc741eabf57fd0c6b08120f452_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_16d87f495eb8765a1befc88db6d20596_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_16d87f495eb8765a1befc88db6d20596_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_16d87f495eb8765a1befc88db6d20596_1.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_16d87f495eb8765a1befc88db6d20596_1.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_16d87f495eb8765a1befc88db6d20596_2.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_16d87f495eb8765a1befc88db6d20596_2.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_16d87f495eb8765a1befc88db6d20596_3.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_16d87f495eb8765a1befc88db6d20596_3.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_174ad54a937ade857a3952c1ba2dcd40_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_174ad54a937ade857a3952c1ba2dcd40_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_174ad54a937ade857a3952c1ba2dcd40_1.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_174ad54a937ade857a3952c1ba2dcd40_1.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_174ad54a937ade857a3952c1ba2dcd40_10.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_174ad54a937ade857a3952c1ba2dcd40_10.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_174ad54a937ade857a3952c1ba2dcd40_11.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_174ad54a937ade857a3952c1ba2dcd40_11.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_174ad54a937ade857a3952c1ba2dcd40_12.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_174ad54a937ade857a3952c1ba2dcd40_12.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_174ad54a937ade857a3952c1ba2dcd40_13.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_174ad54a937ade857a3952c1ba2dcd40_13.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_174ad54a937ade857a3952c1ba2dcd40_14.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_174ad54a937ade857a3952c1ba2dcd40_14.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_174ad54a937ade857a3952c1ba2dcd40_2.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_174ad54a937ade857a3952c1ba2dcd40_2.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_174ad54a937ade857a3952c1ba2dcd40_3.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_174ad54a937ade857a3952c1ba2dcd40_3.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_174ad54a937ade857a3952c1ba2dcd40_4.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_174ad54a937ade857a3952c1ba2dcd40_4.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_174ad54a937ade857a3952c1ba2dcd40_5.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_174ad54a937ade857a3952c1ba2dcd40_5.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_174ad54a937ade857a3952c1ba2dcd40_6.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_174ad54a937ade857a3952c1ba2dcd40_6.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_174ad54a937ade857a3952c1ba2dcd40_7.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_174ad54a937ade857a3952c1ba2dcd40_7.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_174ad54a937ade857a3952c1ba2dcd40_8.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_174ad54a937ade857a3952c1ba2dcd40_8.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_174ad54a937ade857a3952c1ba2dcd40_9.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_174ad54a937ade857a3952c1ba2dcd40_9.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_1b199dc72909172f9559de5a216b1a97_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_1b199dc72909172f9559de5a216b1a97_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_1b199dc72909172f9559de5a216b1a97_1.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_1b199dc72909172f9559de5a216b1a97_1.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_1b199dc72909172f9559de5a216b1a97_2.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_1b199dc72909172f9559de5a216b1a97_2.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_1b199dc72909172f9559de5a216b1a97_3.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_1b199dc72909172f9559de5a216b1a97_3.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_1f8e42302340798058605c4ac2c97078_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_1f8e42302340798058605c4ac2c97078_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_1f8e42302340798058605c4ac2c97078_1.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_1f8e42302340798058605c4ac2c97078_1.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_1f953ebc8ee2a71710e31a08eaed8d17_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_1f953ebc8ee2a71710e31a08eaed8d17_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_20ddc9b4b97be968e895b180f5dc0bcf_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_20ddc9b4b97be968e895b180f5dc0bcf_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_20ddc9b4b97be968e895b180f5dc0bcf_1.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_20ddc9b4b97be968e895b180f5dc0bcf_1.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_20ddc9b4b97be968e895b180f5dc0bcf_2.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_20ddc9b4b97be968e895b180f5dc0bcf_2.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_20ddc9b4b97be968e895b180f5dc0bcf_3.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_20ddc9b4b97be968e895b180f5dc0bcf_3.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_216c6819617358968badc83e26df067d_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_216c6819617358968badc83e26df067d_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_216c6819617358968badc83e26df067d_1.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_216c6819617358968badc83e26df067d_1.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_223976a88ebc64dd4d2403e32f297200_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_223976a88ebc64dd4d2403e32f297200_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_223976a88ebc64dd4d2403e32f297200_1.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_223976a88ebc64dd4d2403e32f297200_1.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_223976a88ebc64dd4d2403e32f297200_10.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_223976a88ebc64dd4d2403e32f297200_10.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_223976a88ebc64dd4d2403e32f297200_11.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_223976a88ebc64dd4d2403e32f297200_11.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_223976a88ebc64dd4d2403e32f297200_2.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_223976a88ebc64dd4d2403e32f297200_2.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_223976a88ebc64dd4d2403e32f297200_3.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_223976a88ebc64dd4d2403e32f297200_3.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_223976a88ebc64dd4d2403e32f297200_4.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_223976a88ebc64dd4d2403e32f297200_4.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_223976a88ebc64dd4d2403e32f297200_5.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_223976a88ebc64dd4d2403e32f297200_5.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_223976a88ebc64dd4d2403e32f297200_6.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_223976a88ebc64dd4d2403e32f297200_6.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_223976a88ebc64dd4d2403e32f297200_7.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_223976a88ebc64dd4d2403e32f297200_7.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_223976a88ebc64dd4d2403e32f297200_8.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_223976a88ebc64dd4d2403e32f297200_8.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_223976a88ebc64dd4d2403e32f297200_9.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_223976a88ebc64dd4d2403e32f297200_9.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_23d6387fc80890ad6de218dd39ebf8a2_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_23d6387fc80890ad6de218dd39ebf8a2_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_23d6387fc80890ad6de218dd39ebf8a2_1.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_23d6387fc80890ad6de218dd39ebf8a2_1.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_23d6387fc80890ad6de218dd39ebf8a2_10.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_23d6387fc80890ad6de218dd39ebf8a2_10.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_23d6387fc80890ad6de218dd39ebf8a2_11.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_23d6387fc80890ad6de218dd39ebf8a2_11.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_23d6387fc80890ad6de218dd39ebf8a2_12.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_23d6387fc80890ad6de218dd39ebf8a2_12.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_23d6387fc80890ad6de218dd39ebf8a2_13.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_23d6387fc80890ad6de218dd39ebf8a2_13.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_23d6387fc80890ad6de218dd39ebf8a2_14.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_23d6387fc80890ad6de218dd39ebf8a2_14.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_23d6387fc80890ad6de218dd39ebf8a2_15.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_23d6387fc80890ad6de218dd39ebf8a2_15.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_23d6387fc80890ad6de218dd39ebf8a2_16.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_23d6387fc80890ad6de218dd39ebf8a2_16.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_23d6387fc80890ad6de218dd39ebf8a2_17.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_23d6387fc80890ad6de218dd39ebf8a2_17.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_23d6387fc80890ad6de218dd39ebf8a2_18.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_23d6387fc80890ad6de218dd39ebf8a2_18.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_23d6387fc80890ad6de218dd39ebf8a2_19.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_23d6387fc80890ad6de218dd39ebf8a2_19.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_23d6387fc80890ad6de218dd39ebf8a2_2.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_23d6387fc80890ad6de218dd39ebf8a2_2.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_23d6387fc80890ad6de218dd39ebf8a2_20.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_23d6387fc80890ad6de218dd39ebf8a2_20.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_23d6387fc80890ad6de218dd39ebf8a2_21.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_23d6387fc80890ad6de218dd39ebf8a2_21.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_23d6387fc80890ad6de218dd39ebf8a2_22.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_23d6387fc80890ad6de218dd39ebf8a2_22.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_23d6387fc80890ad6de218dd39ebf8a2_23.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_23d6387fc80890ad6de218dd39ebf8a2_23.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_23d6387fc80890ad6de218dd39ebf8a2_24.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_23d6387fc80890ad6de218dd39ebf8a2_24.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_23d6387fc80890ad6de218dd39ebf8a2_25.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_23d6387fc80890ad6de218dd39ebf8a2_25.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_23d6387fc80890ad6de218dd39ebf8a2_26.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_23d6387fc80890ad6de218dd39ebf8a2_26.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_23d6387fc80890ad6de218dd39ebf8a2_27.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_23d6387fc80890ad6de218dd39ebf8a2_27.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_23d6387fc80890ad6de218dd39ebf8a2_28.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_23d6387fc80890ad6de218dd39ebf8a2_28.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_23d6387fc80890ad6de218dd39ebf8a2_29.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_23d6387fc80890ad6de218dd39ebf8a2_29.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_23d6387fc80890ad6de218dd39ebf8a2_3.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_23d6387fc80890ad6de218dd39ebf8a2_3.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_23d6387fc80890ad6de218dd39ebf8a2_30.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_23d6387fc80890ad6de218dd39ebf8a2_30.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_23d6387fc80890ad6de218dd39ebf8a2_31.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_23d6387fc80890ad6de218dd39ebf8a2_31.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_23d6387fc80890ad6de218dd39ebf8a2_4.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_23d6387fc80890ad6de218dd39ebf8a2_4.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_23d6387fc80890ad6de218dd39ebf8a2_5.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_23d6387fc80890ad6de218dd39ebf8a2_5.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_23d6387fc80890ad6de218dd39ebf8a2_6.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_23d6387fc80890ad6de218dd39ebf8a2_6.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_23d6387fc80890ad6de218dd39ebf8a2_7.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_23d6387fc80890ad6de218dd39ebf8a2_7.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_23d6387fc80890ad6de218dd39ebf8a2_8.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_23d6387fc80890ad6de218dd39ebf8a2_8.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_23d6387fc80890ad6de218dd39ebf8a2_9.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_23d6387fc80890ad6de218dd39ebf8a2_9.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_23e8755bfcacdb491f50521941015475_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_23e8755bfcacdb491f50521941015475_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_23e8755bfcacdb491f50521941015475_1.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_23e8755bfcacdb491f50521941015475_1.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_24959ab8991b3fad21de29b996b44a58_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_24959ab8991b3fad21de29b996b44a58_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_24959ab8991b3fad21de29b996b44a58_1.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_24959ab8991b3fad21de29b996b44a58_1.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_24a9c9852832c82a3b03f66490c3d67d_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_24a9c9852832c82a3b03f66490c3d67d_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_24a9c9852832c82a3b03f66490c3d67d_1.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_24a9c9852832c82a3b03f66490c3d67d_1.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_256f352537013d2731f860c146538083_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_256f352537013d2731f860c146538083_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_25797cf5effe9114c074f8782fa3ba5c_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_25797cf5effe9114c074f8782fa3ba5c_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_2644f9cc31ee10a2c5aca4a8a48202e4_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_2644f9cc31ee10a2c5aca4a8a48202e4_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_2644f9cc31ee10a2c5aca4a8a48202e4_1.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_2644f9cc31ee10a2c5aca4a8a48202e4_1.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_2644f9cc31ee10a2c5aca4a8a48202e4_2.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_2644f9cc31ee10a2c5aca4a8a48202e4_2.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_2644f9cc31ee10a2c5aca4a8a48202e4_3.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_2644f9cc31ee10a2c5aca4a8a48202e4_3.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_26512d380c9553e9fb32aaf572027399_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_26512d380c9553e9fb32aaf572027399_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_26512d380c9553e9fb32aaf572027399_1.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_26512d380c9553e9fb32aaf572027399_1.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_26512d380c9553e9fb32aaf572027399_10.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_26512d380c9553e9fb32aaf572027399_10.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_26512d380c9553e9fb32aaf572027399_11.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_26512d380c9553e9fb32aaf572027399_11.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_26512d380c9553e9fb32aaf572027399_12.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_26512d380c9553e9fb32aaf572027399_12.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_26512d380c9553e9fb32aaf572027399_13.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_26512d380c9553e9fb32aaf572027399_13.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_26512d380c9553e9fb32aaf572027399_14.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_26512d380c9553e9fb32aaf572027399_14.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_26512d380c9553e9fb32aaf572027399_2.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_26512d380c9553e9fb32aaf572027399_2.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_26512d380c9553e9fb32aaf572027399_3.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_26512d380c9553e9fb32aaf572027399_3.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_26512d380c9553e9fb32aaf572027399_4.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_26512d380c9553e9fb32aaf572027399_4.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_26512d380c9553e9fb32aaf572027399_5.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_26512d380c9553e9fb32aaf572027399_5.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_26512d380c9553e9fb32aaf572027399_6.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_26512d380c9553e9fb32aaf572027399_6.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_26512d380c9553e9fb32aaf572027399_7.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_26512d380c9553e9fb32aaf572027399_7.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_26512d380c9553e9fb32aaf572027399_8.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_26512d380c9553e9fb32aaf572027399_8.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_26512d380c9553e9fb32aaf572027399_9.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_26512d380c9553e9fb32aaf572027399_9.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_284c3f5e9422e995335f85212bac5a9b_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_284c3f5e9422e995335f85212bac5a9b_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_284c3f5e9422e995335f85212bac5a9b_1.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_284c3f5e9422e995335f85212bac5a9b_1.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_1.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_1.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_10.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_10.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_11.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_11.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_12.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_12.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_13.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_13.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_14.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_14.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_15.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_15.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_16.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_16.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_17.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_17.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_18.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_18.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_19.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_19.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_2.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_2.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_20.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_20.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_21.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_21.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_22.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_22.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_23.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_23.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_24.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_24.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_25.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_25.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_26.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_26.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_27.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_27.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_28.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_28.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_29.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_29.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_3.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_3.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_30.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_30.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_31.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_31.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_32.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_32.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_33.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_33.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_34.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_34.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_35.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_35.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_36.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_36.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_37.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_37.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_38.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_38.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_39.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_39.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_4.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_4.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_40.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_40.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_41.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_41.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_42.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_42.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_43.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_43.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_44.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_44.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_45.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_45.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_46.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_46.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_47.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_47.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_48.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_48.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_49.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_49.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_5.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_5.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_50.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_50.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_51.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_51.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_52.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_52.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_53.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_53.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_54.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_54.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_55.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_55.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_56.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_56.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_57.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_57.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_58.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_58.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_59.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_59.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_6.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_6.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_60.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_60.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_61.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_61.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_62.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_62.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_63.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_63.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_64.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_64.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_65.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_65.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_66.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_66.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_67.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_67.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_68.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_68.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_69.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_69.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_7.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_7.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_70.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_70.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_71.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_71.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_72.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_72.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_73.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_73.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_74.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_74.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_75.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_75.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_76.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_76.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_77.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_77.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_8.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_8.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_9.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_28cb8d6987d725f844ef76741a880a54_9.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_2ac971bc4afbbff30b73e887fc8897d2_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_2ac971bc4afbbff30b73e887fc8897d2_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_2ac971bc4afbbff30b73e887fc8897d2_1.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_2ac971bc4afbbff30b73e887fc8897d2_1.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_2d20714c1bc943850033ed9371001ff5_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_2d20714c1bc943850033ed9371001ff5_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_2d20714c1bc943850033ed9371001ff5_1.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_2d20714c1bc943850033ed9371001ff5_1.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_2d20714c1bc943850033ed9371001ff5_2.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_2d20714c1bc943850033ed9371001ff5_2.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_2db686d2eb0a9904436803bad11dd726_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_2db686d2eb0a9904436803bad11dd726_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_2db686d2eb0a9904436803bad11dd726_1.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_2db686d2eb0a9904436803bad11dd726_1.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_2db686d2eb0a9904436803bad11dd726_2.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_2db686d2eb0a9904436803bad11dd726_2.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_2db686d2eb0a9904436803bad11dd726_3.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_2db686d2eb0a9904436803bad11dd726_3.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_2e1fc63ce59fdb4ab55bee08be62dc3b_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_2e1fc63ce59fdb4ab55bee08be62dc3b_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_2e1fc63ce59fdb4ab55bee08be62dc3b_1.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_2e1fc63ce59fdb4ab55bee08be62dc3b_1.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_2e1fc63ce59fdb4ab55bee08be62dc3b_10.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_2e1fc63ce59fdb4ab55bee08be62dc3b_10.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_2e1fc63ce59fdb4ab55bee08be62dc3b_11.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_2e1fc63ce59fdb4ab55bee08be62dc3b_11.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_2e1fc63ce59fdb4ab55bee08be62dc3b_12.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_2e1fc63ce59fdb4ab55bee08be62dc3b_12.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_2e1fc63ce59fdb4ab55bee08be62dc3b_13.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_2e1fc63ce59fdb4ab55bee08be62dc3b_13.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_2e1fc63ce59fdb4ab55bee08be62dc3b_14.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_2e1fc63ce59fdb4ab55bee08be62dc3b_14.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_2e1fc63ce59fdb4ab55bee08be62dc3b_15.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_2e1fc63ce59fdb4ab55bee08be62dc3b_15.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_2e1fc63ce59fdb4ab55bee08be62dc3b_2.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_2e1fc63ce59fdb4ab55bee08be62dc3b_2.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_2e1fc63ce59fdb4ab55bee08be62dc3b_3.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_2e1fc63ce59fdb4ab55bee08be62dc3b_3.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_2e1fc63ce59fdb4ab55bee08be62dc3b_4.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_2e1fc63ce59fdb4ab55bee08be62dc3b_4.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_2e1fc63ce59fdb4ab55bee08be62dc3b_5.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_2e1fc63ce59fdb4ab55bee08be62dc3b_5.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_2e1fc63ce59fdb4ab55bee08be62dc3b_6.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_2e1fc63ce59fdb4ab55bee08be62dc3b_6.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_2e1fc63ce59fdb4ab55bee08be62dc3b_7.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_2e1fc63ce59fdb4ab55bee08be62dc3b_7.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_2e1fc63ce59fdb4ab55bee08be62dc3b_8.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_2e1fc63ce59fdb4ab55bee08be62dc3b_8.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_2e1fc63ce59fdb4ab55bee08be62dc3b_9.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_2e1fc63ce59fdb4ab55bee08be62dc3b_9.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_2e7fac649d8e7b2b59675516f61f1af3_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_2e7fac649d8e7b2b59675516f61f1af3_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_2e7fac649d8e7b2b59675516f61f1af3_1.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_2e7fac649d8e7b2b59675516f61f1af3_1.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_2e7fac649d8e7b2b59675516f61f1af3_2.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_2e7fac649d8e7b2b59675516f61f1af3_2.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_2e7fac649d8e7b2b59675516f61f1af3_3.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_2e7fac649d8e7b2b59675516f61f1af3_3.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_2e7fac649d8e7b2b59675516f61f1af3_4.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_2e7fac649d8e7b2b59675516f61f1af3_4.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_2f9866c3ba97f58c4219ea0a900d2362_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_2f9866c3ba97f58c4219ea0a900d2362_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_2f9866c3ba97f58c4219ea0a900d2362_1.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_2f9866c3ba97f58c4219ea0a900d2362_1.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_31792cc59837182816922407898124f1_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_31792cc59837182816922407898124f1_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_31792cc59837182816922407898124f1_1.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_31792cc59837182816922407898124f1_1.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_32dd3a890a204afdff0202961daa3502_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_32dd3a890a204afdff0202961daa3502_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_32dd3a890a204afdff0202961daa3502_1.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_32dd3a890a204afdff0202961daa3502_1.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_32dd3a890a204afdff0202961daa3502_2.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_32dd3a890a204afdff0202961daa3502_2.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_32dd3a890a204afdff0202961daa3502_3.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_32dd3a890a204afdff0202961daa3502_3.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_342700812c5c31285e5e6ad990b0f440_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_342700812c5c31285e5e6ad990b0f440_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_342700812c5c31285e5e6ad990b0f440_1.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_342700812c5c31285e5e6ad990b0f440_1.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_342700812c5c31285e5e6ad990b0f440_2.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_342700812c5c31285e5e6ad990b0f440_2.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_342700812c5c31285e5e6ad990b0f440_3.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_342700812c5c31285e5e6ad990b0f440_3.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_342700812c5c31285e5e6ad990b0f440_4.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_342700812c5c31285e5e6ad990b0f440_4.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_342700812c5c31285e5e6ad990b0f440_5.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_342700812c5c31285e5e6ad990b0f440_5.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_342700812c5c31285e5e6ad990b0f440_6.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_342700812c5c31285e5e6ad990b0f440_6.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_342700812c5c31285e5e6ad990b0f440_7.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_342700812c5c31285e5e6ad990b0f440_7.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_359bb38742144693ff835e037bdcbe2a_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_359bb38742144693ff835e037bdcbe2a_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_35b7f475ea67e5b50ad8daf9f0fb7a32_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_35b7f475ea67e5b50ad8daf9f0fb7a32_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_35b7f475ea67e5b50ad8daf9f0fb7a32_1.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_35b7f475ea67e5b50ad8daf9f0fb7a32_1.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_35b7f475ea67e5b50ad8daf9f0fb7a32_2.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_35b7f475ea67e5b50ad8daf9f0fb7a32_2.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_35b7f475ea67e5b50ad8daf9f0fb7a32_3.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_35b7f475ea67e5b50ad8daf9f0fb7a32_3.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_36485519c5fa2a82b15b39ede707af57_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_36485519c5fa2a82b15b39ede707af57_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_39398529bf51708137f143ebe5fc2431_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_39398529bf51708137f143ebe5fc2431_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_39398529bf51708137f143ebe5fc2431_1.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_39398529bf51708137f143ebe5fc2431_1.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_39398529bf51708137f143ebe5fc2431_2.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_39398529bf51708137f143ebe5fc2431_2.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_39398529bf51708137f143ebe5fc2431_3.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_39398529bf51708137f143ebe5fc2431_3.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_39398529bf51708137f143ebe5fc2431_4.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_39398529bf51708137f143ebe5fc2431_4.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_39398529bf51708137f143ebe5fc2431_5.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_39398529bf51708137f143ebe5fc2431_5.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_39398529bf51708137f143ebe5fc2431_6.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_39398529bf51708137f143ebe5fc2431_6.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_39398529bf51708137f143ebe5fc2431_7.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_39398529bf51708137f143ebe5fc2431_7.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_39398529bf51708137f143ebe5fc2431_8.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_39398529bf51708137f143ebe5fc2431_8.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_39398529bf51708137f143ebe5fc2431_9.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_39398529bf51708137f143ebe5fc2431_9.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_393e1e04448860b3f892101eb85fe1d1_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_393e1e04448860b3f892101eb85fe1d1_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_393e1e04448860b3f892101eb85fe1d1_1.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_393e1e04448860b3f892101eb85fe1d1_1.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_394ebaaedd80de898dd6cdf5d8307240_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_394ebaaedd80de898dd6cdf5d8307240_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_394ebaaedd80de898dd6cdf5d8307240_1.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_394ebaaedd80de898dd6cdf5d8307240_1.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_394ebaaedd80de898dd6cdf5d8307240_2.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_394ebaaedd80de898dd6cdf5d8307240_2.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_394ebaaedd80de898dd6cdf5d8307240_3.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_394ebaaedd80de898dd6cdf5d8307240_3.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_394ebaaedd80de898dd6cdf5d8307240_4.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_394ebaaedd80de898dd6cdf5d8307240_4.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_3b77f26274f2c09e5574926484806837_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_3b77f26274f2c09e5574926484806837_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_3b77f26274f2c09e5574926484806837_1.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_3b77f26274f2c09e5574926484806837_1.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_3b77f26274f2c09e5574926484806837_2.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_3b77f26274f2c09e5574926484806837_2.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_3b77f26274f2c09e5574926484806837_3.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_3b77f26274f2c09e5574926484806837_3.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_3eca350db357eb6f8a96f18b4fee685b_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_3eca350db357eb6f8a96f18b4fee685b_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_3eca350db357eb6f8a96f18b4fee685b_1.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_3eca350db357eb6f8a96f18b4fee685b_1.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_3eca350db357eb6f8a96f18b4fee685b_2.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_3eca350db357eb6f8a96f18b4fee685b_2.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_3eca350db357eb6f8a96f18b4fee685b_3.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_3eca350db357eb6f8a96f18b4fee685b_3.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_41499a7b235d89f6206aa9b4ec15e091_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_41499a7b235d89f6206aa9b4ec15e091_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_41499a7b235d89f6206aa9b4ec15e091_1.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_41499a7b235d89f6206aa9b4ec15e091_1.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_41499a7b235d89f6206aa9b4ec15e091_2.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_41499a7b235d89f6206aa9b4ec15e091_2.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_41499a7b235d89f6206aa9b4ec15e091_3.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_41499a7b235d89f6206aa9b4ec15e091_3.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_43bda7f94674ee6caea1f4304f30aa87_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_43bda7f94674ee6caea1f4304f30aa87_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_461ad0aaebddb6bdaaba103c451d42c6_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_461ad0aaebddb6bdaaba103c451d42c6_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_461ad0aaebddb6bdaaba103c451d42c6_1.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_461ad0aaebddb6bdaaba103c451d42c6_1.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_46513e4a5e71eebfcd3c88fa40e061df_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_46513e4a5e71eebfcd3c88fa40e061df_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_46513e4a5e71eebfcd3c88fa40e061df_1.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_46513e4a5e71eebfcd3c88fa40e061df_1.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_46513e4a5e71eebfcd3c88fa40e061df_10.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_46513e4a5e71eebfcd3c88fa40e061df_10.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_46513e4a5e71eebfcd3c88fa40e061df_2.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_46513e4a5e71eebfcd3c88fa40e061df_2.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_46513e4a5e71eebfcd3c88fa40e061df_3.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_46513e4a5e71eebfcd3c88fa40e061df_3.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_46513e4a5e71eebfcd3c88fa40e061df_4.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_46513e4a5e71eebfcd3c88fa40e061df_4.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_46513e4a5e71eebfcd3c88fa40e061df_5.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_46513e4a5e71eebfcd3c88fa40e061df_5.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_46513e4a5e71eebfcd3c88fa40e061df_6.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_46513e4a5e71eebfcd3c88fa40e061df_6.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_46513e4a5e71eebfcd3c88fa40e061df_7.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_46513e4a5e71eebfcd3c88fa40e061df_7.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_46513e4a5e71eebfcd3c88fa40e061df_8.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_46513e4a5e71eebfcd3c88fa40e061df_8.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_46513e4a5e71eebfcd3c88fa40e061df_9.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_46513e4a5e71eebfcd3c88fa40e061df_9.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_46625e38dbe2a29524e1590d7ae78f02_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_46625e38dbe2a29524e1590d7ae78f02_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_46625e38dbe2a29524e1590d7ae78f02_1.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_46625e38dbe2a29524e1590d7ae78f02_1.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_46625e38dbe2a29524e1590d7ae78f02_2.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_46625e38dbe2a29524e1590d7ae78f02_2.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_46625e38dbe2a29524e1590d7ae78f02_3.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_46625e38dbe2a29524e1590d7ae78f02_3.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_48d6f11cf92600b7992c1e1dd9fc0742_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_48d6f11cf92600b7992c1e1dd9fc0742_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_48d6f11cf92600b7992c1e1dd9fc0742_1.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_48d6f11cf92600b7992c1e1dd9fc0742_1.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_48d6f11cf92600b7992c1e1dd9fc0742_10.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_48d6f11cf92600b7992c1e1dd9fc0742_10.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_48d6f11cf92600b7992c1e1dd9fc0742_2.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_48d6f11cf92600b7992c1e1dd9fc0742_2.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_48d6f11cf92600b7992c1e1dd9fc0742_3.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_48d6f11cf92600b7992c1e1dd9fc0742_3.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_48d6f11cf92600b7992c1e1dd9fc0742_4.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_48d6f11cf92600b7992c1e1dd9fc0742_4.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_48d6f11cf92600b7992c1e1dd9fc0742_5.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_48d6f11cf92600b7992c1e1dd9fc0742_5.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_48d6f11cf92600b7992c1e1dd9fc0742_6.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_48d6f11cf92600b7992c1e1dd9fc0742_6.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_48d6f11cf92600b7992c1e1dd9fc0742_7.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_48d6f11cf92600b7992c1e1dd9fc0742_7.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_48d6f11cf92600b7992c1e1dd9fc0742_8.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_48d6f11cf92600b7992c1e1dd9fc0742_8.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_48d6f11cf92600b7992c1e1dd9fc0742_9.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_48d6f11cf92600b7992c1e1dd9fc0742_9.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_48e38e457f84588069eceab8a78301a0_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_48e38e457f84588069eceab8a78301a0_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_48e38e457f84588069eceab8a78301a0_1.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_48e38e457f84588069eceab8a78301a0_1.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_48efb56418da9a774c011c8cb5661a7b_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_48efb56418da9a774c011c8cb5661a7b_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_48efb56418da9a774c011c8cb5661a7b_1.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_48efb56418da9a774c011c8cb5661a7b_1.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_48efb56418da9a774c011c8cb5661a7b_10.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_48efb56418da9a774c011c8cb5661a7b_10.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_48efb56418da9a774c011c8cb5661a7b_2.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_48efb56418da9a774c011c8cb5661a7b_2.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_48efb56418da9a774c011c8cb5661a7b_3.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_48efb56418da9a774c011c8cb5661a7b_3.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_48efb56418da9a774c011c8cb5661a7b_4.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_48efb56418da9a774c011c8cb5661a7b_4.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_48efb56418da9a774c011c8cb5661a7b_5.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_48efb56418da9a774c011c8cb5661a7b_5.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_48efb56418da9a774c011c8cb5661a7b_6.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_48efb56418da9a774c011c8cb5661a7b_6.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_48efb56418da9a774c011c8cb5661a7b_7.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_48efb56418da9a774c011c8cb5661a7b_7.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_48efb56418da9a774c011c8cb5661a7b_8.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_48efb56418da9a774c011c8cb5661a7b_8.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_48efb56418da9a774c011c8cb5661a7b_9.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_48efb56418da9a774c011c8cb5661a7b_9.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_4b31a97a3b77ad509c0a44709b032e51_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_4b31a97a3b77ad509c0a44709b032e51_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_4b31a97a3b77ad509c0a44709b032e51_1.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_4b31a97a3b77ad509c0a44709b032e51_1.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_4c4a2c6ad662b8472386c0ff0e474b7f_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_4c4a2c6ad662b8472386c0ff0e474b7f_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_4c4a2c6ad662b8472386c0ff0e474b7f_1.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_4c4a2c6ad662b8472386c0ff0e474b7f_1.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_4c61d342db9054e1430815f08a84ff0c_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_4c61d342db9054e1430815f08a84ff0c_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_5266554b1f83a82edd6a98083dcffe58_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_5266554b1f83a82edd6a98083dcffe58_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_5266554b1f83a82edd6a98083dcffe58_1.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_5266554b1f83a82edd6a98083dcffe58_1.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_5266554b1f83a82edd6a98083dcffe58_10.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_5266554b1f83a82edd6a98083dcffe58_10.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_5266554b1f83a82edd6a98083dcffe58_11.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_5266554b1f83a82edd6a98083dcffe58_11.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_5266554b1f83a82edd6a98083dcffe58_12.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_5266554b1f83a82edd6a98083dcffe58_12.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_5266554b1f83a82edd6a98083dcffe58_13.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_5266554b1f83a82edd6a98083dcffe58_13.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_5266554b1f83a82edd6a98083dcffe58_14.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_5266554b1f83a82edd6a98083dcffe58_14.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_5266554b1f83a82edd6a98083dcffe58_15.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_5266554b1f83a82edd6a98083dcffe58_15.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_5266554b1f83a82edd6a98083dcffe58_16.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_5266554b1f83a82edd6a98083dcffe58_16.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_5266554b1f83a82edd6a98083dcffe58_17.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_5266554b1f83a82edd6a98083dcffe58_17.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_5266554b1f83a82edd6a98083dcffe58_18.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_5266554b1f83a82edd6a98083dcffe58_18.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_5266554b1f83a82edd6a98083dcffe58_2.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_5266554b1f83a82edd6a98083dcffe58_2.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_5266554b1f83a82edd6a98083dcffe58_3.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_5266554b1f83a82edd6a98083dcffe58_3.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_5266554b1f83a82edd6a98083dcffe58_4.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_5266554b1f83a82edd6a98083dcffe58_4.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_5266554b1f83a82edd6a98083dcffe58_5.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_5266554b1f83a82edd6a98083dcffe58_5.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_5266554b1f83a82edd6a98083dcffe58_6.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_5266554b1f83a82edd6a98083dcffe58_6.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_5266554b1f83a82edd6a98083dcffe58_7.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_5266554b1f83a82edd6a98083dcffe58_7.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_5266554b1f83a82edd6a98083dcffe58_8.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_5266554b1f83a82edd6a98083dcffe58_8.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_5266554b1f83a82edd6a98083dcffe58_9.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_5266554b1f83a82edd6a98083dcffe58_9.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_537df5c98545bb447acab4f20eee685c_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_537df5c98545bb447acab4f20eee685c_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_537df5c98545bb447acab4f20eee685c_1.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_537df5c98545bb447acab4f20eee685c_1.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_537df5c98545bb447acab4f20eee685c_10.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_537df5c98545bb447acab4f20eee685c_10.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_537df5c98545bb447acab4f20eee685c_11.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_537df5c98545bb447acab4f20eee685c_11.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_537df5c98545bb447acab4f20eee685c_12.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_537df5c98545bb447acab4f20eee685c_12.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_537df5c98545bb447acab4f20eee685c_13.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_537df5c98545bb447acab4f20eee685c_13.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_537df5c98545bb447acab4f20eee685c_2.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_537df5c98545bb447acab4f20eee685c_2.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_537df5c98545bb447acab4f20eee685c_3.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_537df5c98545bb447acab4f20eee685c_3.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_537df5c98545bb447acab4f20eee685c_4.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_537df5c98545bb447acab4f20eee685c_4.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_537df5c98545bb447acab4f20eee685c_5.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_537df5c98545bb447acab4f20eee685c_5.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_537df5c98545bb447acab4f20eee685c_6.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_537df5c98545bb447acab4f20eee685c_6.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_537df5c98545bb447acab4f20eee685c_7.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_537df5c98545bb447acab4f20eee685c_7.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_537df5c98545bb447acab4f20eee685c_8.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_537df5c98545bb447acab4f20eee685c_8.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_537df5c98545bb447acab4f20eee685c_9.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_537df5c98545bb447acab4f20eee685c_9.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_5618cdf93f29ac1c1ee1ca11f57b26d1_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_5618cdf93f29ac1c1ee1ca11f57b26d1_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_57e9457f3fd5a59d5b715e150d747a0c_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_57e9457f3fd5a59d5b715e150d747a0c_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_57e9457f3fd5a59d5b715e150d747a0c_1.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_57e9457f3fd5a59d5b715e150d747a0c_1.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_5c3c0ae521be04bcff642225de468e26_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_5c3c0ae521be04bcff642225de468e26_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_5c3c0ae521be04bcff642225de468e26_1.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_5c3c0ae521be04bcff642225de468e26_1.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_5c3c0ae521be04bcff642225de468e26_10.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_5c3c0ae521be04bcff642225de468e26_10.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_5c3c0ae521be04bcff642225de468e26_11.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_5c3c0ae521be04bcff642225de468e26_11.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_5c3c0ae521be04bcff642225de468e26_12.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_5c3c0ae521be04bcff642225de468e26_12.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_5c3c0ae521be04bcff642225de468e26_13.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_5c3c0ae521be04bcff642225de468e26_13.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_5c3c0ae521be04bcff642225de468e26_14.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_5c3c0ae521be04bcff642225de468e26_14.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_5c3c0ae521be04bcff642225de468e26_15.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_5c3c0ae521be04bcff642225de468e26_15.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_5c3c0ae521be04bcff642225de468e26_2.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_5c3c0ae521be04bcff642225de468e26_2.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_5c3c0ae521be04bcff642225de468e26_3.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_5c3c0ae521be04bcff642225de468e26_3.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_5c3c0ae521be04bcff642225de468e26_4.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_5c3c0ae521be04bcff642225de468e26_4.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_5c3c0ae521be04bcff642225de468e26_5.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_5c3c0ae521be04bcff642225de468e26_5.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_5c3c0ae521be04bcff642225de468e26_6.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_5c3c0ae521be04bcff642225de468e26_6.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_5c3c0ae521be04bcff642225de468e26_7.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_5c3c0ae521be04bcff642225de468e26_7.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_5c3c0ae521be04bcff642225de468e26_8.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_5c3c0ae521be04bcff642225de468e26_8.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_5c3c0ae521be04bcff642225de468e26_9.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_5c3c0ae521be04bcff642225de468e26_9.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_61d998ee5f98ea2f11cfc89f2c6b7f4d_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_61d998ee5f98ea2f11cfc89f2c6b7f4d_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_61d998ee5f98ea2f11cfc89f2c6b7f4d_1.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_61d998ee5f98ea2f11cfc89f2c6b7f4d_1.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_61e1abcde68ea3a8a8edfc1a29d49cf1_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_61e1abcde68ea3a8a8edfc1a29d49cf1_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_61f59b8e735008a4d5b936994eaae9c5_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_61f59b8e735008a4d5b936994eaae9c5_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_64902819a5b144aa518dcc1b62619713_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_64902819a5b144aa518dcc1b62619713_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_64902819a5b144aa518dcc1b62619713_1.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_64902819a5b144aa518dcc1b62619713_1.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_64deaeb90374535d42a90ac3c17f5a6c_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_64deaeb90374535d42a90ac3c17f5a6c_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_693b754ebedcd2145a8806243de0cd69_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_693b754ebedcd2145a8806243de0cd69_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_6c6d905aa687fca7b0555891b4cfe8f8_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_6c6d905aa687fca7b0555891b4cfe8f8_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_6c88c8533a0830843aabbd038e23e335_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_6c88c8533a0830843aabbd038e23e335_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_6fe4c642a9ba608051457dbdc26f5840_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_6fe4c642a9ba608051457dbdc26f5840_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_6fe4c642a9ba608051457dbdc26f5840_1.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_6fe4c642a9ba608051457dbdc26f5840_1.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_6fe4c642a9ba608051457dbdc26f5840_2.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_6fe4c642a9ba608051457dbdc26f5840_2.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_6fe4c642a9ba608051457dbdc26f5840_3.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_6fe4c642a9ba608051457dbdc26f5840_3.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_714f611b6bb042489b44581960ec6d12_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_714f611b6bb042489b44581960ec6d12_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_714f611b6bb042489b44581960ec6d12_1.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_714f611b6bb042489b44581960ec6d12_1.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_724316c7bf5883c229048cc808301aeb_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_724316c7bf5883c229048cc808301aeb_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_724316c7bf5883c229048cc808301aeb_1.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_724316c7bf5883c229048cc808301aeb_1.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_724316c7bf5883c229048cc808301aeb_10.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_724316c7bf5883c229048cc808301aeb_10.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_724316c7bf5883c229048cc808301aeb_11.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_724316c7bf5883c229048cc808301aeb_11.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_724316c7bf5883c229048cc808301aeb_12.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_724316c7bf5883c229048cc808301aeb_12.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_724316c7bf5883c229048cc808301aeb_13.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_724316c7bf5883c229048cc808301aeb_13.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_724316c7bf5883c229048cc808301aeb_14.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_724316c7bf5883c229048cc808301aeb_14.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_724316c7bf5883c229048cc808301aeb_15.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_724316c7bf5883c229048cc808301aeb_15.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_724316c7bf5883c229048cc808301aeb_16.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_724316c7bf5883c229048cc808301aeb_16.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_724316c7bf5883c229048cc808301aeb_17.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_724316c7bf5883c229048cc808301aeb_17.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_724316c7bf5883c229048cc808301aeb_18.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_724316c7bf5883c229048cc808301aeb_18.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_724316c7bf5883c229048cc808301aeb_19.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_724316c7bf5883c229048cc808301aeb_19.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_724316c7bf5883c229048cc808301aeb_2.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_724316c7bf5883c229048cc808301aeb_2.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_724316c7bf5883c229048cc808301aeb_20.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_724316c7bf5883c229048cc808301aeb_20.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_724316c7bf5883c229048cc808301aeb_21.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_724316c7bf5883c229048cc808301aeb_21.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_724316c7bf5883c229048cc808301aeb_22.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_724316c7bf5883c229048cc808301aeb_22.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_724316c7bf5883c229048cc808301aeb_23.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_724316c7bf5883c229048cc808301aeb_23.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_724316c7bf5883c229048cc808301aeb_24.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_724316c7bf5883c229048cc808301aeb_24.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_724316c7bf5883c229048cc808301aeb_25.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_724316c7bf5883c229048cc808301aeb_25.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_724316c7bf5883c229048cc808301aeb_26.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_724316c7bf5883c229048cc808301aeb_26.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_724316c7bf5883c229048cc808301aeb_27.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_724316c7bf5883c229048cc808301aeb_27.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_724316c7bf5883c229048cc808301aeb_28.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_724316c7bf5883c229048cc808301aeb_28.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_724316c7bf5883c229048cc808301aeb_29.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_724316c7bf5883c229048cc808301aeb_29.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_724316c7bf5883c229048cc808301aeb_3.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_724316c7bf5883c229048cc808301aeb_3.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_724316c7bf5883c229048cc808301aeb_30.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_724316c7bf5883c229048cc808301aeb_30.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_724316c7bf5883c229048cc808301aeb_31.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_724316c7bf5883c229048cc808301aeb_31.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_724316c7bf5883c229048cc808301aeb_32.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_724316c7bf5883c229048cc808301aeb_32.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_724316c7bf5883c229048cc808301aeb_4.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_724316c7bf5883c229048cc808301aeb_4.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_724316c7bf5883c229048cc808301aeb_5.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_724316c7bf5883c229048cc808301aeb_5.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_724316c7bf5883c229048cc808301aeb_6.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_724316c7bf5883c229048cc808301aeb_6.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_724316c7bf5883c229048cc808301aeb_7.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_724316c7bf5883c229048cc808301aeb_7.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_724316c7bf5883c229048cc808301aeb_8.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_724316c7bf5883c229048cc808301aeb_8.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_724316c7bf5883c229048cc808301aeb_9.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_724316c7bf5883c229048cc808301aeb_9.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_72c6000930c316ad64aa52384d2025ed_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_72c6000930c316ad64aa52384d2025ed_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_72c6000930c316ad64aa52384d2025ed_1.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_72c6000930c316ad64aa52384d2025ed_1.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_72c6000930c316ad64aa52384d2025ed_2.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_72c6000930c316ad64aa52384d2025ed_2.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_72c6000930c316ad64aa52384d2025ed_3.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_72c6000930c316ad64aa52384d2025ed_3.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_72c6000930c316ad64aa52384d2025ed_4.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_72c6000930c316ad64aa52384d2025ed_4.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_7360516ed5c48eb489dc9c3d5659b851_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_7360516ed5c48eb489dc9c3d5659b851_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_74516d598b9e521d4f60ea5eb5e7e882_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_74516d598b9e521d4f60ea5eb5e7e882_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_74516d598b9e521d4f60ea5eb5e7e882_1.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_74516d598b9e521d4f60ea5eb5e7e882_1.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_74516d598b9e521d4f60ea5eb5e7e882_10.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_74516d598b9e521d4f60ea5eb5e7e882_10.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_74516d598b9e521d4f60ea5eb5e7e882_2.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_74516d598b9e521d4f60ea5eb5e7e882_2.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_74516d598b9e521d4f60ea5eb5e7e882_3.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_74516d598b9e521d4f60ea5eb5e7e882_3.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_74516d598b9e521d4f60ea5eb5e7e882_4.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_74516d598b9e521d4f60ea5eb5e7e882_4.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_74516d598b9e521d4f60ea5eb5e7e882_5.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_74516d598b9e521d4f60ea5eb5e7e882_5.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_74516d598b9e521d4f60ea5eb5e7e882_6.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_74516d598b9e521d4f60ea5eb5e7e882_6.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_74516d598b9e521d4f60ea5eb5e7e882_7.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_74516d598b9e521d4f60ea5eb5e7e882_7.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_74516d598b9e521d4f60ea5eb5e7e882_8.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_74516d598b9e521d4f60ea5eb5e7e882_8.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_74516d598b9e521d4f60ea5eb5e7e882_9.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_74516d598b9e521d4f60ea5eb5e7e882_9.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_7477569d924cfdaa7583ae8cd252f67e_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_7477569d924cfdaa7583ae8cd252f67e_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_7477569d924cfdaa7583ae8cd252f67e_1.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_7477569d924cfdaa7583ae8cd252f67e_1.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_750e713ff4e65310a5fa3888413a6f3f_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_750e713ff4e65310a5fa3888413a6f3f_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_750e713ff4e65310a5fa3888413a6f3f_1.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_750e713ff4e65310a5fa3888413a6f3f_1.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_77194a13dd0096713e7b4ba3e4dec53a_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_77194a13dd0096713e7b4ba3e4dec53a_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_77194a13dd0096713e7b4ba3e4dec53a_1.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_77194a13dd0096713e7b4ba3e4dec53a_1.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_79e6c3327ee40619a1894080d11c544f_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_79e6c3327ee40619a1894080d11c544f_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_79e6c3327ee40619a1894080d11c544f_1.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_79e6c3327ee40619a1894080d11c544f_1.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_7a124668a5b889fb71a9e17dafd2befb_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_7a124668a5b889fb71a9e17dafd2befb_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_7a5a79eac8dfe394a9759f16c6f5bf9f_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_7a5a79eac8dfe394a9759f16c6f5bf9f_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_7a5a79eac8dfe394a9759f16c6f5bf9f_1.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_7a5a79eac8dfe394a9759f16c6f5bf9f_1.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_7a5a79eac8dfe394a9759f16c6f5bf9f_2.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_7a5a79eac8dfe394a9759f16c6f5bf9f_2.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_7a5a79eac8dfe394a9759f16c6f5bf9f_3.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_7a5a79eac8dfe394a9759f16c6f5bf9f_3.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_7b09957c0814d6090180509f5c9a0374_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_7b09957c0814d6090180509f5c9a0374_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_7b09957c0814d6090180509f5c9a0374_1.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_7b09957c0814d6090180509f5c9a0374_1.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_7b09957c0814d6090180509f5c9a0374_2.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_7b09957c0814d6090180509f5c9a0374_2.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_7b09957c0814d6090180509f5c9a0374_3.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_7b09957c0814d6090180509f5c9a0374_3.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_7b09957c0814d6090180509f5c9a0374_4.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_7b09957c0814d6090180509f5c9a0374_4.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_7b09957c0814d6090180509f5c9a0374_5.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_7b09957c0814d6090180509f5c9a0374_5.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_7dea3f2fe2a67782e97196ccc6e21779_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_7dea3f2fe2a67782e97196ccc6e21779_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_7dea3f2fe2a67782e97196ccc6e21779_1.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_7dea3f2fe2a67782e97196ccc6e21779_1.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8041aaee37b5d202d258ed22b37a4013_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8041aaee37b5d202d258ed22b37a4013_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8041aaee37b5d202d258ed22b37a4013_1.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8041aaee37b5d202d258ed22b37a4013_1.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_830894b355afe4f2c6b76318dd540e4d_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_830894b355afe4f2c6b76318dd540e4d_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_830894b355afe4f2c6b76318dd540e4d_1.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_830894b355afe4f2c6b76318dd540e4d_1.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_85393e80e8e7bb773c5386ba49f7d25c_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_85393e80e8e7bb773c5386ba49f7d25c_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_85393e80e8e7bb773c5386ba49f7d25c_1.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_85393e80e8e7bb773c5386ba49f7d25c_1.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_85393e80e8e7bb773c5386ba49f7d25c_2.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_85393e80e8e7bb773c5386ba49f7d25c_2.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_85393e80e8e7bb773c5386ba49f7d25c_3.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_85393e80e8e7bb773c5386ba49f7d25c_3.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_85393e80e8e7bb773c5386ba49f7d25c_4.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_85393e80e8e7bb773c5386ba49f7d25c_4.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_85393e80e8e7bb773c5386ba49f7d25c_5.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_85393e80e8e7bb773c5386ba49f7d25c_5.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_85393e80e8e7bb773c5386ba49f7d25c_6.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_85393e80e8e7bb773c5386ba49f7d25c_6.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_85393e80e8e7bb773c5386ba49f7d25c_7.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_85393e80e8e7bb773c5386ba49f7d25c_7.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_85393e80e8e7bb773c5386ba49f7d25c_8.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_85393e80e8e7bb773c5386ba49f7d25c_8.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_85393e80e8e7bb773c5386ba49f7d25c_9.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_85393e80e8e7bb773c5386ba49f7d25c_9.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_870e360a0d9fc48328d317218a7c0231_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_870e360a0d9fc48328d317218a7c0231_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_870e360a0d9fc48328d317218a7c0231_1.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_870e360a0d9fc48328d317218a7c0231_1.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_870e360a0d9fc48328d317218a7c0231_2.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_870e360a0d9fc48328d317218a7c0231_2.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_870e360a0d9fc48328d317218a7c0231_3.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_870e360a0d9fc48328d317218a7c0231_3.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_870e360a0d9fc48328d317218a7c0231_4.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_870e360a0d9fc48328d317218a7c0231_4.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_87c5e3fac28ebc6c86d41a31fcd0132e_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_87c5e3fac28ebc6c86d41a31fcd0132e_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_87c5e3fac28ebc6c86d41a31fcd0132e_1.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_87c5e3fac28ebc6c86d41a31fcd0132e_1.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_89a846735edaffe405eac11acac35d89_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_89a846735edaffe405eac11acac35d89_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_89a846735edaffe405eac11acac35d89_1.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_89a846735edaffe405eac11acac35d89_1.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8a84c96f0d16e6a06ad85e0031e8e8be_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8a84c96f0d16e6a06ad85e0031e8e8be_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8a84c96f0d16e6a06ad85e0031e8e8be_1.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8a84c96f0d16e6a06ad85e0031e8e8be_1.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8bb5194cac7f112ddc2e793484458267_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8bb5194cac7f112ddc2e793484458267_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8c7e9c10ecba586c690967f573754dbb_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8c7e9c10ecba586c690967f573754dbb_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8c7e9c10ecba586c690967f573754dbb_1.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8c7e9c10ecba586c690967f573754dbb_1.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8c7e9c10ecba586c690967f573754dbb_2.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8c7e9c10ecba586c690967f573754dbb_2.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8c7e9c10ecba586c690967f573754dbb_3.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8c7e9c10ecba586c690967f573754dbb_3.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8c7e9c10ecba586c690967f573754dbb_4.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8c7e9c10ecba586c690967f573754dbb_4.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8c7e9c10ecba586c690967f573754dbb_5.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8c7e9c10ecba586c690967f573754dbb_5.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8c7e9c10ecba586c690967f573754dbb_6.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8c7e9c10ecba586c690967f573754dbb_6.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8c7e9c10ecba586c690967f573754dbb_7.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8c7e9c10ecba586c690967f573754dbb_7.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8c7e9c10ecba586c690967f573754dbb_8.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8c7e9c10ecba586c690967f573754dbb_8.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8c7e9c10ecba586c690967f573754dbb_9.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8c7e9c10ecba586c690967f573754dbb_9.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8d08032a0ece709ec814ca6f022ac703_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8d08032a0ece709ec814ca6f022ac703_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8d08032a0ece709ec814ca6f022ac703_1.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8d08032a0ece709ec814ca6f022ac703_1.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8d08032a0ece709ec814ca6f022ac703_10.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8d08032a0ece709ec814ca6f022ac703_10.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8d08032a0ece709ec814ca6f022ac703_11.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8d08032a0ece709ec814ca6f022ac703_11.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8d08032a0ece709ec814ca6f022ac703_12.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8d08032a0ece709ec814ca6f022ac703_12.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8d08032a0ece709ec814ca6f022ac703_13.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8d08032a0ece709ec814ca6f022ac703_13.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8d08032a0ece709ec814ca6f022ac703_14.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8d08032a0ece709ec814ca6f022ac703_14.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8d08032a0ece709ec814ca6f022ac703_2.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8d08032a0ece709ec814ca6f022ac703_2.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8d08032a0ece709ec814ca6f022ac703_3.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8d08032a0ece709ec814ca6f022ac703_3.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8d08032a0ece709ec814ca6f022ac703_4.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8d08032a0ece709ec814ca6f022ac703_4.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8d08032a0ece709ec814ca6f022ac703_5.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8d08032a0ece709ec814ca6f022ac703_5.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8d08032a0ece709ec814ca6f022ac703_6.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8d08032a0ece709ec814ca6f022ac703_6.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8d08032a0ece709ec814ca6f022ac703_7.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8d08032a0ece709ec814ca6f022ac703_7.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8d08032a0ece709ec814ca6f022ac703_8.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8d08032a0ece709ec814ca6f022ac703_8.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8d08032a0ece709ec814ca6f022ac703_9.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8d08032a0ece709ec814ca6f022ac703_9.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8dd17f007b111edecab78d809092e98a_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8dd17f007b111edecab78d809092e98a_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8ddb8ff2cf98a43c378897c71f93e13f_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8ddb8ff2cf98a43c378897c71f93e13f_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8e6e91ec859c0757059294f6029ac4d2_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8e6e91ec859c0757059294f6029ac4d2_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8e6e91ec859c0757059294f6029ac4d2_1.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8e6e91ec859c0757059294f6029ac4d2_1.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8e6e91ec859c0757059294f6029ac4d2_2.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8e6e91ec859c0757059294f6029ac4d2_2.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8e6e91ec859c0757059294f6029ac4d2_3.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8e6e91ec859c0757059294f6029ac4d2_3.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8e6e91ec859c0757059294f6029ac4d2_4.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8e6e91ec859c0757059294f6029ac4d2_4.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8e6e91ec859c0757059294f6029ac4d2_5.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8e6e91ec859c0757059294f6029ac4d2_5.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8e6e91ec859c0757059294f6029ac4d2_6.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8e6e91ec859c0757059294f6029ac4d2_6.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8e6e91ec859c0757059294f6029ac4d2_7.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8e6e91ec859c0757059294f6029ac4d2_7.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8e93a51eeecf46a9775ee8acb48fa053_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8e93a51eeecf46a9775ee8acb48fa053_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8e93a51eeecf46a9775ee8acb48fa053_1.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8e93a51eeecf46a9775ee8acb48fa053_1.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8e93a51eeecf46a9775ee8acb48fa053_10.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8e93a51eeecf46a9775ee8acb48fa053_10.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8e93a51eeecf46a9775ee8acb48fa053_11.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8e93a51eeecf46a9775ee8acb48fa053_11.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8e93a51eeecf46a9775ee8acb48fa053_12.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8e93a51eeecf46a9775ee8acb48fa053_12.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8e93a51eeecf46a9775ee8acb48fa053_13.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8e93a51eeecf46a9775ee8acb48fa053_13.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8e93a51eeecf46a9775ee8acb48fa053_14.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8e93a51eeecf46a9775ee8acb48fa053_14.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8e93a51eeecf46a9775ee8acb48fa053_15.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8e93a51eeecf46a9775ee8acb48fa053_15.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8e93a51eeecf46a9775ee8acb48fa053_16.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8e93a51eeecf46a9775ee8acb48fa053_16.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8e93a51eeecf46a9775ee8acb48fa053_17.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8e93a51eeecf46a9775ee8acb48fa053_17.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8e93a51eeecf46a9775ee8acb48fa053_18.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8e93a51eeecf46a9775ee8acb48fa053_18.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8e93a51eeecf46a9775ee8acb48fa053_19.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8e93a51eeecf46a9775ee8acb48fa053_19.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8e93a51eeecf46a9775ee8acb48fa053_2.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8e93a51eeecf46a9775ee8acb48fa053_2.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8e93a51eeecf46a9775ee8acb48fa053_20.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8e93a51eeecf46a9775ee8acb48fa053_20.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8e93a51eeecf46a9775ee8acb48fa053_21.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8e93a51eeecf46a9775ee8acb48fa053_21.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8e93a51eeecf46a9775ee8acb48fa053_22.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8e93a51eeecf46a9775ee8acb48fa053_22.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8e93a51eeecf46a9775ee8acb48fa053_23.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8e93a51eeecf46a9775ee8acb48fa053_23.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8e93a51eeecf46a9775ee8acb48fa053_24.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8e93a51eeecf46a9775ee8acb48fa053_24.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8e93a51eeecf46a9775ee8acb48fa053_25.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8e93a51eeecf46a9775ee8acb48fa053_25.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8e93a51eeecf46a9775ee8acb48fa053_26.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8e93a51eeecf46a9775ee8acb48fa053_26.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8e93a51eeecf46a9775ee8acb48fa053_27.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8e93a51eeecf46a9775ee8acb48fa053_27.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8e93a51eeecf46a9775ee8acb48fa053_28.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8e93a51eeecf46a9775ee8acb48fa053_28.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8e93a51eeecf46a9775ee8acb48fa053_29.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8e93a51eeecf46a9775ee8acb48fa053_29.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8e93a51eeecf46a9775ee8acb48fa053_3.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8e93a51eeecf46a9775ee8acb48fa053_3.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8e93a51eeecf46a9775ee8acb48fa053_30.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8e93a51eeecf46a9775ee8acb48fa053_30.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8e93a51eeecf46a9775ee8acb48fa053_31.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8e93a51eeecf46a9775ee8acb48fa053_31.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8e93a51eeecf46a9775ee8acb48fa053_32.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8e93a51eeecf46a9775ee8acb48fa053_32.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8e93a51eeecf46a9775ee8acb48fa053_33.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8e93a51eeecf46a9775ee8acb48fa053_33.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8e93a51eeecf46a9775ee8acb48fa053_34.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8e93a51eeecf46a9775ee8acb48fa053_34.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8e93a51eeecf46a9775ee8acb48fa053_35.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8e93a51eeecf46a9775ee8acb48fa053_35.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8e93a51eeecf46a9775ee8acb48fa053_4.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8e93a51eeecf46a9775ee8acb48fa053_4.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8e93a51eeecf46a9775ee8acb48fa053_5.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8e93a51eeecf46a9775ee8acb48fa053_5.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8e93a51eeecf46a9775ee8acb48fa053_6.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8e93a51eeecf46a9775ee8acb48fa053_6.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8e93a51eeecf46a9775ee8acb48fa053_7.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8e93a51eeecf46a9775ee8acb48fa053_7.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8e93a51eeecf46a9775ee8acb48fa053_8.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8e93a51eeecf46a9775ee8acb48fa053_8.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8e93a51eeecf46a9775ee8acb48fa053_9.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8e93a51eeecf46a9775ee8acb48fa053_9.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8f019a90ebeb49f114796c1660e3c3e1_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8f019a90ebeb49f114796c1660e3c3e1_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8f019a90ebeb49f114796c1660e3c3e1_1.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_8f019a90ebeb49f114796c1660e3c3e1_1.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_90b830c93674911625d91e5d5d1f111a_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_90b830c93674911625d91e5d5d1f111a_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_90b830c93674911625d91e5d5d1f111a_1.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_90b830c93674911625d91e5d5d1f111a_1.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_90b830c93674911625d91e5d5d1f111a_2.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_90b830c93674911625d91e5d5d1f111a_2.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_90b830c93674911625d91e5d5d1f111a_3.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_90b830c93674911625d91e5d5d1f111a_3.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_90b830c93674911625d91e5d5d1f111a_4.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_90b830c93674911625d91e5d5d1f111a_4.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_90b830c93674911625d91e5d5d1f111a_5.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_90b830c93674911625d91e5d5d1f111a_5.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_90b830c93674911625d91e5d5d1f111a_6.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_90b830c93674911625d91e5d5d1f111a_6.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_90b830c93674911625d91e5d5d1f111a_7.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_90b830c93674911625d91e5d5d1f111a_7.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_90b830c93674911625d91e5d5d1f111a_8.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_90b830c93674911625d91e5d5d1f111a_8.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_90b830c93674911625d91e5d5d1f111a_9.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_90b830c93674911625d91e5d5d1f111a_9.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_92b388d7a2a42943588b9b99e28fc37f_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_92b388d7a2a42943588b9b99e28fc37f_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_92b388d7a2a42943588b9b99e28fc37f_1.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_92b388d7a2a42943588b9b99e28fc37f_1.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_92b388d7a2a42943588b9b99e28fc37f_10.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_92b388d7a2a42943588b9b99e28fc37f_10.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_92b388d7a2a42943588b9b99e28fc37f_11.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_92b388d7a2a42943588b9b99e28fc37f_11.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_92b388d7a2a42943588b9b99e28fc37f_12.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_92b388d7a2a42943588b9b99e28fc37f_12.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_92b388d7a2a42943588b9b99e28fc37f_13.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_92b388d7a2a42943588b9b99e28fc37f_13.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_92b388d7a2a42943588b9b99e28fc37f_14.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_92b388d7a2a42943588b9b99e28fc37f_14.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_92b388d7a2a42943588b9b99e28fc37f_15.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_92b388d7a2a42943588b9b99e28fc37f_15.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_92b388d7a2a42943588b9b99e28fc37f_16.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_92b388d7a2a42943588b9b99e28fc37f_16.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_92b388d7a2a42943588b9b99e28fc37f_17.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_92b388d7a2a42943588b9b99e28fc37f_17.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_92b388d7a2a42943588b9b99e28fc37f_18.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_92b388d7a2a42943588b9b99e28fc37f_18.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_92b388d7a2a42943588b9b99e28fc37f_19.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_92b388d7a2a42943588b9b99e28fc37f_19.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_92b388d7a2a42943588b9b99e28fc37f_2.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_92b388d7a2a42943588b9b99e28fc37f_2.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_92b388d7a2a42943588b9b99e28fc37f_20.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_92b388d7a2a42943588b9b99e28fc37f_20.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_92b388d7a2a42943588b9b99e28fc37f_21.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_92b388d7a2a42943588b9b99e28fc37f_21.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_92b388d7a2a42943588b9b99e28fc37f_22.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_92b388d7a2a42943588b9b99e28fc37f_22.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_92b388d7a2a42943588b9b99e28fc37f_23.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_92b388d7a2a42943588b9b99e28fc37f_23.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_92b388d7a2a42943588b9b99e28fc37f_24.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_92b388d7a2a42943588b9b99e28fc37f_24.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_92b388d7a2a42943588b9b99e28fc37f_25.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_92b388d7a2a42943588b9b99e28fc37f_25.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_92b388d7a2a42943588b9b99e28fc37f_26.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_92b388d7a2a42943588b9b99e28fc37f_26.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_92b388d7a2a42943588b9b99e28fc37f_27.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_92b388d7a2a42943588b9b99e28fc37f_27.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_92b388d7a2a42943588b9b99e28fc37f_28.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_92b388d7a2a42943588b9b99e28fc37f_28.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_92b388d7a2a42943588b9b99e28fc37f_29.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_92b388d7a2a42943588b9b99e28fc37f_29.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_92b388d7a2a42943588b9b99e28fc37f_3.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_92b388d7a2a42943588b9b99e28fc37f_3.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_92b388d7a2a42943588b9b99e28fc37f_30.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_92b388d7a2a42943588b9b99e28fc37f_30.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_92b388d7a2a42943588b9b99e28fc37f_31.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_92b388d7a2a42943588b9b99e28fc37f_31.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_92b388d7a2a42943588b9b99e28fc37f_32.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_92b388d7a2a42943588b9b99e28fc37f_32.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_92b388d7a2a42943588b9b99e28fc37f_33.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_92b388d7a2a42943588b9b99e28fc37f_33.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_92b388d7a2a42943588b9b99e28fc37f_4.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_92b388d7a2a42943588b9b99e28fc37f_4.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_92b388d7a2a42943588b9b99e28fc37f_5.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_92b388d7a2a42943588b9b99e28fc37f_5.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_92b388d7a2a42943588b9b99e28fc37f_6.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_92b388d7a2a42943588b9b99e28fc37f_6.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_92b388d7a2a42943588b9b99e28fc37f_7.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_92b388d7a2a42943588b9b99e28fc37f_7.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_92b388d7a2a42943588b9b99e28fc37f_8.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_92b388d7a2a42943588b9b99e28fc37f_8.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_92b388d7a2a42943588b9b99e28fc37f_9.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_92b388d7a2a42943588b9b99e28fc37f_9.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_938845538096b7c30219af0c20076f6f_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_938845538096b7c30219af0c20076f6f_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_93f7b9cdac3302e6b6edf7456bf141c5_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_93f7b9cdac3302e6b6edf7456bf141c5_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_94d7887d501e79fd36cc5f092aea68d5_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_94d7887d501e79fd36cc5f092aea68d5_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_94d7887d501e79fd36cc5f092aea68d5_1.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_94d7887d501e79fd36cc5f092aea68d5_1.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_97d9c6d1ea07b646b855f81e285d8dc1_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_97d9c6d1ea07b646b855f81e285d8dc1_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_994a935a53f9eb0cb5194618f7973710_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_994a935a53f9eb0cb5194618f7973710_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_994a935a53f9eb0cb5194618f7973710_1.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_994a935a53f9eb0cb5194618f7973710_1.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_994a935a53f9eb0cb5194618f7973710_2.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_994a935a53f9eb0cb5194618f7973710_2.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_9acfbcce718bf2b38fa02cdf5ff38910_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_9acfbcce718bf2b38fa02cdf5ff38910_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_9acfbcce718bf2b38fa02cdf5ff38910_1.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_9acfbcce718bf2b38fa02cdf5ff38910_1.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_9acfbcce718bf2b38fa02cdf5ff38910_2.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_9acfbcce718bf2b38fa02cdf5ff38910_2.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_9acfbcce718bf2b38fa02cdf5ff38910_3.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_9acfbcce718bf2b38fa02cdf5ff38910_3.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_a13147f9cd709afed1a73a290570068a_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_a13147f9cd709afed1a73a290570068a_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_a184b2b1f4178314a2e38cbc99cf9958_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_a184b2b1f4178314a2e38cbc99cf9958_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_a184b2b1f4178314a2e38cbc99cf9958_1.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_a184b2b1f4178314a2e38cbc99cf9958_1.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_a324c382499c55f5b5db8249722b6cad_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_a324c382499c55f5b5db8249722b6cad_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_a324c382499c55f5b5db8249722b6cad_1.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_a324c382499c55f5b5db8249722b6cad_1.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_a48aafa81ef5b50f956e5cdcf3df4a00_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_a48aafa81ef5b50f956e5cdcf3df4a00_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_a48aafa81ef5b50f956e5cdcf3df4a00_1.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_a48aafa81ef5b50f956e5cdcf3df4a00_1.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_a48aafa81ef5b50f956e5cdcf3df4a00_2.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_a48aafa81ef5b50f956e5cdcf3df4a00_2.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_a5913494ac271cc08fea4d79e0e84784_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_a5913494ac271cc08fea4d79e0e84784_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_a5913494ac271cc08fea4d79e0e84784_1.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_a5913494ac271cc08fea4d79e0e84784_1.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_a5913494ac271cc08fea4d79e0e84784_2.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_a5913494ac271cc08fea4d79e0e84784_2.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_a5913494ac271cc08fea4d79e0e84784_3.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_a5913494ac271cc08fea4d79e0e84784_3.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_a5913494ac271cc08fea4d79e0e84784_4.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_a5913494ac271cc08fea4d79e0e84784_4.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_a5913494ac271cc08fea4d79e0e84784_5.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_a5913494ac271cc08fea4d79e0e84784_5.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_a5913494ac271cc08fea4d79e0e84784_6.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_a5913494ac271cc08fea4d79e0e84784_6.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_a5913494ac271cc08fea4d79e0e84784_7.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_a5913494ac271cc08fea4d79e0e84784_7.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_a5913494ac271cc08fea4d79e0e84784_8.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_a5913494ac271cc08fea4d79e0e84784_8.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_a632868125d896cd2b6467069e4692b1_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_a632868125d896cd2b6467069e4692b1_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_a632868125d896cd2b6467069e4692b1_1.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_a632868125d896cd2b6467069e4692b1_1.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_a678c736950aeebf0563fef75d98bdc9_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_a678c736950aeebf0563fef75d98bdc9_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_a678c736950aeebf0563fef75d98bdc9_1.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_a678c736950aeebf0563fef75d98bdc9_1.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_a678c736950aeebf0563fef75d98bdc9_2.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_a678c736950aeebf0563fef75d98bdc9_2.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_a678c736950aeebf0563fef75d98bdc9_3.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_a678c736950aeebf0563fef75d98bdc9_3.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_a678c736950aeebf0563fef75d98bdc9_4.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_a678c736950aeebf0563fef75d98bdc9_4.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_acc460502863a0042579cdad61fcfd67_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_acc460502863a0042579cdad61fcfd67_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_acc460502863a0042579cdad61fcfd67_1.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_acc460502863a0042579cdad61fcfd67_1.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_acc460502863a0042579cdad61fcfd67_10.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_acc460502863a0042579cdad61fcfd67_10.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_acc460502863a0042579cdad61fcfd67_11.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_acc460502863a0042579cdad61fcfd67_11.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_acc460502863a0042579cdad61fcfd67_12.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_acc460502863a0042579cdad61fcfd67_12.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_acc460502863a0042579cdad61fcfd67_13.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_acc460502863a0042579cdad61fcfd67_13.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_acc460502863a0042579cdad61fcfd67_2.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_acc460502863a0042579cdad61fcfd67_2.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_acc460502863a0042579cdad61fcfd67_3.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_acc460502863a0042579cdad61fcfd67_3.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_acc460502863a0042579cdad61fcfd67_4.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_acc460502863a0042579cdad61fcfd67_4.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_acc460502863a0042579cdad61fcfd67_5.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_acc460502863a0042579cdad61fcfd67_5.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_acc460502863a0042579cdad61fcfd67_6.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_acc460502863a0042579cdad61fcfd67_6.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_acc460502863a0042579cdad61fcfd67_7.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_acc460502863a0042579cdad61fcfd67_7.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_acc460502863a0042579cdad61fcfd67_8.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_acc460502863a0042579cdad61fcfd67_8.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_acc460502863a0042579cdad61fcfd67_9.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_acc460502863a0042579cdad61fcfd67_9.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_af7f2783a27ca7afff842ab1126288b2_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_af7f2783a27ca7afff842ab1126288b2_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_afa83585888bb8e0da4f3d0c1829adc5_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_afa83585888bb8e0da4f3d0c1829adc5_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_b421ccf2c1722f437c271dfb12af94c0_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_b421ccf2c1722f437c271dfb12af94c0_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_b421ccf2c1722f437c271dfb12af94c0_1.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_b421ccf2c1722f437c271dfb12af94c0_1.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_b421ccf2c1722f437c271dfb12af94c0_2.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_b421ccf2c1722f437c271dfb12af94c0_2.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_b421ccf2c1722f437c271dfb12af94c0_3.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_b421ccf2c1722f437c271dfb12af94c0_3.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_b421ccf2c1722f437c271dfb12af94c0_4.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_b421ccf2c1722f437c271dfb12af94c0_4.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_b421ccf2c1722f437c271dfb12af94c0_5.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_b421ccf2c1722f437c271dfb12af94c0_5.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_b421ccf2c1722f437c271dfb12af94c0_6.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_b421ccf2c1722f437c271dfb12af94c0_6.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_b4c45b56ea86bf4c512bb37ba74b7d43_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_b4c45b56ea86bf4c512bb37ba74b7d43_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_b55b967ad7ce71b854f3182dc86a9967_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_b55b967ad7ce71b854f3182dc86a9967_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_b55b967ad7ce71b854f3182dc86a9967_1.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_b55b967ad7ce71b854f3182dc86a9967_1.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_b55b967ad7ce71b854f3182dc86a9967_10.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_b55b967ad7ce71b854f3182dc86a9967_10.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_b55b967ad7ce71b854f3182dc86a9967_2.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_b55b967ad7ce71b854f3182dc86a9967_2.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_b55b967ad7ce71b854f3182dc86a9967_3.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_b55b967ad7ce71b854f3182dc86a9967_3.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_b55b967ad7ce71b854f3182dc86a9967_4.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_b55b967ad7ce71b854f3182dc86a9967_4.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_b55b967ad7ce71b854f3182dc86a9967_5.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_b55b967ad7ce71b854f3182dc86a9967_5.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_b55b967ad7ce71b854f3182dc86a9967_6.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_b55b967ad7ce71b854f3182dc86a9967_6.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_b55b967ad7ce71b854f3182dc86a9967_7.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_b55b967ad7ce71b854f3182dc86a9967_7.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_b55b967ad7ce71b854f3182dc86a9967_8.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_b55b967ad7ce71b854f3182dc86a9967_8.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_b55b967ad7ce71b854f3182dc86a9967_9.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_b55b967ad7ce71b854f3182dc86a9967_9.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_b7b70e7039122d168e8c439c1fc01218_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_b7b70e7039122d168e8c439c1fc01218_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_b7c161ab5e9f597f9086ab32db656524_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_b7c161ab5e9f597f9086ab32db656524_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_b874380a8f79899f28efb0252d60d0e2_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_b874380a8f79899f28efb0252d60d0e2_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_b874380a8f79899f28efb0252d60d0e2_1.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_b874380a8f79899f28efb0252d60d0e2_1.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_b874380a8f79899f28efb0252d60d0e2_2.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_b874380a8f79899f28efb0252d60d0e2_2.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_b874380a8f79899f28efb0252d60d0e2_3.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_b874380a8f79899f28efb0252d60d0e2_3.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_b874380a8f79899f28efb0252d60d0e2_4.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_b874380a8f79899f28efb0252d60d0e2_4.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_b874380a8f79899f28efb0252d60d0e2_5.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_b874380a8f79899f28efb0252d60d0e2_5.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_b874380a8f79899f28efb0252d60d0e2_6.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_b874380a8f79899f28efb0252d60d0e2_6.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_b874380a8f79899f28efb0252d60d0e2_7.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_b874380a8f79899f28efb0252d60d0e2_7.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_b874380a8f79899f28efb0252d60d0e2_8.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_b874380a8f79899f28efb0252d60d0e2_8.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_b874380a8f79899f28efb0252d60d0e2_9.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_b874380a8f79899f28efb0252d60d0e2_9.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_b9ccd5ed4067d43f920d0380ceb573dc_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_b9ccd5ed4067d43f920d0380ceb573dc_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_b9ccd5ed4067d43f920d0380ceb573dc_1.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_b9ccd5ed4067d43f920d0380ceb573dc_1.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_badda5cd3018c11d0da695a1070131bd_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_badda5cd3018c11d0da695a1070131bd_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_badda5cd3018c11d0da695a1070131bd_1.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_badda5cd3018c11d0da695a1070131bd_1.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_badda5cd3018c11d0da695a1070131bd_10.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_badda5cd3018c11d0da695a1070131bd_10.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_badda5cd3018c11d0da695a1070131bd_11.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_badda5cd3018c11d0da695a1070131bd_11.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_badda5cd3018c11d0da695a1070131bd_2.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_badda5cd3018c11d0da695a1070131bd_2.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_badda5cd3018c11d0da695a1070131bd_3.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_badda5cd3018c11d0da695a1070131bd_3.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_badda5cd3018c11d0da695a1070131bd_4.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_badda5cd3018c11d0da695a1070131bd_4.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_badda5cd3018c11d0da695a1070131bd_5.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_badda5cd3018c11d0da695a1070131bd_5.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_badda5cd3018c11d0da695a1070131bd_6.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_badda5cd3018c11d0da695a1070131bd_6.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_badda5cd3018c11d0da695a1070131bd_7.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_badda5cd3018c11d0da695a1070131bd_7.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_badda5cd3018c11d0da695a1070131bd_8.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_badda5cd3018c11d0da695a1070131bd_8.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_badda5cd3018c11d0da695a1070131bd_9.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_badda5cd3018c11d0da695a1070131bd_9.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_bec92a199482a24830e2ee3d94aa5700_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_bec92a199482a24830e2ee3d94aa5700_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_bf78f6fec7a9b4ab90c74f4ef26dd350_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_bf78f6fec7a9b4ab90c74f4ef26dd350_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_bf78f6fec7a9b4ab90c74f4ef26dd350_1.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_bf78f6fec7a9b4ab90c74f4ef26dd350_1.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_c28f16be2fc8166bef1b59203c3aaae5_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_c28f16be2fc8166bef1b59203c3aaae5_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_c28f16be2fc8166bef1b59203c3aaae5_1.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_c28f16be2fc8166bef1b59203c3aaae5_1.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_c2bd19212db2943689335c8b86a166c3_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_c2bd19212db2943689335c8b86a166c3_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_c2bd19212db2943689335c8b86a166c3_1.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_c2bd19212db2943689335c8b86a166c3_1.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_c2bd19212db2943689335c8b86a166c3_10.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_c2bd19212db2943689335c8b86a166c3_10.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_c2bd19212db2943689335c8b86a166c3_11.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_c2bd19212db2943689335c8b86a166c3_11.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_c2bd19212db2943689335c8b86a166c3_2.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_c2bd19212db2943689335c8b86a166c3_2.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_c2bd19212db2943689335c8b86a166c3_3.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_c2bd19212db2943689335c8b86a166c3_3.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_c2bd19212db2943689335c8b86a166c3_4.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_c2bd19212db2943689335c8b86a166c3_4.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_c2bd19212db2943689335c8b86a166c3_5.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_c2bd19212db2943689335c8b86a166c3_5.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_c2bd19212db2943689335c8b86a166c3_6.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_c2bd19212db2943689335c8b86a166c3_6.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_c2bd19212db2943689335c8b86a166c3_7.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_c2bd19212db2943689335c8b86a166c3_7.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_c2bd19212db2943689335c8b86a166c3_8.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_c2bd19212db2943689335c8b86a166c3_8.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_c2bd19212db2943689335c8b86a166c3_9.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_c2bd19212db2943689335c8b86a166c3_9.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_c4892a7bf8b8b5115441ad7171c143f8_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_c4892a7bf8b8b5115441ad7171c143f8_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_c4892a7bf8b8b5115441ad7171c143f8_1.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_c4892a7bf8b8b5115441ad7171c143f8_1.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_c4892a7bf8b8b5115441ad7171c143f8_2.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_c4892a7bf8b8b5115441ad7171c143f8_2.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_c530dbb9a5a58693cf79d5ce5cf3fab0_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_c530dbb9a5a58693cf79d5ce5cf3fab0_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_c530dbb9a5a58693cf79d5ce5cf3fab0_1.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_c530dbb9a5a58693cf79d5ce5cf3fab0_1.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_c530dbb9a5a58693cf79d5ce5cf3fab0_10.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_c530dbb9a5a58693cf79d5ce5cf3fab0_10.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_c530dbb9a5a58693cf79d5ce5cf3fab0_2.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_c530dbb9a5a58693cf79d5ce5cf3fab0_2.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_c530dbb9a5a58693cf79d5ce5cf3fab0_3.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_c530dbb9a5a58693cf79d5ce5cf3fab0_3.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_c530dbb9a5a58693cf79d5ce5cf3fab0_4.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_c530dbb9a5a58693cf79d5ce5cf3fab0_4.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_c530dbb9a5a58693cf79d5ce5cf3fab0_5.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_c530dbb9a5a58693cf79d5ce5cf3fab0_5.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_c530dbb9a5a58693cf79d5ce5cf3fab0_6.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_c530dbb9a5a58693cf79d5ce5cf3fab0_6.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_c530dbb9a5a58693cf79d5ce5cf3fab0_7.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_c530dbb9a5a58693cf79d5ce5cf3fab0_7.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_c530dbb9a5a58693cf79d5ce5cf3fab0_8.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_c530dbb9a5a58693cf79d5ce5cf3fab0_8.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_c530dbb9a5a58693cf79d5ce5cf3fab0_9.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_c530dbb9a5a58693cf79d5ce5cf3fab0_9.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_c8df1e480fce46022ffac0bd416a7c4a_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_c8df1e480fce46022ffac0bd416a7c4a_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_c8fcf53f17be032c4503242758088c70_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_c8fcf53f17be032c4503242758088c70_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_c8fcf53f17be032c4503242758088c70_1.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_c8fcf53f17be032c4503242758088c70_1.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_caf6fbf1dc609fe123418578b46f72cd_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_caf6fbf1dc609fe123418578b46f72cd_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_caf6fbf1dc609fe123418578b46f72cd_1.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_caf6fbf1dc609fe123418578b46f72cd_1.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_caf6fbf1dc609fe123418578b46f72cd_2.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_caf6fbf1dc609fe123418578b46f72cd_2.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_caf6fbf1dc609fe123418578b46f72cd_3.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_caf6fbf1dc609fe123418578b46f72cd_3.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cb19eb88b0ee10866a9679713b7c1e5f_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cb19eb88b0ee10866a9679713b7c1e5f_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cc97d27b1b2a5aa3c98551075fb32cf7_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cc97d27b1b2a5aa3c98551075fb32cf7_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cc97d27b1b2a5aa3c98551075fb32cf7_1.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cc97d27b1b2a5aa3c98551075fb32cf7_1.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cc97d27b1b2a5aa3c98551075fb32cf7_2.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cc97d27b1b2a5aa3c98551075fb32cf7_2.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cc97d27b1b2a5aa3c98551075fb32cf7_3.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cc97d27b1b2a5aa3c98551075fb32cf7_3.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cc97d27b1b2a5aa3c98551075fb32cf7_4.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cc97d27b1b2a5aa3c98551075fb32cf7_4.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cc97d27b1b2a5aa3c98551075fb32cf7_5.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cc97d27b1b2a5aa3c98551075fb32cf7_5.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cc97d27b1b2a5aa3c98551075fb32cf7_6.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cc97d27b1b2a5aa3c98551075fb32cf7_6.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cc97d27b1b2a5aa3c98551075fb32cf7_7.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cc97d27b1b2a5aa3c98551075fb32cf7_7.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cce341ee7cc87d386b241f3fda62e82e_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cce341ee7cc87d386b241f3fda62e82e_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cce341ee7cc87d386b241f3fda62e82e_1.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cce341ee7cc87d386b241f3fda62e82e_1.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cd25bcd63b549e75cb6783b6583c1520_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cd25bcd63b549e75cb6783b6583c1520_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cd25bcd63b549e75cb6783b6583c1520_1.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cd25bcd63b549e75cb6783b6583c1520_1.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cd25bcd63b549e75cb6783b6583c1520_2.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cd25bcd63b549e75cb6783b6583c1520_2.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cd25bcd63b549e75cb6783b6583c1520_3.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cd25bcd63b549e75cb6783b6583c1520_3.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cf057a37303ac6c0659fe6c0873638aa_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cf057a37303ac6c0659fe6c0873638aa_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cf057a37303ac6c0659fe6c0873638aa_1.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cf057a37303ac6c0659fe6c0873638aa_1.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cf057a37303ac6c0659fe6c0873638aa_10.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cf057a37303ac6c0659fe6c0873638aa_10.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cf057a37303ac6c0659fe6c0873638aa_11.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cf057a37303ac6c0659fe6c0873638aa_11.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cf057a37303ac6c0659fe6c0873638aa_12.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cf057a37303ac6c0659fe6c0873638aa_12.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cf057a37303ac6c0659fe6c0873638aa_13.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cf057a37303ac6c0659fe6c0873638aa_13.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cf057a37303ac6c0659fe6c0873638aa_14.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cf057a37303ac6c0659fe6c0873638aa_14.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cf057a37303ac6c0659fe6c0873638aa_15.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cf057a37303ac6c0659fe6c0873638aa_15.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cf057a37303ac6c0659fe6c0873638aa_16.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cf057a37303ac6c0659fe6c0873638aa_16.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cf057a37303ac6c0659fe6c0873638aa_17.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cf057a37303ac6c0659fe6c0873638aa_17.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cf057a37303ac6c0659fe6c0873638aa_18.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cf057a37303ac6c0659fe6c0873638aa_18.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cf057a37303ac6c0659fe6c0873638aa_19.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cf057a37303ac6c0659fe6c0873638aa_19.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cf057a37303ac6c0659fe6c0873638aa_2.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cf057a37303ac6c0659fe6c0873638aa_2.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cf057a37303ac6c0659fe6c0873638aa_20.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cf057a37303ac6c0659fe6c0873638aa_20.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cf057a37303ac6c0659fe6c0873638aa_21.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cf057a37303ac6c0659fe6c0873638aa_21.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cf057a37303ac6c0659fe6c0873638aa_22.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cf057a37303ac6c0659fe6c0873638aa_22.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cf057a37303ac6c0659fe6c0873638aa_23.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cf057a37303ac6c0659fe6c0873638aa_23.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cf057a37303ac6c0659fe6c0873638aa_24.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cf057a37303ac6c0659fe6c0873638aa_24.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cf057a37303ac6c0659fe6c0873638aa_25.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cf057a37303ac6c0659fe6c0873638aa_25.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cf057a37303ac6c0659fe6c0873638aa_26.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cf057a37303ac6c0659fe6c0873638aa_26.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cf057a37303ac6c0659fe6c0873638aa_27.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cf057a37303ac6c0659fe6c0873638aa_27.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cf057a37303ac6c0659fe6c0873638aa_28.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cf057a37303ac6c0659fe6c0873638aa_28.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cf057a37303ac6c0659fe6c0873638aa_29.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cf057a37303ac6c0659fe6c0873638aa_29.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cf057a37303ac6c0659fe6c0873638aa_3.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cf057a37303ac6c0659fe6c0873638aa_3.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cf057a37303ac6c0659fe6c0873638aa_30.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cf057a37303ac6c0659fe6c0873638aa_30.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cf057a37303ac6c0659fe6c0873638aa_31.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cf057a37303ac6c0659fe6c0873638aa_31.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cf057a37303ac6c0659fe6c0873638aa_32.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cf057a37303ac6c0659fe6c0873638aa_32.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cf057a37303ac6c0659fe6c0873638aa_33.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cf057a37303ac6c0659fe6c0873638aa_33.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cf057a37303ac6c0659fe6c0873638aa_34.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cf057a37303ac6c0659fe6c0873638aa_34.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cf057a37303ac6c0659fe6c0873638aa_35.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cf057a37303ac6c0659fe6c0873638aa_35.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cf057a37303ac6c0659fe6c0873638aa_36.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cf057a37303ac6c0659fe6c0873638aa_36.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cf057a37303ac6c0659fe6c0873638aa_37.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cf057a37303ac6c0659fe6c0873638aa_37.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cf057a37303ac6c0659fe6c0873638aa_38.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cf057a37303ac6c0659fe6c0873638aa_38.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cf057a37303ac6c0659fe6c0873638aa_39.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cf057a37303ac6c0659fe6c0873638aa_39.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cf057a37303ac6c0659fe6c0873638aa_4.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cf057a37303ac6c0659fe6c0873638aa_4.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cf057a37303ac6c0659fe6c0873638aa_40.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cf057a37303ac6c0659fe6c0873638aa_40.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cf057a37303ac6c0659fe6c0873638aa_41.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cf057a37303ac6c0659fe6c0873638aa_41.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cf057a37303ac6c0659fe6c0873638aa_42.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cf057a37303ac6c0659fe6c0873638aa_42.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cf057a37303ac6c0659fe6c0873638aa_43.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cf057a37303ac6c0659fe6c0873638aa_43.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cf057a37303ac6c0659fe6c0873638aa_44.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cf057a37303ac6c0659fe6c0873638aa_44.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cf057a37303ac6c0659fe6c0873638aa_45.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cf057a37303ac6c0659fe6c0873638aa_45.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cf057a37303ac6c0659fe6c0873638aa_46.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cf057a37303ac6c0659fe6c0873638aa_46.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cf057a37303ac6c0659fe6c0873638aa_47.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cf057a37303ac6c0659fe6c0873638aa_47.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cf057a37303ac6c0659fe6c0873638aa_48.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cf057a37303ac6c0659fe6c0873638aa_48.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cf057a37303ac6c0659fe6c0873638aa_49.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cf057a37303ac6c0659fe6c0873638aa_49.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cf057a37303ac6c0659fe6c0873638aa_5.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cf057a37303ac6c0659fe6c0873638aa_5.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cf057a37303ac6c0659fe6c0873638aa_50.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cf057a37303ac6c0659fe6c0873638aa_50.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cf057a37303ac6c0659fe6c0873638aa_51.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cf057a37303ac6c0659fe6c0873638aa_51.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cf057a37303ac6c0659fe6c0873638aa_52.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cf057a37303ac6c0659fe6c0873638aa_52.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cf057a37303ac6c0659fe6c0873638aa_53.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cf057a37303ac6c0659fe6c0873638aa_53.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cf057a37303ac6c0659fe6c0873638aa_54.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cf057a37303ac6c0659fe6c0873638aa_54.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cf057a37303ac6c0659fe6c0873638aa_55.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cf057a37303ac6c0659fe6c0873638aa_55.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cf057a37303ac6c0659fe6c0873638aa_56.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cf057a37303ac6c0659fe6c0873638aa_56.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cf057a37303ac6c0659fe6c0873638aa_57.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cf057a37303ac6c0659fe6c0873638aa_57.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cf057a37303ac6c0659fe6c0873638aa_58.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cf057a37303ac6c0659fe6c0873638aa_58.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cf057a37303ac6c0659fe6c0873638aa_59.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cf057a37303ac6c0659fe6c0873638aa_59.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cf057a37303ac6c0659fe6c0873638aa_6.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cf057a37303ac6c0659fe6c0873638aa_6.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cf057a37303ac6c0659fe6c0873638aa_60.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cf057a37303ac6c0659fe6c0873638aa_60.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cf057a37303ac6c0659fe6c0873638aa_61.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cf057a37303ac6c0659fe6c0873638aa_61.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cf057a37303ac6c0659fe6c0873638aa_62.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cf057a37303ac6c0659fe6c0873638aa_62.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cf057a37303ac6c0659fe6c0873638aa_63.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cf057a37303ac6c0659fe6c0873638aa_63.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cf057a37303ac6c0659fe6c0873638aa_7.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cf057a37303ac6c0659fe6c0873638aa_7.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cf057a37303ac6c0659fe6c0873638aa_8.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cf057a37303ac6c0659fe6c0873638aa_8.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cf057a37303ac6c0659fe6c0873638aa_9.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cf057a37303ac6c0659fe6c0873638aa_9.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cf2eff92c0461eabf34f66e6aada9944_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_cf2eff92c0461eabf34f66e6aada9944_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_d08de5b352a07641280303ba4017b26d_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_d08de5b352a07641280303ba4017b26d_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_d08de5b352a07641280303ba4017b26d_1.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_d08de5b352a07641280303ba4017b26d_1.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_d08de5b352a07641280303ba4017b26d_2.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_d08de5b352a07641280303ba4017b26d_2.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_d08de5b352a07641280303ba4017b26d_3.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_d08de5b352a07641280303ba4017b26d_3.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_d08de5b352a07641280303ba4017b26d_4.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_d08de5b352a07641280303ba4017b26d_4.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_d08de5b352a07641280303ba4017b26d_5.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_d08de5b352a07641280303ba4017b26d_5.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_d08de5b352a07641280303ba4017b26d_6.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_d08de5b352a07641280303ba4017b26d_6.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_d08de5b352a07641280303ba4017b26d_7.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_d08de5b352a07641280303ba4017b26d_7.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_d08de5b352a07641280303ba4017b26d_8.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_d08de5b352a07641280303ba4017b26d_8.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_d08de5b352a07641280303ba4017b26d_9.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_d08de5b352a07641280303ba4017b26d_9.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_d5a61d00a3968f2e56e4f467ca14efd7_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_d5a61d00a3968f2e56e4f467ca14efd7_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_d5a61d00a3968f2e56e4f467ca14efd7_1.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_d5a61d00a3968f2e56e4f467ca14efd7_1.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_d5cdf67df942c507581dee299a8c2490_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_d5cdf67df942c507581dee299a8c2490_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_d5cdf67df942c507581dee299a8c2490_1.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_d5cdf67df942c507581dee299a8c2490_1.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_d5cdf67df942c507581dee299a8c2490_2.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_d5cdf67df942c507581dee299a8c2490_2.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_d5cdf67df942c507581dee299a8c2490_3.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_d5cdf67df942c507581dee299a8c2490_3.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_d6995219feb474fbd4df795e3f858ca0_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_d6995219feb474fbd4df795e3f858ca0_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_d6995219feb474fbd4df795e3f858ca0_1.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_d6995219feb474fbd4df795e3f858ca0_1.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_d6a23a9acf716806a9f201121e35c9db_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_d6a23a9acf716806a9f201121e35c9db_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_d6a23a9acf716806a9f201121e35c9db_1.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_d6a23a9acf716806a9f201121e35c9db_1.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_d6a23a9acf716806a9f201121e35c9db_2.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_d6a23a9acf716806a9f201121e35c9db_2.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_d6a23a9acf716806a9f201121e35c9db_3.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_d6a23a9acf716806a9f201121e35c9db_3.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_d6a23a9acf716806a9f201121e35c9db_4.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_d6a23a9acf716806a9f201121e35c9db_4.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_d6a23a9acf716806a9f201121e35c9db_5.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_d6a23a9acf716806a9f201121e35c9db_5.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_d6a23a9acf716806a9f201121e35c9db_6.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_d6a23a9acf716806a9f201121e35c9db_6.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_d6a23a9acf716806a9f201121e35c9db_7.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_d6a23a9acf716806a9f201121e35c9db_7.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_d7113cc7ef8e27e5a2eeb15f963a7064_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_d7113cc7ef8e27e5a2eeb15f963a7064_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_d71873b02ec9b90cc07a0ef8ae817b79_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_d71873b02ec9b90cc07a0ef8ae817b79_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_d74c1cf67b50bacbcb0f1db3536656d0_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_d74c1cf67b50bacbcb0f1db3536656d0_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_d7e867a77bb1d40676c94ade4ba3ea64_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_d7e867a77bb1d40676c94ade4ba3ea64_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_d84f9c04db33861adc4aec4aaba44297_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_d84f9c04db33861adc4aec4aaba44297_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_d84f9c04db33861adc4aec4aaba44297_1.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_d84f9c04db33861adc4aec4aaba44297_1.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_d84f9c04db33861adc4aec4aaba44297_10.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_d84f9c04db33861adc4aec4aaba44297_10.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_d84f9c04db33861adc4aec4aaba44297_11.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_d84f9c04db33861adc4aec4aaba44297_11.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_d84f9c04db33861adc4aec4aaba44297_12.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_d84f9c04db33861adc4aec4aaba44297_12.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_d84f9c04db33861adc4aec4aaba44297_13.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_d84f9c04db33861adc4aec4aaba44297_13.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_d84f9c04db33861adc4aec4aaba44297_14.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_d84f9c04db33861adc4aec4aaba44297_14.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_d84f9c04db33861adc4aec4aaba44297_15.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_d84f9c04db33861adc4aec4aaba44297_15.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_d84f9c04db33861adc4aec4aaba44297_16.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_d84f9c04db33861adc4aec4aaba44297_16.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_d84f9c04db33861adc4aec4aaba44297_17.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_d84f9c04db33861adc4aec4aaba44297_17.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_d84f9c04db33861adc4aec4aaba44297_18.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_d84f9c04db33861adc4aec4aaba44297_18.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_d84f9c04db33861adc4aec4aaba44297_19.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_d84f9c04db33861adc4aec4aaba44297_19.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_d84f9c04db33861adc4aec4aaba44297_2.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_d84f9c04db33861adc4aec4aaba44297_2.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_d84f9c04db33861adc4aec4aaba44297_20.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_d84f9c04db33861adc4aec4aaba44297_20.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_d84f9c04db33861adc4aec4aaba44297_21.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_d84f9c04db33861adc4aec4aaba44297_21.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_d84f9c04db33861adc4aec4aaba44297_22.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_d84f9c04db33861adc4aec4aaba44297_22.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_d84f9c04db33861adc4aec4aaba44297_23.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_d84f9c04db33861adc4aec4aaba44297_23.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_d84f9c04db33861adc4aec4aaba44297_24.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_d84f9c04db33861adc4aec4aaba44297_24.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_d84f9c04db33861adc4aec4aaba44297_25.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_d84f9c04db33861adc4aec4aaba44297_25.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_d84f9c04db33861adc4aec4aaba44297_26.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_d84f9c04db33861adc4aec4aaba44297_26.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_d84f9c04db33861adc4aec4aaba44297_27.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_d84f9c04db33861adc4aec4aaba44297_27.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_d84f9c04db33861adc4aec4aaba44297_28.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_d84f9c04db33861adc4aec4aaba44297_28.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_d84f9c04db33861adc4aec4aaba44297_29.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_d84f9c04db33861adc4aec4aaba44297_29.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_d84f9c04db33861adc4aec4aaba44297_3.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_d84f9c04db33861adc4aec4aaba44297_3.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_d84f9c04db33861adc4aec4aaba44297_30.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_d84f9c04db33861adc4aec4aaba44297_30.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_d84f9c04db33861adc4aec4aaba44297_31.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_d84f9c04db33861adc4aec4aaba44297_31.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_d84f9c04db33861adc4aec4aaba44297_32.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_d84f9c04db33861adc4aec4aaba44297_32.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_d84f9c04db33861adc4aec4aaba44297_33.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_d84f9c04db33861adc4aec4aaba44297_33.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_d84f9c04db33861adc4aec4aaba44297_34.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_d84f9c04db33861adc4aec4aaba44297_34.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_d84f9c04db33861adc4aec4aaba44297_35.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_d84f9c04db33861adc4aec4aaba44297_35.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_d84f9c04db33861adc4aec4aaba44297_36.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_d84f9c04db33861adc4aec4aaba44297_36.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_d84f9c04db33861adc4aec4aaba44297_37.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_d84f9c04db33861adc4aec4aaba44297_37.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_d84f9c04db33861adc4aec4aaba44297_38.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_d84f9c04db33861adc4aec4aaba44297_38.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_d84f9c04db33861adc4aec4aaba44297_39.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_d84f9c04db33861adc4aec4aaba44297_39.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_d84f9c04db33861adc4aec4aaba44297_4.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_d84f9c04db33861adc4aec4aaba44297_4.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_d84f9c04db33861adc4aec4aaba44297_40.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_d84f9c04db33861adc4aec4aaba44297_40.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_d84f9c04db33861adc4aec4aaba44297_5.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_d84f9c04db33861adc4aec4aaba44297_5.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_d84f9c04db33861adc4aec4aaba44297_6.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_d84f9c04db33861adc4aec4aaba44297_6.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_d84f9c04db33861adc4aec4aaba44297_7.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_d84f9c04db33861adc4aec4aaba44297_7.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_d84f9c04db33861adc4aec4aaba44297_8.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_d84f9c04db33861adc4aec4aaba44297_8.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_d84f9c04db33861adc4aec4aaba44297_9.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_d84f9c04db33861adc4aec4aaba44297_9.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_dade1437b3aa53361dae5228cf67d3ea_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_dade1437b3aa53361dae5228cf67d3ea_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_dade1437b3aa53361dae5228cf67d3ea_1.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_dade1437b3aa53361dae5228cf67d3ea_1.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_dade1437b3aa53361dae5228cf67d3ea_10.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_dade1437b3aa53361dae5228cf67d3ea_10.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_dade1437b3aa53361dae5228cf67d3ea_11.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_dade1437b3aa53361dae5228cf67d3ea_11.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_dade1437b3aa53361dae5228cf67d3ea_12.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_dade1437b3aa53361dae5228cf67d3ea_12.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_dade1437b3aa53361dae5228cf67d3ea_13.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_dade1437b3aa53361dae5228cf67d3ea_13.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_dade1437b3aa53361dae5228cf67d3ea_14.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_dade1437b3aa53361dae5228cf67d3ea_14.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_dade1437b3aa53361dae5228cf67d3ea_15.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_dade1437b3aa53361dae5228cf67d3ea_15.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_dade1437b3aa53361dae5228cf67d3ea_16.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_dade1437b3aa53361dae5228cf67d3ea_16.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_dade1437b3aa53361dae5228cf67d3ea_17.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_dade1437b3aa53361dae5228cf67d3ea_17.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_dade1437b3aa53361dae5228cf67d3ea_18.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_dade1437b3aa53361dae5228cf67d3ea_18.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_dade1437b3aa53361dae5228cf67d3ea_19.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_dade1437b3aa53361dae5228cf67d3ea_19.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_dade1437b3aa53361dae5228cf67d3ea_2.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_dade1437b3aa53361dae5228cf67d3ea_2.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_dade1437b3aa53361dae5228cf67d3ea_20.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_dade1437b3aa53361dae5228cf67d3ea_20.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_dade1437b3aa53361dae5228cf67d3ea_21.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_dade1437b3aa53361dae5228cf67d3ea_21.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_dade1437b3aa53361dae5228cf67d3ea_22.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_dade1437b3aa53361dae5228cf67d3ea_22.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_dade1437b3aa53361dae5228cf67d3ea_23.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_dade1437b3aa53361dae5228cf67d3ea_23.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_dade1437b3aa53361dae5228cf67d3ea_24.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_dade1437b3aa53361dae5228cf67d3ea_24.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_dade1437b3aa53361dae5228cf67d3ea_25.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_dade1437b3aa53361dae5228cf67d3ea_25.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_dade1437b3aa53361dae5228cf67d3ea_26.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_dade1437b3aa53361dae5228cf67d3ea_26.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_dade1437b3aa53361dae5228cf67d3ea_27.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_dade1437b3aa53361dae5228cf67d3ea_27.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_dade1437b3aa53361dae5228cf67d3ea_28.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_dade1437b3aa53361dae5228cf67d3ea_28.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_dade1437b3aa53361dae5228cf67d3ea_29.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_dade1437b3aa53361dae5228cf67d3ea_29.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_dade1437b3aa53361dae5228cf67d3ea_3.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_dade1437b3aa53361dae5228cf67d3ea_3.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_dade1437b3aa53361dae5228cf67d3ea_30.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_dade1437b3aa53361dae5228cf67d3ea_30.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_dade1437b3aa53361dae5228cf67d3ea_31.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_dade1437b3aa53361dae5228cf67d3ea_31.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_dade1437b3aa53361dae5228cf67d3ea_32.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_dade1437b3aa53361dae5228cf67d3ea_32.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_dade1437b3aa53361dae5228cf67d3ea_33.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_dade1437b3aa53361dae5228cf67d3ea_33.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_dade1437b3aa53361dae5228cf67d3ea_34.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_dade1437b3aa53361dae5228cf67d3ea_34.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_dade1437b3aa53361dae5228cf67d3ea_35.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_dade1437b3aa53361dae5228cf67d3ea_35.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_dade1437b3aa53361dae5228cf67d3ea_36.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_dade1437b3aa53361dae5228cf67d3ea_36.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_dade1437b3aa53361dae5228cf67d3ea_37.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_dade1437b3aa53361dae5228cf67d3ea_37.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_dade1437b3aa53361dae5228cf67d3ea_38.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_dade1437b3aa53361dae5228cf67d3ea_38.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_dade1437b3aa53361dae5228cf67d3ea_39.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_dade1437b3aa53361dae5228cf67d3ea_39.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_dade1437b3aa53361dae5228cf67d3ea_4.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_dade1437b3aa53361dae5228cf67d3ea_4.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_dade1437b3aa53361dae5228cf67d3ea_40.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_dade1437b3aa53361dae5228cf67d3ea_40.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_dade1437b3aa53361dae5228cf67d3ea_41.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_dade1437b3aa53361dae5228cf67d3ea_41.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_dade1437b3aa53361dae5228cf67d3ea_42.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_dade1437b3aa53361dae5228cf67d3ea_42.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_dade1437b3aa53361dae5228cf67d3ea_5.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_dade1437b3aa53361dae5228cf67d3ea_5.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_dade1437b3aa53361dae5228cf67d3ea_6.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_dade1437b3aa53361dae5228cf67d3ea_6.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_dade1437b3aa53361dae5228cf67d3ea_7.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_dade1437b3aa53361dae5228cf67d3ea_7.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_dade1437b3aa53361dae5228cf67d3ea_8.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_dade1437b3aa53361dae5228cf67d3ea_8.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_dade1437b3aa53361dae5228cf67d3ea_9.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_dade1437b3aa53361dae5228cf67d3ea_9.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_dd742580f8d9fdc4163d6ee4d0ed53ff_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_dd742580f8d9fdc4163d6ee4d0ed53ff_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_de679bce71ba6911237af2be6bfb0ae1_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_de679bce71ba6911237af2be6bfb0ae1_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_de679bce71ba6911237af2be6bfb0ae1_1.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_de679bce71ba6911237af2be6bfb0ae1_1.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_de679bce71ba6911237af2be6bfb0ae1_2.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_de679bce71ba6911237af2be6bfb0ae1_2.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_de679bce71ba6911237af2be6bfb0ae1_3.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_de679bce71ba6911237af2be6bfb0ae1_3.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_de679bce71ba6911237af2be6bfb0ae1_4.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_de679bce71ba6911237af2be6bfb0ae1_4.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_de679bce71ba6911237af2be6bfb0ae1_5.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_de679bce71ba6911237af2be6bfb0ae1_5.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_de679bce71ba6911237af2be6bfb0ae1_6.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_de679bce71ba6911237af2be6bfb0ae1_6.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_de679bce71ba6911237af2be6bfb0ae1_7.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_de679bce71ba6911237af2be6bfb0ae1_7.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_de679bce71ba6911237af2be6bfb0ae1_8.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_de679bce71ba6911237af2be6bfb0ae1_8.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_de679bce71ba6911237af2be6bfb0ae1_9.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_de679bce71ba6911237af2be6bfb0ae1_9.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_df017aaea4d095f83df30d09ff687e45_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_df017aaea4d095f83df30d09ff687e45_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_df017aaea4d095f83df30d09ff687e45_1.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_df017aaea4d095f83df30d09ff687e45_1.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_df017aaea4d095f83df30d09ff687e45_2.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_df017aaea4d095f83df30d09ff687e45_2.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_e02207a641519831272855b6c06cd87f_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_e02207a641519831272855b6c06cd87f_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_e02207a641519831272855b6c06cd87f_1.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_e02207a641519831272855b6c06cd87f_1.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_e02207a641519831272855b6c06cd87f_2.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_e02207a641519831272855b6c06cd87f_2.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_e02207a641519831272855b6c06cd87f_3.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_e02207a641519831272855b6c06cd87f_3.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_e02207a641519831272855b6c06cd87f_4.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_e02207a641519831272855b6c06cd87f_4.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_e36e7e56590feb42fe50c07e614ed917_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_e36e7e56590feb42fe50c07e614ed917_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_e36e7e56590feb42fe50c07e614ed917_1.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_e36e7e56590feb42fe50c07e614ed917_1.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_e36e7e56590feb42fe50c07e614ed917_2.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_e36e7e56590feb42fe50c07e614ed917_2.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_e36e7e56590feb42fe50c07e614ed917_3.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_e36e7e56590feb42fe50c07e614ed917_3.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_e50dca1e5e60ed529175c0e254094718_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_e50dca1e5e60ed529175c0e254094718_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_e50dca1e5e60ed529175c0e254094718_1.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_e50dca1e5e60ed529175c0e254094718_1.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_e519df757229e12b1c93f918c5cae6f4_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_e519df757229e12b1c93f918c5cae6f4_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_e519df757229e12b1c93f918c5cae6f4_1.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_e519df757229e12b1c93f918c5cae6f4_1.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_e6bca057ea3aa8e2fd79ad2d9815827d_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_e6bca057ea3aa8e2fd79ad2d9815827d_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_e857f3b7ff9e698846d40f4d6ae45346_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_e857f3b7ff9e698846d40f4d6ae45346_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_ea6a207abbd7c11ee63b0b469cb0d7c5_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_ea6a207abbd7c11ee63b0b469cb0d7c5_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_ea6a207abbd7c11ee63b0b469cb0d7c5_1.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_ea6a207abbd7c11ee63b0b469cb0d7c5_1.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_ec43df55c194d6775c99f0abf1830288_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_ec43df55c194d6775c99f0abf1830288_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_f1f2a6ea141d6a0339cf405f9c711561_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_f1f2a6ea141d6a0339cf405f9c711561_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_f1f2a6ea141d6a0339cf405f9c711561_1.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_f1f2a6ea141d6a0339cf405f9c711561_1.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_f1f2a6ea141d6a0339cf405f9c711561_10.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_f1f2a6ea141d6a0339cf405f9c711561_10.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_f1f2a6ea141d6a0339cf405f9c711561_11.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_f1f2a6ea141d6a0339cf405f9c711561_11.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_f1f2a6ea141d6a0339cf405f9c711561_12.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_f1f2a6ea141d6a0339cf405f9c711561_12.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_f1f2a6ea141d6a0339cf405f9c711561_13.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_f1f2a6ea141d6a0339cf405f9c711561_13.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_f1f2a6ea141d6a0339cf405f9c711561_14.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_f1f2a6ea141d6a0339cf405f9c711561_14.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_f1f2a6ea141d6a0339cf405f9c711561_15.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_f1f2a6ea141d6a0339cf405f9c711561_15.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_f1f2a6ea141d6a0339cf405f9c711561_16.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_f1f2a6ea141d6a0339cf405f9c711561_16.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_f1f2a6ea141d6a0339cf405f9c711561_17.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_f1f2a6ea141d6a0339cf405f9c711561_17.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_f1f2a6ea141d6a0339cf405f9c711561_18.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_f1f2a6ea141d6a0339cf405f9c711561_18.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_f1f2a6ea141d6a0339cf405f9c711561_19.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_f1f2a6ea141d6a0339cf405f9c711561_19.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_f1f2a6ea141d6a0339cf405f9c711561_2.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_f1f2a6ea141d6a0339cf405f9c711561_2.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_f1f2a6ea141d6a0339cf405f9c711561_20.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_f1f2a6ea141d6a0339cf405f9c711561_20.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_f1f2a6ea141d6a0339cf405f9c711561_21.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_f1f2a6ea141d6a0339cf405f9c711561_21.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_f1f2a6ea141d6a0339cf405f9c711561_22.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_f1f2a6ea141d6a0339cf405f9c711561_22.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_f1f2a6ea141d6a0339cf405f9c711561_3.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_f1f2a6ea141d6a0339cf405f9c711561_3.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_f1f2a6ea141d6a0339cf405f9c711561_4.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_f1f2a6ea141d6a0339cf405f9c711561_4.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_f1f2a6ea141d6a0339cf405f9c711561_5.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_f1f2a6ea141d6a0339cf405f9c711561_5.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_f1f2a6ea141d6a0339cf405f9c711561_6.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_f1f2a6ea141d6a0339cf405f9c711561_6.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_f1f2a6ea141d6a0339cf405f9c711561_7.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_f1f2a6ea141d6a0339cf405f9c711561_7.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_f1f2a6ea141d6a0339cf405f9c711561_8.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_f1f2a6ea141d6a0339cf405f9c711561_8.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_f1f2a6ea141d6a0339cf405f9c711561_9.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_f1f2a6ea141d6a0339cf405f9c711561_9.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_f4998fee521cfe900fcfeca810354a11_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_f4998fee521cfe900fcfeca810354a11_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_f4998fee521cfe900fcfeca810354a11_1.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_f4998fee521cfe900fcfeca810354a11_1.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_f4998fee521cfe900fcfeca810354a11_10.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_f4998fee521cfe900fcfeca810354a11_10.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_f4998fee521cfe900fcfeca810354a11_11.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_f4998fee521cfe900fcfeca810354a11_11.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_f4998fee521cfe900fcfeca810354a11_2.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_f4998fee521cfe900fcfeca810354a11_2.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_f4998fee521cfe900fcfeca810354a11_3.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_f4998fee521cfe900fcfeca810354a11_3.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_f4998fee521cfe900fcfeca810354a11_4.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_f4998fee521cfe900fcfeca810354a11_4.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_f4998fee521cfe900fcfeca810354a11_5.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_f4998fee521cfe900fcfeca810354a11_5.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_f4998fee521cfe900fcfeca810354a11_6.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_f4998fee521cfe900fcfeca810354a11_6.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_f4998fee521cfe900fcfeca810354a11_7.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_f4998fee521cfe900fcfeca810354a11_7.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_f4998fee521cfe900fcfeca810354a11_8.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_f4998fee521cfe900fcfeca810354a11_8.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_f4998fee521cfe900fcfeca810354a11_9.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_f4998fee521cfe900fcfeca810354a11_9.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_f5e9bb0e5d1a6caffade5f8d938ebba1_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_f5e9bb0e5d1a6caffade5f8d938ebba1_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_f74ef1e08e8f9c599dac36e6d19bb7f2_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_f74ef1e08e8f9c599dac36e6d19bb7f2_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_f74ef1e08e8f9c599dac36e6d19bb7f2_1.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_f74ef1e08e8f9c599dac36e6d19bb7f2_1.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_f74ef1e08e8f9c599dac36e6d19bb7f2_2.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_f74ef1e08e8f9c599dac36e6d19bb7f2_2.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_f9c9c70cb8a260e5fad03a90fe495309_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_f9c9c70cb8a260e5fad03a90fe495309_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_f9c9c70cb8a260e5fad03a90fe495309_1.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_f9c9c70cb8a260e5fad03a90fe495309_1.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_f9c9c70cb8a260e5fad03a90fe495309_10.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_f9c9c70cb8a260e5fad03a90fe495309_10.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_f9c9c70cb8a260e5fad03a90fe495309_2.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_f9c9c70cb8a260e5fad03a90fe495309_2.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_f9c9c70cb8a260e5fad03a90fe495309_3.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_f9c9c70cb8a260e5fad03a90fe495309_3.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_f9c9c70cb8a260e5fad03a90fe495309_4.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_f9c9c70cb8a260e5fad03a90fe495309_4.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_f9c9c70cb8a260e5fad03a90fe495309_5.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_f9c9c70cb8a260e5fad03a90fe495309_5.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_f9c9c70cb8a260e5fad03a90fe495309_6.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_f9c9c70cb8a260e5fad03a90fe495309_6.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_f9c9c70cb8a260e5fad03a90fe495309_7.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_f9c9c70cb8a260e5fad03a90fe495309_7.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_f9c9c70cb8a260e5fad03a90fe495309_8.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_f9c9c70cb8a260e5fad03a90fe495309_8.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_f9c9c70cb8a260e5fad03a90fe495309_9.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_f9c9c70cb8a260e5fad03a90fe495309_9.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_fc1ab6e3e6280a092089a0c9d75d9f04_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_fc1ab6e3e6280a092089a0c9d75d9f04_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_fc1ab6e3e6280a092089a0c9d75d9f04_1.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_fc1ab6e3e6280a092089a0c9d75d9f04_1.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_fc1ab6e3e6280a092089a0c9d75d9f04_2.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_fc1ab6e3e6280a092089a0c9d75d9f04_2.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_fc1ab6e3e6280a092089a0c9d75d9f04_3.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_fc1ab6e3e6280a092089a0c9d75d9f04_3.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_fd5b52cb9f466cdb9920b2c1ac6b730f_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_fd5b52cb9f466cdb9920b2c1ac6b730f_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_fd5b52cb9f466cdb9920b2c1ac6b730f_1.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_fd5b52cb9f466cdb9920b2c1ac6b730f_1.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_fd5b52cb9f466cdb9920b2c1ac6b730f_2.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_fd5b52cb9f466cdb9920b2c1ac6b730f_2.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_fd5b52cb9f466cdb9920b2c1ac6b730f_3.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_fd5b52cb9f466cdb9920b2c1ac6b730f_3.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_fd5b52cb9f466cdb9920b2c1ac6b730f_4.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_fd5b52cb9f466cdb9920b2c1ac6b730f_4.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_fe32214be726da2f6d69a38a0d7389ed_0.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_fe32214be726da2f6d69a38a0d7389ed_0.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_fe32214be726da2f6d69a38a0d7389ed_1.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_fe32214be726da2f6d69a38a0d7389ed_1.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_fe32214be726da2f6d69a38a0d7389ed_2.py
+++ b/framework/e2e/PaddleLT_new/layerE2Ecase/dynamic-1000-subgraphs/test_module_op_fe32214be726da2f6d69a38a0d7389ed_2.py
@@ -192,6 +192,10 @@ import paddle
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()

--- a/framework/e2e/PaddleLT_new/layercase/debug/mot_ocsort_ocsort_ppyoloe/SIR_105.py
+++ b/framework/e2e/PaddleLT_new/layercase/debug/mot_ocsort_ocsort_ppyoloe/SIR_105.py
@@ -50,7 +50,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/debug/mot_ocsort_ocsort_ppyoloe/SIR_120.py
+++ b/framework/e2e/PaddleLT_new/layercase/debug/mot_ocsort_ocsort_ppyoloe/SIR_120.py
@@ -38,7 +38,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/debug/mot_ocsort_ocsort_ppyoloe/SIR_164.py
+++ b/framework/e2e/PaddleLT_new/layercase/debug/mot_ocsort_ocsort_ppyoloe/SIR_164.py
@@ -51,7 +51,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/debug/mot_ocsort_ocsort_ppyoloe/SIR_167.py
+++ b/framework/e2e/PaddleLT_new/layercase/debug/mot_ocsort_ocsort_ppyoloe/SIR_167.py
@@ -51,7 +51,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/debug/mot_ocsort_ocsort_ppyoloe/SIR_170.py
+++ b/framework/e2e/PaddleLT_new/layercase/debug/mot_ocsort_ocsort_ppyoloe/SIR_170.py
@@ -51,7 +51,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/debug/mot_ocsort_ocsort_ppyoloe/SIR_173.py
+++ b/framework/e2e/PaddleLT_new/layercase/debug/mot_ocsort_ocsort_ppyoloe/SIR_173.py
@@ -57,7 +57,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/debug/mot_ocsort_ocsort_ppyoloe/SIR_178.py
+++ b/framework/e2e/PaddleLT_new/layercase/debug/mot_ocsort_ocsort_ppyoloe/SIR_178.py
@@ -141,7 +141,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/debug/mot_ocsort_ocsort_ppyoloe/SIR_21.py
+++ b/framework/e2e/PaddleLT_new/layercase/debug/mot_ocsort_ocsort_ppyoloe/SIR_21.py
@@ -50,7 +50,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/debug/mot_ocsort_ocsort_ppyoloe/SIR_60.py
+++ b/framework/e2e/PaddleLT_new/layercase/debug/mot_ocsort_ocsort_ppyoloe/SIR_60.py
@@ -50,7 +50,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/debug/mot_ocsort_ocsort_ppyoloe/SIR_91.py
+++ b/framework/e2e/PaddleLT_new/layercase/debug/mot_ocsort_ocsort_ppyoloe/SIR_91.py
@@ -50,7 +50,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/debug/rotate_fcosr_fcosr_x50_3x_dota/SIR_33.py
+++ b/framework/e2e/PaddleLT_new/layercase/debug/rotate_fcosr_fcosr_x50_3x_dota/SIR_33.py
@@ -117,7 +117,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/debug/rotate_fcosr_fcosr_x50_3x_dota/SIR_35.py
+++ b/framework/e2e/PaddleLT_new/layercase/debug/rotate_fcosr_fcosr_x50_3x_dota/SIR_35.py
@@ -148,7 +148,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/debug/rotate_fcosr_fcosr_x50_3x_dota/SIR_41.py
+++ b/framework/e2e/PaddleLT_new/layercase/debug/rotate_fcosr_fcosr_x50_3x_dota/SIR_41.py
@@ -46,7 +46,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/debug/rotate_fcosr_fcosr_x50_3x_dota/SIR_44.py
+++ b/framework/e2e/PaddleLT_new/layercase/debug/rotate_fcosr_fcosr_x50_3x_dota/SIR_44.py
@@ -84,7 +84,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/debug/rotate_fcosr_fcosr_x50_3x_dota/SIR_47.py
+++ b/framework/e2e/PaddleLT_new/layercase/debug/rotate_fcosr_fcosr_x50_3x_dota/SIR_47.py
@@ -46,7 +46,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/debug/rotate_fcosr_fcosr_x50_3x_dota/SIR_50.py
+++ b/framework/e2e/PaddleLT_new/layercase/debug/rotate_fcosr_fcosr_x50_3x_dota/SIR_50.py
@@ -84,7 +84,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/debug/rotate_fcosr_fcosr_x50_3x_dota/SIR_53.py
+++ b/framework/e2e/PaddleLT_new/layercase/debug/rotate_fcosr_fcosr_x50_3x_dota/SIR_53.py
@@ -46,7 +46,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/debug/rotate_fcosr_fcosr_x50_3x_dota/SIR_56.py
+++ b/framework/e2e/PaddleLT_new/layercase/debug/rotate_fcosr_fcosr_x50_3x_dota/SIR_56.py
@@ -84,7 +84,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/debug/rotate_fcosr_fcosr_x50_3x_dota/SIR_57.py
+++ b/framework/e2e/PaddleLT_new/layercase/debug/rotate_fcosr_fcosr_x50_3x_dota/SIR_57.py
@@ -46,7 +46,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/debug/rotate_fcosr_fcosr_x50_3x_dota/SIR_62.py
+++ b/framework/e2e/PaddleLT_new/layercase/debug/rotate_fcosr_fcosr_x50_3x_dota/SIR_62.py
@@ -84,7 +84,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/debug/rotate_fcosr_fcosr_x50_3x_dota/SIR_63.py
+++ b/framework/e2e/PaddleLT_new/layercase/debug/rotate_fcosr_fcosr_x50_3x_dota/SIR_63.py
@@ -46,7 +46,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/debug/rotate_fcosr_fcosr_x50_3x_dota/SIR_68.py
+++ b/framework/e2e/PaddleLT_new/layercase/debug/rotate_fcosr_fcosr_x50_3x_dota/SIR_68.py
@@ -84,7 +84,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/debug/rotate_fcosr_fcosr_x50_3x_dota/SIR_73.py
+++ b/framework/e2e/PaddleLT_new/layercase/debug/rotate_fcosr_fcosr_x50_3x_dota/SIR_73.py
@@ -82,7 +82,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/debug/rotate_fcosr_fcosr_x50_3x_dota/SIR_92.py
+++ b/framework/e2e/PaddleLT_new/layercase/debug/rotate_fcosr_fcosr_x50_3x_dota/SIR_92.py
@@ -47,7 +47,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/debug/rotate_ppyoloe_r_ppyoloe_r_crn_x_3x_dota/SIR_101.py
+++ b/framework/e2e/PaddleLT_new/layercase/debug/rotate_ppyoloe_r_ppyoloe_r_crn_x_3x_dota/SIR_101.py
@@ -58,7 +58,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/perf245/Clas_cases/CSWinTransformer_CSWinTransformer_base_384/SIR_236.py
+++ b/framework/e2e/PaddleLT_new/layercase/perf245/Clas_cases/CSWinTransformer_CSWinTransformer_base_384/SIR_236.py
@@ -44,7 +44,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/perf245/Clas_cases/CSWinTransformer_CSWinTransformer_base_384/SIR_239.py
+++ b/framework/e2e/PaddleLT_new/layercase/perf245/Clas_cases/CSWinTransformer_CSWinTransformer_base_384/SIR_239.py
@@ -56,7 +56,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/perf245/Clas_cases/CSWinTransformer_CSWinTransformer_base_384/SIR_285.py
+++ b/framework/e2e/PaddleLT_new/layercase/perf245/Clas_cases/CSWinTransformer_CSWinTransformer_base_384/SIR_285.py
@@ -56,7 +56,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/perf245/Clas_cases/CSWinTransformer_CSWinTransformer_base_384/SIR_308.py
+++ b/framework/e2e/PaddleLT_new/layercase/perf245/Clas_cases/CSWinTransformer_CSWinTransformer_base_384/SIR_308.py
@@ -56,7 +56,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/perf245/Clas_cases/CSWinTransformer_CSWinTransformer_base_384/SIR_348.py
+++ b/framework/e2e/PaddleLT_new/layercase/perf245/Clas_cases/CSWinTransformer_CSWinTransformer_base_384/SIR_348.py
@@ -56,7 +56,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/perf245/Clas_cases/CSWinTransformer_CSWinTransformer_base_384/SIR_418.py
+++ b/framework/e2e/PaddleLT_new/layercase/perf245/Clas_cases/CSWinTransformer_CSWinTransformer_base_384/SIR_418.py
@@ -56,7 +56,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/perf245/Clas_cases/CSWinTransformer_CSWinTransformer_base_384/SIR_42.py
+++ b/framework/e2e/PaddleLT_new/layercase/perf245/Clas_cases/CSWinTransformer_CSWinTransformer_base_384/SIR_42.py
@@ -56,7 +56,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/perf245/Clas_cases/CSWinTransformer_CSWinTransformer_base_384/SIR_420.py
+++ b/framework/e2e/PaddleLT_new/layercase/perf245/Clas_cases/CSWinTransformer_CSWinTransformer_base_384/SIR_420.py
@@ -44,7 +44,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/perf245/Clas_cases/CSWinTransformer_CSWinTransformer_base_384/SIR_5.py
+++ b/framework/e2e/PaddleLT_new/layercase/perf245/Clas_cases/CSWinTransformer_CSWinTransformer_base_384/SIR_5.py
@@ -56,7 +56,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/perf245/Clas_cases/CSWinTransformer_CSWinTransformer_base_384/SIR_598.py
+++ b/framework/e2e/PaddleLT_new/layercase/perf245/Clas_cases/CSWinTransformer_CSWinTransformer_base_384/SIR_598.py
@@ -44,7 +44,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/perf245/Clas_cases/CSWinTransformer_CSWinTransformer_base_384/SIR_83.py
+++ b/framework/e2e/PaddleLT_new/layercase/perf245/Clas_cases/CSWinTransformer_CSWinTransformer_base_384/SIR_83.py
@@ -56,7 +56,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/perf245/Clas_cases/DeiT_DeiT_tiny_distilled_patch16_224/SIR_52.py
+++ b/framework/e2e/PaddleLT_new/layercase/perf245/Clas_cases/DeiT_DeiT_tiny_distilled_patch16_224/SIR_52.py
@@ -57,7 +57,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/perf245/Clas_cases/DeiT_DeiT_tiny_distilled_patch16_224/SIR_92.py
+++ b/framework/e2e/PaddleLT_new/layercase/perf245/Clas_cases/DeiT_DeiT_tiny_distilled_patch16_224/SIR_92.py
@@ -57,7 +57,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/perf245/Clas_cases/Distillation_PPLCNet_x2_5_ssld/SIR_32.py
+++ b/framework/e2e/PaddleLT_new/layercase/perf245/Clas_cases/Distillation_PPLCNet_x2_5_ssld/SIR_32.py
@@ -45,7 +45,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/perf245/Clas_cases/Distillation_PPLCNet_x2_5_ssld/SIR_45.py
+++ b/framework/e2e/PaddleLT_new/layercase/perf245/Clas_cases/Distillation_PPLCNet_x2_5_ssld/SIR_45.py
@@ -45,7 +45,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/perf245/Clas_cases/Distillation_resnet34_distill_resnet18_afd/SIR_104.py
+++ b/framework/e2e/PaddleLT_new/layercase/perf245/Clas_cases/Distillation_resnet34_distill_resnet18_afd/SIR_104.py
@@ -88,7 +88,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/perf245/Clas_cases/Distillation_resnet34_distill_resnet18_afd/SIR_70.py
+++ b/framework/e2e/PaddleLT_new/layercase/perf245/Clas_cases/Distillation_resnet34_distill_resnet18_afd/SIR_70.py
@@ -88,7 +88,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/perf245/Clas_cases/Distillation_resnet34_distill_resnet18_afd/SIR_92.py
+++ b/framework/e2e/PaddleLT_new/layercase/perf245/Clas_cases/Distillation_resnet34_distill_resnet18_afd/SIR_92.py
@@ -88,7 +88,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/perf245/Clas_cases/Distillation_resnet34_distill_resnet18_afd/SIR_97.py
+++ b/framework/e2e/PaddleLT_new/layercase/perf245/Clas_cases/Distillation_resnet34_distill_resnet18_afd/SIR_97.py
@@ -88,7 +88,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/perf245/Clas_cases/EfficientNet_EfficientNetB0/SIR_109.py
+++ b/framework/e2e/PaddleLT_new/layercase/perf245/Clas_cases/EfficientNet_EfficientNetB0/SIR_109.py
@@ -45,7 +45,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/perf245/Clas_cases/EfficientNet_EfficientNetB0/SIR_115.py
+++ b/framework/e2e/PaddleLT_new/layercase/perf245/Clas_cases/EfficientNet_EfficientNetB0/SIR_115.py
@@ -45,7 +45,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/perf245/Clas_cases/EfficientNet_EfficientNetB0/SIR_121.py
+++ b/framework/e2e/PaddleLT_new/layercase/perf245/Clas_cases/EfficientNet_EfficientNetB0/SIR_121.py
@@ -45,7 +45,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/perf245/Clas_cases/EfficientNet_EfficientNetB0/SIR_128.py
+++ b/framework/e2e/PaddleLT_new/layercase/perf245/Clas_cases/EfficientNet_EfficientNetB0/SIR_128.py
@@ -45,7 +45,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/perf245/Clas_cases/EfficientNet_EfficientNetB0/SIR_134.py
+++ b/framework/e2e/PaddleLT_new/layercase/perf245/Clas_cases/EfficientNet_EfficientNetB0/SIR_134.py
@@ -45,7 +45,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/perf245/Clas_cases/EfficientNet_EfficientNetB0/SIR_37.py
+++ b/framework/e2e/PaddleLT_new/layercase/perf245/Clas_cases/EfficientNet_EfficientNetB0/SIR_37.py
@@ -45,7 +45,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/perf245/Clas_cases/EfficientNet_EfficientNetB0/SIR_53.py
+++ b/framework/e2e/PaddleLT_new/layercase/perf245/Clas_cases/EfficientNet_EfficientNetB0/SIR_53.py
@@ -45,7 +45,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/perf245/Clas_cases/EfficientNet_EfficientNetB0/SIR_56.py
+++ b/framework/e2e/PaddleLT_new/layercase/perf245/Clas_cases/EfficientNet_EfficientNetB0/SIR_56.py
@@ -57,7 +57,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/perf245/Clas_cases/EfficientNet_EfficientNetB0/SIR_66.py
+++ b/framework/e2e/PaddleLT_new/layercase/perf245/Clas_cases/EfficientNet_EfficientNetB0/SIR_66.py
@@ -57,7 +57,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/perf245/Clas_cases/EfficientNet_EfficientNetB0/SIR_70.py
+++ b/framework/e2e/PaddleLT_new/layercase/perf245/Clas_cases/EfficientNet_EfficientNetB0/SIR_70.py
@@ -45,7 +45,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/perf245/Clas_cases/EfficientNet_EfficientNetB0/SIR_82.py
+++ b/framework/e2e/PaddleLT_new/layercase/perf245/Clas_cases/EfficientNet_EfficientNetB0/SIR_82.py
@@ -45,7 +45,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/perf245/Clas_cases/EfficientNet_EfficientNetB0/SIR_89.py
+++ b/framework/e2e/PaddleLT_new/layercase/perf245/Clas_cases/EfficientNet_EfficientNetB0/SIR_89.py
@@ -45,7 +45,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/perf245/Det_cases/cascade_rcnn_cascade_rcnn_r50_fpn_1x_coco/SIR_106.py
+++ b/framework/e2e/PaddleLT_new/layercase/perf245/Det_cases/cascade_rcnn_cascade_rcnn_r50_fpn_1x_coco/SIR_106.py
@@ -56,7 +56,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/perf245/Det_cases/centernet_centernet_mbv3_small_140e_coco/SIR_14.py
+++ b/framework/e2e/PaddleLT_new/layercase/perf245/Det_cases/centernet_centernet_mbv3_small_140e_coco/SIR_14.py
@@ -56,7 +56,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/perf245/Ocr_cases/det_ch_PP_OCRv3_ch_PP_OCRv3_det_cml/SIR_43.py
+++ b/framework/e2e/PaddleLT_new/layercase/perf245/Ocr_cases/det_ch_PP_OCRv3_ch_PP_OCRv3_det_cml/SIR_43.py
@@ -131,7 +131,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/perf245/Ocr_cases/det_ch_PP_OCRv3_ch_PP_OCRv3_det_cml/SIR_56.py
+++ b/framework/e2e/PaddleLT_new/layercase/perf245/Ocr_cases/det_ch_PP_OCRv3_ch_PP_OCRv3_det_cml/SIR_56.py
@@ -131,7 +131,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/perf245/Ocr_cases/rec_rec_svtrnet/SIR_15.py
+++ b/framework/e2e/PaddleLT_new/layercase/perf245/Ocr_cases/rec_rec_svtrnet/SIR_15.py
@@ -42,7 +42,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/perf245/Ocr_cases/table_SLANet/SIR_23.py
+++ b/framework/e2e/PaddleLT_new/layercase/perf245/Ocr_cases/table_SLANet/SIR_23.py
@@ -39,7 +39,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/perf245/Seg_cases/espnet_espnet_cityscapes_1024x512_120k/SIR_116.py
+++ b/framework/e2e/PaddleLT_new/layercase/perf245/Seg_cases/espnet_espnet_cityscapes_1024x512_120k/SIR_116.py
@@ -58,7 +58,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/perf245/Seg_cases/espnet_espnet_cityscapes_1024x512_120k/SIR_12.py
+++ b/framework/e2e/PaddleLT_new/layercase/perf245/Seg_cases/espnet_espnet_cityscapes_1024x512_120k/SIR_12.py
@@ -58,7 +58,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/perf245/Seg_cases/espnet_espnet_cityscapes_1024x512_120k/SIR_143.py
+++ b/framework/e2e/PaddleLT_new/layercase/perf245/Seg_cases/espnet_espnet_cityscapes_1024x512_120k/SIR_143.py
@@ -52,7 +52,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/perf245/Seg_cases/espnet_espnet_cityscapes_1024x512_120k/SIR_33.py
+++ b/framework/e2e/PaddleLT_new/layercase/perf245/Seg_cases/espnet_espnet_cityscapes_1024x512_120k/SIR_33.py
@@ -58,7 +58,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/perf245/Seg_cases/espnet_espnet_cityscapes_1024x512_120k/SIR_64.py
+++ b/framework/e2e/PaddleLT_new/layercase/perf245/Seg_cases/espnet_espnet_cityscapes_1024x512_120k/SIR_64.py
@@ -58,7 +58,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/perf245/Seg_cases/mobileseg_mobileseg_litehrnet18_cityscapes_1024x512_80k/SIR_111.py
+++ b/framework/e2e/PaddleLT_new/layercase/perf245/Seg_cases/mobileseg_mobileseg_litehrnet18_cityscapes_1024x512_80k/SIR_111.py
@@ -49,7 +49,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/perf245/Seg_cases/mobileseg_mobileseg_litehrnet18_cityscapes_1024x512_80k/SIR_18.py
+++ b/framework/e2e/PaddleLT_new/layercase/perf245/Seg_cases/mobileseg_mobileseg_litehrnet18_cityscapes_1024x512_80k/SIR_18.py
@@ -45,7 +45,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/perf245/Seg_cases/mobileseg_mobileseg_litehrnet18_cityscapes_1024x512_80k/SIR_228.py
+++ b/framework/e2e/PaddleLT_new/layercase/perf245/Seg_cases/mobileseg_mobileseg_litehrnet18_cityscapes_1024x512_80k/SIR_228.py
@@ -55,7 +55,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/CSWinTransformer_CSWinTransformer_base_384/SIR_1.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/CSWinTransformer_CSWinTransformer_base_384/SIR_1.py
@@ -61,7 +61,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/CSWinTransformer_CSWinTransformer_base_384/SIR_156.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/CSWinTransformer_CSWinTransformer_base_384/SIR_156.py
@@ -52,7 +52,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/CSWinTransformer_CSWinTransformer_base_384/SIR_180.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/CSWinTransformer_CSWinTransformer_base_384/SIR_180.py
@@ -45,7 +45,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/CSWinTransformer_CSWinTransformer_base_384/SIR_236.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/CSWinTransformer_CSWinTransformer_base_384/SIR_236.py
@@ -52,7 +52,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/CSWinTransformer_CSWinTransformer_base_384/SIR_239.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/CSWinTransformer_CSWinTransformer_base_384/SIR_239.py
@@ -63,7 +63,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/CSWinTransformer_CSWinTransformer_base_384/SIR_24.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/CSWinTransformer_CSWinTransformer_base_384/SIR_24.py
@@ -52,7 +52,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/CSWinTransformer_CSWinTransformer_base_384/SIR_283.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/CSWinTransformer_CSWinTransformer_base_384/SIR_283.py
@@ -61,7 +61,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/CSWinTransformer_CSWinTransformer_base_384/SIR_285.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/CSWinTransformer_CSWinTransformer_base_384/SIR_285.py
@@ -63,7 +63,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/CSWinTransformer_CSWinTransformer_base_384/SIR_291.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/CSWinTransformer_CSWinTransformer_base_384/SIR_291.py
@@ -52,7 +52,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/CSWinTransformer_CSWinTransformer_base_384/SIR_308.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/CSWinTransformer_CSWinTransformer_base_384/SIR_308.py
@@ -63,7 +63,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/CSWinTransformer_CSWinTransformer_base_384/SIR_323.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/CSWinTransformer_CSWinTransformer_base_384/SIR_323.py
@@ -52,7 +52,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/CSWinTransformer_CSWinTransformer_base_384/SIR_348.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/CSWinTransformer_CSWinTransformer_base_384/SIR_348.py
@@ -63,7 +63,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/CSWinTransformer_CSWinTransformer_base_384/SIR_381.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/CSWinTransformer_CSWinTransformer_base_384/SIR_381.py
@@ -52,7 +52,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/CSWinTransformer_CSWinTransformer_base_384/SIR_418.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/CSWinTransformer_CSWinTransformer_base_384/SIR_418.py
@@ -63,7 +63,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/CSWinTransformer_CSWinTransformer_base_384/SIR_42.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/CSWinTransformer_CSWinTransformer_base_384/SIR_42.py
@@ -63,7 +63,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/CSWinTransformer_CSWinTransformer_base_384/SIR_420.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/CSWinTransformer_CSWinTransformer_base_384/SIR_420.py
@@ -52,7 +52,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/CSWinTransformer_CSWinTransformer_base_384/SIR_448.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/CSWinTransformer_CSWinTransformer_base_384/SIR_448.py
@@ -52,7 +52,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/CSWinTransformer_CSWinTransformer_base_384/SIR_487.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/CSWinTransformer_CSWinTransformer_base_384/SIR_487.py
@@ -52,7 +52,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/CSWinTransformer_CSWinTransformer_base_384/SIR_5.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/CSWinTransformer_CSWinTransformer_base_384/SIR_5.py
@@ -63,7 +63,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/CSWinTransformer_CSWinTransformer_base_384/SIR_520.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/CSWinTransformer_CSWinTransformer_base_384/SIR_520.py
@@ -52,7 +52,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/CSWinTransformer_CSWinTransformer_base_384/SIR_598.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/CSWinTransformer_CSWinTransformer_base_384/SIR_598.py
@@ -52,7 +52,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/CSWinTransformer_CSWinTransformer_base_384/SIR_616.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/CSWinTransformer_CSWinTransformer_base_384/SIR_616.py
@@ -52,7 +52,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/CSWinTransformer_CSWinTransformer_base_384/SIR_634.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/CSWinTransformer_CSWinTransformer_base_384/SIR_634.py
@@ -52,7 +52,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/CSWinTransformer_CSWinTransformer_base_384/SIR_660.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/CSWinTransformer_CSWinTransformer_base_384/SIR_660.py
@@ -52,7 +52,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/CSWinTransformer_CSWinTransformer_base_384/SIR_67.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/CSWinTransformer_CSWinTransformer_base_384/SIR_67.py
@@ -52,7 +52,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/CSWinTransformer_CSWinTransformer_base_384/SIR_83.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/CSWinTransformer_CSWinTransformer_base_384/SIR_83.py
@@ -63,7 +63,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/DLA_DLA102/SIR_24.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/DLA_DLA102/SIR_24.py
@@ -52,7 +52,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/DLA_DLA102/SIR_25.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/DLA_DLA102/SIR_25.py
@@ -52,7 +52,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/DeiT_DeiT_tiny_distilled_patch16_224/SIR_4.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/DeiT_DeiT_tiny_distilled_patch16_224/SIR_4.py
@@ -83,7 +83,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/DeiT_DeiT_tiny_distilled_patch16_224/SIR_52.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/DeiT_DeiT_tiny_distilled_patch16_224/SIR_52.py
@@ -65,7 +65,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/DeiT_DeiT_tiny_distilled_patch16_224/SIR_56.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/DeiT_DeiT_tiny_distilled_patch16_224/SIR_56.py
@@ -83,7 +83,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/DeiT_DeiT_tiny_distilled_patch16_224/SIR_92.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/DeiT_DeiT_tiny_distilled_patch16_224/SIR_92.py
@@ -65,7 +65,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/DeiT_DeiT_tiny_patch16_224/SIR_4.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/DeiT_DeiT_tiny_patch16_224/SIR_4.py
@@ -83,7 +83,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/DeiT_DeiT_tiny_patch16_224/SIR_56.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/DeiT_DeiT_tiny_patch16_224/SIR_56.py
@@ -83,7 +83,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/Distillation_PPLCNet_x2_5_ssld/SIR_32.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/Distillation_PPLCNet_x2_5_ssld/SIR_32.py
@@ -52,7 +52,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/Distillation_PPLCNet_x2_5_ssld/SIR_45.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/Distillation_PPLCNet_x2_5_ssld/SIR_45.py
@@ -52,7 +52,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/Distillation_resnet34_distill_resnet18_afd/SIR_104.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/Distillation_resnet34_distill_resnet18_afd/SIR_104.py
@@ -102,7 +102,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/Distillation_resnet34_distill_resnet18_afd/SIR_70.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/Distillation_resnet34_distill_resnet18_afd/SIR_70.py
@@ -102,7 +102,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/Distillation_resnet34_distill_resnet18_afd/SIR_92.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/Distillation_resnet34_distill_resnet18_afd/SIR_92.py
@@ -102,7 +102,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/Distillation_resnet34_distill_resnet18_afd/SIR_97.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/Distillation_resnet34_distill_resnet18_afd/SIR_97.py
@@ -102,7 +102,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/EfficientNet_EfficientNetB0/SIR_10.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/EfficientNet_EfficientNetB0/SIR_10.py
@@ -64,7 +64,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/EfficientNet_EfficientNetB0/SIR_104.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/EfficientNet_EfficientNetB0/SIR_104.py
@@ -64,7 +64,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/EfficientNet_EfficientNetB0/SIR_108.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/EfficientNet_EfficientNetB0/SIR_108.py
@@ -64,7 +64,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/EfficientNet_EfficientNetB0/SIR_109.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/EfficientNet_EfficientNetB0/SIR_109.py
@@ -53,7 +53,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/EfficientNet_EfficientNetB0/SIR_110.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/EfficientNet_EfficientNetB0/SIR_110.py
@@ -64,7 +64,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/EfficientNet_EfficientNetB0/SIR_114.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/EfficientNet_EfficientNetB0/SIR_114.py
@@ -64,7 +64,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/EfficientNet_EfficientNetB0/SIR_115.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/EfficientNet_EfficientNetB0/SIR_115.py
@@ -53,7 +53,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/EfficientNet_EfficientNetB0/SIR_116.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/EfficientNet_EfficientNetB0/SIR_116.py
@@ -64,7 +64,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/EfficientNet_EfficientNetB0/SIR_120.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/EfficientNet_EfficientNetB0/SIR_120.py
@@ -64,7 +64,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/EfficientNet_EfficientNetB0/SIR_121.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/EfficientNet_EfficientNetB0/SIR_121.py
@@ -53,7 +53,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/EfficientNet_EfficientNetB0/SIR_126.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/EfficientNet_EfficientNetB0/SIR_126.py
@@ -64,7 +64,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/EfficientNet_EfficientNetB0/SIR_128.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/EfficientNet_EfficientNetB0/SIR_128.py
@@ -53,7 +53,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/EfficientNet_EfficientNetB0/SIR_129.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/EfficientNet_EfficientNetB0/SIR_129.py
@@ -64,7 +64,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/EfficientNet_EfficientNetB0/SIR_133.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/EfficientNet_EfficientNetB0/SIR_133.py
@@ -64,7 +64,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/EfficientNet_EfficientNetB0/SIR_134.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/EfficientNet_EfficientNetB0/SIR_134.py
@@ -53,7 +53,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/EfficientNet_EfficientNetB0/SIR_140.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/EfficientNet_EfficientNetB0/SIR_140.py
@@ -54,7 +54,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/EfficientNet_EfficientNetB0/SIR_142.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/EfficientNet_EfficientNetB0/SIR_142.py
@@ -64,7 +64,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/EfficientNet_EfficientNetB0/SIR_147.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/EfficientNet_EfficientNetB0/SIR_147.py
@@ -64,7 +64,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/EfficientNet_EfficientNetB0/SIR_151.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/EfficientNet_EfficientNetB0/SIR_151.py
@@ -64,7 +64,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/EfficientNet_EfficientNetB0/SIR_153.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/EfficientNet_EfficientNetB0/SIR_153.py
@@ -64,7 +64,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/EfficientNet_EfficientNetB0/SIR_157.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/EfficientNet_EfficientNetB0/SIR_157.py
@@ -64,7 +64,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/EfficientNet_EfficientNetB0/SIR_159.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/EfficientNet_EfficientNetB0/SIR_159.py
@@ -64,7 +64,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/EfficientNet_EfficientNetB0/SIR_163.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/EfficientNet_EfficientNetB0/SIR_163.py
@@ -64,7 +64,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/EfficientNet_EfficientNetB0/SIR_169.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/EfficientNet_EfficientNetB0/SIR_169.py
@@ -64,7 +64,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/EfficientNet_EfficientNetB0/SIR_172.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/EfficientNet_EfficientNetB0/SIR_172.py
@@ -64,7 +64,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/EfficientNet_EfficientNetB0/SIR_176.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/EfficientNet_EfficientNetB0/SIR_176.py
@@ -64,7 +64,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/EfficientNet_EfficientNetB0/SIR_185.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/EfficientNet_EfficientNetB0/SIR_185.py
@@ -64,7 +64,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/EfficientNet_EfficientNetB0/SIR_190.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/EfficientNet_EfficientNetB0/SIR_190.py
@@ -64,7 +64,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/EfficientNet_EfficientNetB0/SIR_194.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/EfficientNet_EfficientNetB0/SIR_194.py
@@ -64,7 +64,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/EfficientNet_EfficientNetB0/SIR_196.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/EfficientNet_EfficientNetB0/SIR_196.py
@@ -63,7 +63,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/EfficientNet_EfficientNetB0/SIR_197.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/EfficientNet_EfficientNetB0/SIR_197.py
@@ -63,7 +63,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/EfficientNet_EfficientNetB0/SIR_199.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/EfficientNet_EfficientNetB0/SIR_199.py
@@ -63,7 +63,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/EfficientNet_EfficientNetB0/SIR_200.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/EfficientNet_EfficientNetB0/SIR_200.py
@@ -63,7 +63,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/EfficientNet_EfficientNetB0/SIR_201.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/EfficientNet_EfficientNetB0/SIR_201.py
@@ -63,7 +63,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/EfficientNet_EfficientNetB0/SIR_202.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/EfficientNet_EfficientNetB0/SIR_202.py
@@ -63,7 +63,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/EfficientNet_EfficientNetB0/SIR_203.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/EfficientNet_EfficientNetB0/SIR_203.py
@@ -63,7 +63,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/EfficientNet_EfficientNetB0/SIR_24.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/EfficientNet_EfficientNetB0/SIR_24.py
@@ -64,7 +64,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/EfficientNet_EfficientNetB0/SIR_34.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/EfficientNet_EfficientNetB0/SIR_34.py
@@ -64,7 +64,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/EfficientNet_EfficientNetB0/SIR_37.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/EfficientNet_EfficientNetB0/SIR_37.py
@@ -53,7 +53,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/EfficientNet_EfficientNetB0/SIR_40.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/EfficientNet_EfficientNetB0/SIR_40.py
@@ -64,7 +64,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/EfficientNet_EfficientNetB0/SIR_50.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/EfficientNet_EfficientNetB0/SIR_50.py
@@ -64,7 +64,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/EfficientNet_EfficientNetB0/SIR_53.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/EfficientNet_EfficientNetB0/SIR_53.py
@@ -53,7 +53,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/EfficientNet_EfficientNetB0/SIR_56.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/EfficientNet_EfficientNetB0/SIR_56.py
@@ -64,7 +64,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/EfficientNet_EfficientNetB0/SIR_66.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/EfficientNet_EfficientNetB0/SIR_66.py
@@ -64,7 +64,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/EfficientNet_EfficientNetB0/SIR_70.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/EfficientNet_EfficientNetB0/SIR_70.py
@@ -53,7 +53,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/EfficientNet_EfficientNetB0/SIR_79.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/EfficientNet_EfficientNetB0/SIR_79.py
@@ -64,7 +64,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/EfficientNet_EfficientNetB0/SIR_82.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/EfficientNet_EfficientNetB0/SIR_82.py
@@ -53,7 +53,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/EfficientNet_EfficientNetB0/SIR_83.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/EfficientNet_EfficientNetB0/SIR_83.py
@@ -64,7 +64,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/EfficientNet_EfficientNetB0/SIR_87.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/EfficientNet_EfficientNetB0/SIR_87.py
@@ -64,7 +64,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/EfficientNet_EfficientNetB0/SIR_89.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/EfficientNet_EfficientNetB0/SIR_89.py
@@ -53,7 +53,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/EfficientNet_EfficientNetB0/SIR_96.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/EfficientNet_EfficientNetB0/SIR_96.py
@@ -54,7 +54,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/EfficientNet_EfficientNetB0/SIR_99.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/EfficientNet_EfficientNetB0/SIR_99.py
@@ -64,7 +64,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/GhostNet_GhostNet_x0_5/SIR_101.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/GhostNet_GhostNet_x0_5/SIR_101.py
@@ -65,7 +65,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/GhostNet_GhostNet_x0_5/SIR_21.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/GhostNet_GhostNet_x0_5/SIR_21.py
@@ -65,7 +65,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/GhostNet_GhostNet_x0_5/SIR_25.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/GhostNet_GhostNet_x0_5/SIR_25.py
@@ -65,7 +65,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/GhostNet_GhostNet_x0_5/SIR_29.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/GhostNet_GhostNet_x0_5/SIR_29.py
@@ -65,7 +65,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/GhostNet_GhostNet_x0_5/SIR_33.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/GhostNet_GhostNet_x0_5/SIR_33.py
@@ -65,7 +65,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/GhostNet_GhostNet_x0_5/SIR_35.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/GhostNet_GhostNet_x0_5/SIR_35.py
@@ -65,7 +65,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/GhostNet_GhostNet_x0_5/SIR_40.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/GhostNet_GhostNet_x0_5/SIR_40.py
@@ -65,7 +65,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/GhostNet_GhostNet_x0_5/SIR_45.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/GhostNet_GhostNet_x0_5/SIR_45.py
@@ -65,7 +65,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/GhostNet_GhostNet_x0_5/SIR_49.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/GhostNet_GhostNet_x0_5/SIR_49.py
@@ -65,7 +65,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/GhostNet_GhostNet_x0_5/SIR_51.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/GhostNet_GhostNet_x0_5/SIR_51.py
@@ -65,7 +65,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/GhostNet_GhostNet_x0_5/SIR_55.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/GhostNet_GhostNet_x0_5/SIR_55.py
@@ -65,7 +65,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/GhostNet_GhostNet_x0_5/SIR_57.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/GhostNet_GhostNet_x0_5/SIR_57.py
@@ -65,7 +65,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/GhostNet_GhostNet_x0_5/SIR_61.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/GhostNet_GhostNet_x0_5/SIR_61.py
@@ -65,7 +65,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/GhostNet_GhostNet_x0_5/SIR_65.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/GhostNet_GhostNet_x0_5/SIR_65.py
@@ -65,7 +65,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/GhostNet_GhostNet_x0_5/SIR_69.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/GhostNet_GhostNet_x0_5/SIR_69.py
@@ -65,7 +65,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/GhostNet_GhostNet_x0_5/SIR_71.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/GhostNet_GhostNet_x0_5/SIR_71.py
@@ -65,7 +65,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/GhostNet_GhostNet_x0_5/SIR_75.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/GhostNet_GhostNet_x0_5/SIR_75.py
@@ -65,7 +65,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/GhostNet_GhostNet_x0_5/SIR_77.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/GhostNet_GhostNet_x0_5/SIR_77.py
@@ -65,7 +65,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/GhostNet_GhostNet_x0_5/SIR_81.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/GhostNet_GhostNet_x0_5/SIR_81.py
@@ -65,7 +65,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/GhostNet_GhostNet_x0_5/SIR_85.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/GhostNet_GhostNet_x0_5/SIR_85.py
@@ -65,7 +65,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/GhostNet_GhostNet_x0_5/SIR_89.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/GhostNet_GhostNet_x0_5/SIR_89.py
@@ -65,7 +65,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/GhostNet_GhostNet_x0_5/SIR_91.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/GhostNet_GhostNet_x0_5/SIR_91.py
@@ -65,7 +65,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/GhostNet_GhostNet_x0_5/SIR_95.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/GhostNet_GhostNet_x0_5/SIR_95.py
@@ -65,7 +65,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/GhostNet_GhostNet_x0_5/SIR_97.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/GhostNet_GhostNet_x0_5/SIR_97.py
@@ -65,7 +65,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/Inception_InceptionV4/SIR_39.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/Inception_InceptionV4/SIR_39.py
@@ -54,7 +54,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/Inception_InceptionV4/SIR_40.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/Inception_InceptionV4/SIR_40.py
@@ -54,7 +54,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/LeViT_LeViT_128/SIR_12.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/LeViT_LeViT_128/SIR_12.py
@@ -110,7 +110,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/LeViT_LeViT_128/SIR_32.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/LeViT_LeViT_128/SIR_32.py
@@ -47,7 +47,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/LeViT_LeViT_128/SIR_37.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/LeViT_LeViT_128/SIR_37.py
@@ -149,7 +149,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/LeViT_LeViT_128/SIR_48.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/LeViT_LeViT_128/SIR_48.py
@@ -152,7 +152,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/LeViT_LeViT_128/SIR_59.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/LeViT_LeViT_128/SIR_59.py
@@ -47,7 +47,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/LeViT_LeViT_128/SIR_63.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/LeViT_LeViT_128/SIR_63.py
@@ -92,7 +92,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/LeViT_LeViT_128/SIR_74.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/LeViT_LeViT_128/SIR_74.py
@@ -94,7 +94,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/MixNet_MixNet_S/SIR_103.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/MixNet_MixNet_S/SIR_103.py
@@ -72,7 +72,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/MixNet_MixNet_S/SIR_105.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/MixNet_MixNet_S/SIR_105.py
@@ -58,7 +58,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/MixNet_MixNet_S/SIR_111.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/MixNet_MixNet_S/SIR_111.py
@@ -58,7 +58,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/MixNet_MixNet_S/SIR_113.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/MixNet_MixNet_S/SIR_113.py
@@ -58,7 +58,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/MixNet_MixNet_S/SIR_20.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/MixNet_MixNet_S/SIR_20.py
@@ -58,7 +58,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/MixNet_MixNet_S/SIR_26.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/MixNet_MixNet_S/SIR_26.py
@@ -58,7 +58,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/MixNet_MixNet_S/SIR_31.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/MixNet_MixNet_S/SIR_31.py
@@ -65,7 +65,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/MixNet_MixNet_S/SIR_41.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/MixNet_MixNet_S/SIR_41.py
@@ -58,7 +58,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/MixNet_MixNet_S/SIR_43.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/MixNet_MixNet_S/SIR_43.py
@@ -58,7 +58,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/MixNet_MixNet_S/SIR_60.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/MixNet_MixNet_S/SIR_60.py
@@ -65,7 +65,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/MixNet_MixNet_S/SIR_63.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/MixNet_MixNet_S/SIR_63.py
@@ -58,7 +58,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/MixNet_MixNet_S/SIR_67.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/MixNet_MixNet_S/SIR_67.py
@@ -58,7 +58,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/MixNet_MixNet_S/SIR_79.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/MixNet_MixNet_S/SIR_79.py
@@ -58,7 +58,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/MixNet_MixNet_S/SIR_80.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/MixNet_MixNet_S/SIR_80.py
@@ -65,7 +65,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/MixNet_MixNet_S/SIR_83.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/MixNet_MixNet_S/SIR_83.py
@@ -58,7 +58,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/MixNet_MixNet_S/SIR_84.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/MixNet_MixNet_S/SIR_84.py
@@ -72,7 +72,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/MixNet_MixNet_S/SIR_86.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/MixNet_MixNet_S/SIR_86.py
@@ -58,7 +58,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/MixNet_MixNet_S/SIR_93.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/MixNet_MixNet_S/SIR_93.py
@@ -79,7 +79,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/MobileViT_MobileViT_XXS/SIR_26.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/MobileViT_MobileViT_XXS/SIR_26.py
@@ -54,7 +54,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/MobileViT_MobileViT_XXS/SIR_27.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/MobileViT_MobileViT_XXS/SIR_27.py
@@ -54,7 +54,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/PPHGNet_PPHGNet_tiny/SIR_20.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/PPHGNet_PPHGNet_tiny/SIR_20.py
@@ -62,7 +62,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/PPHGNet_PPHGNet_tiny/SIR_37.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/PPHGNet_PPHGNet_tiny/SIR_37.py
@@ -62,7 +62,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/PPHGNet_PPHGNet_tiny/SIR_44.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/PPHGNet_PPHGNet_tiny/SIR_44.py
@@ -62,7 +62,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/PPHGNet_PPHGNet_tiny/SIR_48.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/PPHGNet_PPHGNet_tiny/SIR_48.py
@@ -62,7 +62,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/PPHGNet_PPHGNet_tiny/SIR_55.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/PPHGNet_PPHGNet_tiny/SIR_55.py
@@ -62,7 +62,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/PPHGNet_PPHGNet_tiny/SIR_61.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/PPHGNet_PPHGNet_tiny/SIR_61.py
@@ -62,7 +62,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/PPHGNet_PPHGNet_tiny/SIR_68.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/PPHGNet_PPHGNet_tiny/SIR_68.py
@@ -62,7 +62,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/PPHGNet_PPHGNet_tiny/SIR_74.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/PPHGNet_PPHGNet_tiny/SIR_74.py
@@ -62,7 +62,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/PPHGNet_PPHGNet_tiny/SIR_78.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/PPHGNet_PPHGNet_tiny/SIR_78.py
@@ -62,7 +62,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/PPHGNet_PPHGNet_tiny/SIR_82.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/PPHGNet_PPHGNet_tiny/SIR_82.py
@@ -62,7 +62,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/PeleeNet_PeleeNet/SIR_41.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/PeleeNet_PeleeNet/SIR_41.py
@@ -54,7 +54,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/PeleeNet_PeleeNet/SIR_42.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/PeleeNet_PeleeNet/SIR_42.py
@@ -54,7 +54,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/ReXNet_ReXNet_3_0/SIR_60.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/ReXNet_ReXNet_3_0/SIR_60.py
@@ -54,7 +54,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/ReXNet_ReXNet_3_0/SIR_61.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/ReXNet_ReXNet_3_0/SIR_61.py
@@ -54,7 +54,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/RedNet_RedNet38/SIR_10.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/RedNet_RedNet38/SIR_10.py
@@ -61,7 +61,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/RedNet_RedNet38/SIR_18.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/RedNet_RedNet38/SIR_18.py
@@ -61,7 +61,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/RedNet_RedNet38/SIR_21.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/RedNet_RedNet38/SIR_21.py
@@ -61,7 +61,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/RedNet_RedNet38/SIR_28.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/RedNet_RedNet38/SIR_28.py
@@ -61,7 +61,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/RedNet_RedNet38/SIR_31.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/RedNet_RedNet38/SIR_31.py
@@ -61,7 +61,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/RedNet_RedNet38/SIR_40.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/RedNet_RedNet38/SIR_40.py
@@ -61,7 +61,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/RedNet_RedNet38/SIR_41.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/RedNet_RedNet38/SIR_41.py
@@ -61,7 +61,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/RedNet_RedNet38/SIR_43.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/RedNet_RedNet38/SIR_43.py
@@ -61,7 +61,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/RedNet_RedNet38/SIR_46.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/RedNet_RedNet38/SIR_46.py
@@ -61,7 +61,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/RedNet_RedNet38/SIR_49.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/RedNet_RedNet38/SIR_49.py
@@ -61,7 +61,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/RedNet_RedNet38/SIR_5.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/RedNet_RedNet38/SIR_5.py
@@ -61,7 +61,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/RedNet_RedNet38/SIR_51.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/RedNet_RedNet38/SIR_51.py
@@ -61,7 +61,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/RedNet_RedNet38/SIR_54.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/RedNet_RedNet38/SIR_54.py
@@ -61,7 +61,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/RedNet_RedNet38/SIR_57.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/RedNet_RedNet38/SIR_57.py
@@ -61,7 +61,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/RedNet_RedNet38/SIR_61.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/RedNet_RedNet38/SIR_61.py
@@ -61,7 +61,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/RedNet_RedNet38/SIR_62.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/RedNet_RedNet38/SIR_62.py
@@ -61,7 +61,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/Res2Net_Res2Net50_14w_8s/SIR_118.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/Res2Net_Res2Net50_14w_8s/SIR_118.py
@@ -50,7 +50,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/Res2Net_Res2Net50_14w_8s/SIR_135.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/Res2Net_Res2Net50_14w_8s/SIR_135.py
@@ -50,7 +50,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/Res2Net_Res2Net50_14w_8s/SIR_174.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/Res2Net_Res2Net50_14w_8s/SIR_174.py
@@ -50,7 +50,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/Res2Net_Res2Net50_14w_8s/SIR_242.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/Res2Net_Res2Net50_14w_8s/SIR_242.py
@@ -50,7 +50,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/Res2Net_Res2Net50_14w_8s/SIR_28.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/Res2Net_Res2Net50_14w_8s/SIR_28.py
@@ -50,7 +50,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/Res2Net_Res2Net50_14w_8s/SIR_281.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/Res2Net_Res2Net50_14w_8s/SIR_281.py
@@ -50,7 +50,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/Res2Net_Res2Net50_14w_8s/SIR_338.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/Res2Net_Res2Net50_14w_8s/SIR_338.py
@@ -50,7 +50,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/Res2Net_Res2Net50_14w_8s/SIR_355.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/Res2Net_Res2Net50_14w_8s/SIR_355.py
@@ -50,7 +50,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/Res2Net_Res2Net50_14w_8s/SIR_62.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/Res2Net_Res2Net50_14w_8s/SIR_62.py
@@ -50,7 +50,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/ResNet_ResNet50_amp_O1/SIR_28.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/ResNet_ResNet50_amp_O1/SIR_28.py
@@ -52,7 +52,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/ResNet_ResNet50_amp_O1_ultra/SIR_28.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/ResNet_ResNet50_amp_O1_ultra/SIR_28.py
@@ -52,7 +52,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/SqueezeNet_SqueezeNet1_0/SIR_0.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/SqueezeNet_SqueezeNet1_0/SIR_0.py
@@ -316,7 +316,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/SqueezeNet_SqueezeNet1_0/SIR_1.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/SqueezeNet_SqueezeNet1_0/SIR_1.py
@@ -316,7 +316,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/SqueezeNet_SqueezeNet1_0/SIR_2.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/SqueezeNet_SqueezeNet1_0/SIR_2.py
@@ -316,7 +316,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/SqueezeNet_SqueezeNet1_0/SIR_3.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/SqueezeNet_SqueezeNet1_0/SIR_3.py
@@ -316,7 +316,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/SwinTransformer_SwinTransformer_small_patch4_window7_224/SIR_104.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/SwinTransformer_SwinTransformer_small_patch4_window7_224/SIR_104.py
@@ -61,7 +61,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/SwinTransformer_SwinTransformer_small_patch4_window7_224/SIR_11.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/SwinTransformer_SwinTransformer_small_patch4_window7_224/SIR_11.py
@@ -61,7 +61,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/SwinTransformer_SwinTransformer_small_patch4_window7_224/SIR_129.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/SwinTransformer_SwinTransformer_small_patch4_window7_224/SIR_129.py
@@ -60,7 +60,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/SwinTransformer_SwinTransformer_small_patch4_window7_224/SIR_133.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/SwinTransformer_SwinTransformer_small_patch4_window7_224/SIR_133.py
@@ -61,7 +61,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/SwinTransformer_SwinTransformer_small_patch4_window7_224/SIR_136.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/SwinTransformer_SwinTransformer_small_patch4_window7_224/SIR_136.py
@@ -53,7 +53,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/SwinTransformer_SwinTransformer_small_patch4_window7_224/SIR_140.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/SwinTransformer_SwinTransformer_small_patch4_window7_224/SIR_140.py
@@ -60,7 +60,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/SwinTransformer_SwinTransformer_small_patch4_window7_224/SIR_179.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/SwinTransformer_SwinTransformer_small_patch4_window7_224/SIR_179.py
@@ -61,7 +61,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/SwinTransformer_SwinTransformer_small_patch4_window7_224/SIR_19.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/SwinTransformer_SwinTransformer_small_patch4_window7_224/SIR_19.py
@@ -60,7 +60,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/SwinTransformer_SwinTransformer_small_patch4_window7_224/SIR_192.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/SwinTransformer_SwinTransformer_small_patch4_window7_224/SIR_192.py
@@ -60,7 +60,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/SwinTransformer_SwinTransformer_small_patch4_window7_224/SIR_208.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/SwinTransformer_SwinTransformer_small_patch4_window7_224/SIR_208.py
@@ -61,7 +61,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/SwinTransformer_SwinTransformer_small_patch4_window7_224/SIR_214.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/SwinTransformer_SwinTransformer_small_patch4_window7_224/SIR_214.py
@@ -50,7 +50,7 @@ class TestLayer(unittest.TestCase):
 
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({"FLAGS_prim_all": with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/SwinTransformer_SwinTransformer_small_patch4_window7_224/SIR_24.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/SwinTransformer_SwinTransformer_small_patch4_window7_224/SIR_24.py
@@ -61,7 +61,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/SwinTransformer_SwinTransformer_small_patch4_window7_224/SIR_30.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/SwinTransformer_SwinTransformer_small_patch4_window7_224/SIR_30.py
@@ -60,7 +60,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/SwinTransformer_SwinTransformer_small_patch4_window7_224/SIR_35.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/SwinTransformer_SwinTransformer_small_patch4_window7_224/SIR_35.py
@@ -61,7 +61,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/SwinTransformer_SwinTransformer_small_patch4_window7_224/SIR_5.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/SwinTransformer_SwinTransformer_small_patch4_window7_224/SIR_5.py
@@ -60,7 +60,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/SwinTransformer_SwinTransformer_small_patch4_window7_224/SIR_65.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/SwinTransformer_SwinTransformer_small_patch4_window7_224/SIR_65.py
@@ -60,7 +60,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/SwinTransformer_SwinTransformer_small_patch4_window7_224/SIR_70.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/SwinTransformer_SwinTransformer_small_patch4_window7_224/SIR_70.py
@@ -61,7 +61,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/SwinTransformer_SwinTransformer_small_patch4_window7_224/SIR_76.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/SwinTransformer_SwinTransformer_small_patch4_window7_224/SIR_76.py
@@ -53,7 +53,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/SwinTransformer_SwinTransformer_small_patch4_window7_224/SIR_80.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/SwinTransformer_SwinTransformer_small_patch4_window7_224/SIR_80.py
@@ -60,7 +60,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/SwinTransformer_SwinTransformer_small_patch4_window7_224/SIR_85.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/SwinTransformer_SwinTransformer_small_patch4_window7_224/SIR_85.py
@@ -61,7 +61,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/SwinTransformer_SwinTransformer_small_patch4_window7_224/SIR_90.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/SwinTransformer_SwinTransformer_small_patch4_window7_224/SIR_90.py
@@ -60,7 +60,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/SwinTransformer_SwinTransformer_small_patch4_window7_224/SIR_95.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/SwinTransformer_SwinTransformer_small_patch4_window7_224/SIR_95.py
@@ -61,7 +61,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/SwinTransformer_SwinTransformer_small_patch4_window7_224/SIR_99.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/SwinTransformer_SwinTransformer_small_patch4_window7_224/SIR_99.py
@@ -60,7 +60,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/TNT_TNT_small/SIR_4.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/TNT_TNT_small/SIR_4.py
@@ -58,7 +58,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/TNT_TNT_small/SIR_40.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/TNT_TNT_small/SIR_40.py
@@ -58,7 +58,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/TNT_TNT_small/SIR_44.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/TNT_TNT_small/SIR_44.py
@@ -58,7 +58,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/TNT_TNT_small/SIR_8.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/TNT_TNT_small/SIR_8.py
@@ -58,7 +58,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/Twins_alt_gvt_base/SIR_102.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/Twins_alt_gvt_base/SIR_102.py
@@ -55,7 +55,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/Twins_alt_gvt_base/SIR_103.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/Twins_alt_gvt_base/SIR_103.py
@@ -88,7 +88,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/Twins_alt_gvt_base/SIR_108.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/Twins_alt_gvt_base/SIR_108.py
@@ -63,7 +63,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/Twins_alt_gvt_base/SIR_111.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/Twins_alt_gvt_base/SIR_111.py
@@ -58,7 +58,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/Twins_alt_gvt_base/SIR_114.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/Twins_alt_gvt_base/SIR_114.py
@@ -55,7 +55,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/Twins_alt_gvt_base/SIR_115.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/Twins_alt_gvt_base/SIR_115.py
@@ -88,7 +88,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/Twins_alt_gvt_base/SIR_136.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/Twins_alt_gvt_base/SIR_136.py
@@ -63,7 +63,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/Twins_alt_gvt_base/SIR_139.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/Twins_alt_gvt_base/SIR_139.py
@@ -58,7 +58,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/Twins_alt_gvt_base/SIR_14.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/Twins_alt_gvt_base/SIR_14.py
@@ -63,7 +63,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/Twins_alt_gvt_base/SIR_142.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/Twins_alt_gvt_base/SIR_142.py
@@ -55,7 +55,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/Twins_alt_gvt_base/SIR_143.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/Twins_alt_gvt_base/SIR_143.py
@@ -66,7 +66,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/Twins_alt_gvt_base/SIR_153.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/Twins_alt_gvt_base/SIR_153.py
@@ -58,7 +58,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/Twins_alt_gvt_base/SIR_157.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/Twins_alt_gvt_base/SIR_157.py
@@ -88,7 +88,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/Twins_alt_gvt_base/SIR_165.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/Twins_alt_gvt_base/SIR_165.py
@@ -58,7 +58,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/Twins_alt_gvt_base/SIR_169.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/Twins_alt_gvt_base/SIR_169.py
@@ -88,7 +88,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/Twins_alt_gvt_base/SIR_17.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/Twins_alt_gvt_base/SIR_17.py
@@ -58,7 +58,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/Twins_alt_gvt_base/SIR_177.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/Twins_alt_gvt_base/SIR_177.py
@@ -58,7 +58,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/Twins_alt_gvt_base/SIR_181.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/Twins_alt_gvt_base/SIR_181.py
@@ -88,7 +88,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/Twins_alt_gvt_base/SIR_2.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/Twins_alt_gvt_base/SIR_2.py
@@ -63,7 +63,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/Twins_alt_gvt_base/SIR_20.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/Twins_alt_gvt_base/SIR_20.py
@@ -55,7 +55,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/Twins_alt_gvt_base/SIR_205.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/Twins_alt_gvt_base/SIR_205.py
@@ -58,7 +58,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/Twins_alt_gvt_base/SIR_209.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/Twins_alt_gvt_base/SIR_209.py
@@ -66,7 +66,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/Twins_alt_gvt_base/SIR_21.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/Twins_alt_gvt_base/SIR_21.py
@@ -88,7 +88,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/Twins_alt_gvt_base/SIR_219.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/Twins_alt_gvt_base/SIR_219.py
@@ -58,7 +58,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/Twins_alt_gvt_base/SIR_223.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/Twins_alt_gvt_base/SIR_223.py
@@ -88,7 +88,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/Twins_alt_gvt_base/SIR_231.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/Twins_alt_gvt_base/SIR_231.py
@@ -58,7 +58,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/Twins_alt_gvt_base/SIR_235.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/Twins_alt_gvt_base/SIR_235.py
@@ -88,7 +88,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/Twins_alt_gvt_base/SIR_243.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/Twins_alt_gvt_base/SIR_243.py
@@ -58,7 +58,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/Twins_alt_gvt_base/SIR_247.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/Twins_alt_gvt_base/SIR_247.py
@@ -88,7 +88,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/Twins_alt_gvt_base/SIR_26.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/Twins_alt_gvt_base/SIR_26.py
@@ -63,7 +63,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/Twins_alt_gvt_base/SIR_271.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/Twins_alt_gvt_base/SIR_271.py
@@ -58,7 +58,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/Twins_alt_gvt_base/SIR_275.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/Twins_alt_gvt_base/SIR_275.py
@@ -66,7 +66,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/Twins_alt_gvt_base/SIR_29.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/Twins_alt_gvt_base/SIR_29.py
@@ -58,7 +58,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/Twins_alt_gvt_base/SIR_32.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/Twins_alt_gvt_base/SIR_32.py
@@ -55,7 +55,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/Twins_alt_gvt_base/SIR_33.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/Twins_alt_gvt_base/SIR_33.py
@@ -88,7 +88,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/Twins_alt_gvt_base/SIR_5.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/Twins_alt_gvt_base/SIR_5.py
@@ -58,7 +58,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/Twins_alt_gvt_base/SIR_70.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/Twins_alt_gvt_base/SIR_70.py
@@ -63,7 +63,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/Twins_alt_gvt_base/SIR_73.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/Twins_alt_gvt_base/SIR_73.py
@@ -58,7 +58,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/Twins_alt_gvt_base/SIR_76.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/Twins_alt_gvt_base/SIR_76.py
@@ -55,7 +55,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/Twins_alt_gvt_base/SIR_77.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/Twins_alt_gvt_base/SIR_77.py
@@ -66,7 +66,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/Twins_alt_gvt_base/SIR_8.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/Twins_alt_gvt_base/SIR_8.py
@@ -55,7 +55,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/Twins_alt_gvt_base/SIR_84.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/Twins_alt_gvt_base/SIR_84.py
@@ -63,7 +63,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/Twins_alt_gvt_base/SIR_87.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/Twins_alt_gvt_base/SIR_87.py
@@ -58,7 +58,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/Twins_alt_gvt_base/SIR_9.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/Twins_alt_gvt_base/SIR_9.py
@@ -88,7 +88,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/Twins_alt_gvt_base/SIR_90.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/Twins_alt_gvt_base/SIR_90.py
@@ -55,7 +55,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/Twins_alt_gvt_base/SIR_91.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/Twins_alt_gvt_base/SIR_91.py
@@ -88,7 +88,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/Twins_alt_gvt_base/SIR_96.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/Twins_alt_gvt_base/SIR_96.py
@@ -63,7 +63,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/Twins_alt_gvt_base/SIR_99.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/Twins_alt_gvt_base/SIR_99.py
@@ -58,7 +58,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/Xception_Xception65_deeplab/SIR_35.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/Xception_Xception65_deeplab/SIR_35.py
@@ -54,7 +54,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/Xception_Xception65_deeplab/SIR_55.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Clas_cases/Xception_Xception65_deeplab/SIR_55.py
@@ -54,7 +54,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/cascade_rcnn_cascade_mask_rcnn_r50_fpn_1x_coco/SIR_87.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/cascade_rcnn_cascade_mask_rcnn_r50_fpn_1x_coco/SIR_87.py
@@ -77,7 +77,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/cascade_rcnn_cascade_mask_rcnn_r50_vd_fpn_ssld_1x_coco/SIR_143.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/cascade_rcnn_cascade_mask_rcnn_r50_vd_fpn_ssld_1x_coco/SIR_143.py
@@ -62,7 +62,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/cascade_rcnn_cascade_mask_rcnn_r50_vd_fpn_ssld_1x_coco/SIR_145.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/cascade_rcnn_cascade_mask_rcnn_r50_vd_fpn_ssld_1x_coco/SIR_145.py
@@ -77,7 +77,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/cascade_rcnn_cascade_mask_rcnn_r50_vd_fpn_ssld_1x_coco/SIR_148.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/cascade_rcnn_cascade_mask_rcnn_r50_vd_fpn_ssld_1x_coco/SIR_148.py
@@ -71,7 +71,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/cascade_rcnn_cascade_mask_rcnn_r50_vd_fpn_ssld_1x_coco/SIR_85.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/cascade_rcnn_cascade_mask_rcnn_r50_vd_fpn_ssld_1x_coco/SIR_85.py
@@ -58,7 +58,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/cascade_rcnn_cascade_mask_rcnn_r50_vd_fpn_ssld_1x_coco/SIR_89.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/cascade_rcnn_cascade_mask_rcnn_r50_vd_fpn_ssld_1x_coco/SIR_89.py
@@ -77,7 +77,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/cascade_rcnn_cascade_rcnn_r50_fpn_1x_coco/SIR_106.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/cascade_rcnn_cascade_rcnn_r50_fpn_1x_coco/SIR_106.py
@@ -70,7 +70,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/cascade_rcnn_cascade_rcnn_r50_fpn_1x_coco/SIR_87.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/cascade_rcnn_cascade_rcnn_r50_fpn_1x_coco/SIR_87.py
@@ -77,7 +77,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/cascade_rcnn_cascade_rcnn_r50_vd_fpn_ssld_1x_coco/SIR_89.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/cascade_rcnn_cascade_rcnn_r50_vd_fpn_ssld_1x_coco/SIR_89.py
@@ -75,7 +75,7 @@ class TestLayer(unittest.TestCase):
 
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({"FLAGS_prim_all": with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/cascade_rcnn_cascade_rcnn_r50_vd_fpn_ssld_2x_coco/SIR_89.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/cascade_rcnn_cascade_rcnn_r50_vd_fpn_ssld_2x_coco/SIR_89.py
@@ -77,7 +77,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/centernet_centernet_mbv3_large_140e_coco/SIR_22.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/centernet_centernet_mbv3_large_140e_coco/SIR_22.py
@@ -63,7 +63,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/centernet_centernet_mbv3_large_140e_coco/SIR_31.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/centernet_centernet_mbv3_large_140e_coco/SIR_31.py
@@ -63,7 +63,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/centernet_centernet_mbv3_large_140e_coco/SIR_64.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/centernet_centernet_mbv3_large_140e_coco/SIR_64.py
@@ -63,7 +63,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/centernet_centernet_mbv3_large_140e_coco/SIR_71.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/centernet_centernet_mbv3_large_140e_coco/SIR_71.py
@@ -63,7 +63,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/centernet_centernet_mbv3_large_140e_coco/SIR_74.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/centernet_centernet_mbv3_large_140e_coco/SIR_74.py
@@ -63,7 +63,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/centernet_centernet_mbv3_large_140e_coco/SIR_77.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/centernet_centernet_mbv3_large_140e_coco/SIR_77.py
@@ -63,7 +63,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/centernet_centernet_mbv3_small_140e_coco/SIR_14.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/centernet_centernet_mbv3_small_140e_coco/SIR_14.py
@@ -63,7 +63,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/centernet_centernet_mbv3_small_140e_coco/SIR_40.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/centernet_centernet_mbv3_small_140e_coco/SIR_40.py
@@ -63,7 +63,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/centernet_centernet_mbv3_small_140e_coco/SIR_49.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/centernet_centernet_mbv3_small_140e_coco/SIR_49.py
@@ -63,7 +63,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/centernet_centernet_mbv3_small_140e_coco/SIR_59.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/centernet_centernet_mbv3_small_140e_coco/SIR_59.py
@@ -63,7 +63,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/centernet_centernet_mbv3_small_140e_coco/SIR_66.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/centernet_centernet_mbv3_small_140e_coco/SIR_66.py
@@ -63,7 +63,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/centernet_centernet_mbv3_small_140e_coco/SIR_69.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/centernet_centernet_mbv3_small_140e_coco/SIR_69.py
@@ -63,7 +63,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/centernet_centernet_mbv3_small_140e_coco/SIR_72.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/centernet_centernet_mbv3_small_140e_coco/SIR_72.py
@@ -63,7 +63,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/dcn_faster_rcnn_dcn_r101_vd_fpn_1x_coco/SIR_35.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/dcn_faster_rcnn_dcn_r101_vd_fpn_1x_coco/SIR_35.py
@@ -132,7 +132,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/dcn_faster_rcnn_dcn_r101_vd_fpn_1x_coco/SIR_44.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/dcn_faster_rcnn_dcn_r101_vd_fpn_1x_coco/SIR_44.py
@@ -125,7 +125,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/dcn_faster_rcnn_dcn_r101_vd_fpn_1x_coco/SIR_49.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/dcn_faster_rcnn_dcn_r101_vd_fpn_1x_coco/SIR_49.py
@@ -67,7 +67,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/dcn_faster_rcnn_dcn_r101_vd_fpn_1x_coco/SIR_55.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/dcn_faster_rcnn_dcn_r101_vd_fpn_1x_coco/SIR_55.py
@@ -56,7 +56,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/dcn_faster_rcnn_dcn_r101_vd_fpn_1x_coco/SIR_56.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/dcn_faster_rcnn_dcn_r101_vd_fpn_1x_coco/SIR_56.py
@@ -73,7 +73,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/dcn_faster_rcnn_dcn_r101_vd_fpn_1x_coco/SIR_71.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/dcn_faster_rcnn_dcn_r101_vd_fpn_1x_coco/SIR_71.py
@@ -77,7 +77,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/dcn_faster_rcnn_dcn_r50_vd_fpn_2x_coco/SIR_56.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/dcn_faster_rcnn_dcn_r50_vd_fpn_2x_coco/SIR_56.py
@@ -73,7 +73,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/dcn_mask_rcnn_dcn_r50_vd_fpn_2x_coco/SIR_108.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/dcn_mask_rcnn_dcn_r50_vd_fpn_2x_coco/SIR_108.py
@@ -77,7 +77,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/faster_rcnn_faster_rcnn_r101_fpn_2x_coco/SIR_33.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/faster_rcnn_faster_rcnn_r101_fpn_2x_coco/SIR_33.py
@@ -132,7 +132,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/faster_rcnn_faster_rcnn_r101_fpn_2x_coco/SIR_42.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/faster_rcnn_faster_rcnn_r101_fpn_2x_coco/SIR_42.py
@@ -125,7 +125,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/faster_rcnn_faster_rcnn_r101_fpn_2x_coco/SIR_47.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/faster_rcnn_faster_rcnn_r101_fpn_2x_coco/SIR_47.py
@@ -67,7 +67,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/faster_rcnn_faster_rcnn_r101_fpn_2x_coco/SIR_53.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/faster_rcnn_faster_rcnn_r101_fpn_2x_coco/SIR_53.py
@@ -56,7 +56,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/faster_rcnn_faster_rcnn_r101_fpn_2x_coco/SIR_54.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/faster_rcnn_faster_rcnn_r101_fpn_2x_coco/SIR_54.py
@@ -73,7 +73,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/faster_rcnn_faster_rcnn_r101_fpn_2x_coco/SIR_69.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/faster_rcnn_faster_rcnn_r101_fpn_2x_coco/SIR_69.py
@@ -77,7 +77,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/faster_rcnn_faster_rcnn_r101_vd_fpn_1x_coco/SIR_35.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/faster_rcnn_faster_rcnn_r101_vd_fpn_1x_coco/SIR_35.py
@@ -132,7 +132,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/faster_rcnn_faster_rcnn_r101_vd_fpn_1x_coco/SIR_44.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/faster_rcnn_faster_rcnn_r101_vd_fpn_1x_coco/SIR_44.py
@@ -125,7 +125,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/faster_rcnn_faster_rcnn_r101_vd_fpn_1x_coco/SIR_49.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/faster_rcnn_faster_rcnn_r101_vd_fpn_1x_coco/SIR_49.py
@@ -67,7 +67,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/faster_rcnn_faster_rcnn_r101_vd_fpn_1x_coco/SIR_55.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/faster_rcnn_faster_rcnn_r101_vd_fpn_1x_coco/SIR_55.py
@@ -56,7 +56,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/faster_rcnn_faster_rcnn_r101_vd_fpn_1x_coco/SIR_56.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/faster_rcnn_faster_rcnn_r101_vd_fpn_1x_coco/SIR_56.py
@@ -73,7 +73,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/faster_rcnn_faster_rcnn_r101_vd_fpn_1x_coco/SIR_71.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/faster_rcnn_faster_rcnn_r101_vd_fpn_1x_coco/SIR_71.py
@@ -77,7 +77,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/faster_rcnn_faster_rcnn_r34_vd_fpn_1x_coco/SIR_33.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/faster_rcnn_faster_rcnn_r34_vd_fpn_1x_coco/SIR_33.py
@@ -132,7 +132,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/faster_rcnn_faster_rcnn_r50_vd_fpn_2x_coco/SIR_35.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/faster_rcnn_faster_rcnn_r50_vd_fpn_2x_coco/SIR_35.py
@@ -132,7 +132,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/faster_rcnn_faster_rcnn_r50_vd_fpn_2x_coco/SIR_44.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/faster_rcnn_faster_rcnn_r50_vd_fpn_2x_coco/SIR_44.py
@@ -125,7 +125,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/faster_rcnn_faster_rcnn_r50_vd_fpn_2x_coco/SIR_49.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/faster_rcnn_faster_rcnn_r50_vd_fpn_2x_coco/SIR_49.py
@@ -67,7 +67,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/faster_rcnn_faster_rcnn_r50_vd_fpn_2x_coco/SIR_55.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/faster_rcnn_faster_rcnn_r50_vd_fpn_2x_coco/SIR_55.py
@@ -56,7 +56,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/faster_rcnn_faster_rcnn_r50_vd_fpn_2x_coco/SIR_56.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/faster_rcnn_faster_rcnn_r50_vd_fpn_2x_coco/SIR_56.py
@@ -73,7 +73,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/faster_rcnn_faster_rcnn_r50_vd_fpn_2x_coco/SIR_71.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/faster_rcnn_faster_rcnn_r50_vd_fpn_2x_coco/SIR_71.py
@@ -75,7 +75,7 @@ class TestLayer(unittest.TestCase):
 
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({"FLAGS_prim_all": with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/faster_rcnn_faster_rcnn_r50_vd_fpn_ssld_1x_coco/SIR_35.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/faster_rcnn_faster_rcnn_r50_vd_fpn_ssld_1x_coco/SIR_35.py
@@ -132,7 +132,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/faster_rcnn_faster_rcnn_r50_vd_fpn_ssld_1x_coco/SIR_44.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/faster_rcnn_faster_rcnn_r50_vd_fpn_ssld_1x_coco/SIR_44.py
@@ -125,7 +125,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/faster_rcnn_faster_rcnn_r50_vd_fpn_ssld_1x_coco/SIR_49.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/faster_rcnn_faster_rcnn_r50_vd_fpn_ssld_1x_coco/SIR_49.py
@@ -67,7 +67,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/faster_rcnn_faster_rcnn_r50_vd_fpn_ssld_1x_coco/SIR_55.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/faster_rcnn_faster_rcnn_r50_vd_fpn_ssld_1x_coco/SIR_55.py
@@ -56,7 +56,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/faster_rcnn_faster_rcnn_r50_vd_fpn_ssld_1x_coco/SIR_56.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/faster_rcnn_faster_rcnn_r50_vd_fpn_ssld_1x_coco/SIR_56.py
@@ -73,7 +73,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/faster_rcnn_faster_rcnn_r50_vd_fpn_ssld_1x_coco/SIR_71.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/faster_rcnn_faster_rcnn_r50_vd_fpn_ssld_1x_coco/SIR_71.py
@@ -77,7 +77,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/faster_rcnn_faster_rcnn_swin_tiny_fpn_1x_coco/SIR_3.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/faster_rcnn_faster_rcnn_swin_tiny_fpn_1x_coco/SIR_3.py
@@ -67,7 +67,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/faster_rcnn_faster_rcnn_swin_tiny_fpn_1x_coco/SIR_85.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/faster_rcnn_faster_rcnn_swin_tiny_fpn_1x_coco/SIR_85.py
@@ -132,7 +132,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/faster_rcnn_faster_rcnn_swin_tiny_fpn_2x_coco/SIR_105.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/faster_rcnn_faster_rcnn_swin_tiny_fpn_2x_coco/SIR_105.py
@@ -56,7 +56,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/faster_rcnn_faster_rcnn_swin_tiny_fpn_2x_coco/SIR_106.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/faster_rcnn_faster_rcnn_swin_tiny_fpn_2x_coco/SIR_106.py
@@ -73,7 +73,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/faster_rcnn_faster_rcnn_swin_tiny_fpn_2x_coco/SIR_114.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/faster_rcnn_faster_rcnn_swin_tiny_fpn_2x_coco/SIR_114.py
@@ -58,7 +58,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/faster_rcnn_faster_rcnn_swin_tiny_fpn_2x_coco/SIR_116.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/faster_rcnn_faster_rcnn_swin_tiny_fpn_2x_coco/SIR_116.py
@@ -64,7 +64,7 @@ class TestLayer(unittest.TestCase):
 
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({"FLAGS_prim_all": with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/faster_rcnn_faster_rcnn_swin_tiny_fpn_2x_coco/SIR_121.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/faster_rcnn_faster_rcnn_swin_tiny_fpn_2x_coco/SIR_121.py
@@ -77,7 +77,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/faster_rcnn_faster_rcnn_swin_tiny_fpn_2x_coco/SIR_122.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/faster_rcnn_faster_rcnn_swin_tiny_fpn_2x_coco/SIR_122.py
@@ -62,7 +62,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/faster_rcnn_faster_rcnn_swin_tiny_fpn_2x_coco/SIR_3.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/faster_rcnn_faster_rcnn_swin_tiny_fpn_2x_coco/SIR_3.py
@@ -67,7 +67,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/faster_rcnn_faster_rcnn_swin_tiny_fpn_2x_coco/SIR_85.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/faster_rcnn_faster_rcnn_swin_tiny_fpn_2x_coco/SIR_85.py
@@ -132,7 +132,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/faster_rcnn_faster_rcnn_swin_tiny_fpn_2x_coco/SIR_94.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/faster_rcnn_faster_rcnn_swin_tiny_fpn_2x_coco/SIR_94.py
@@ -125,7 +125,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/faster_rcnn_faster_rcnn_swin_tiny_fpn_2x_coco/SIR_99.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/faster_rcnn_faster_rcnn_swin_tiny_fpn_2x_coco/SIR_99.py
@@ -67,7 +67,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/fcos_fcos_dcn_r50_fpn_1x_coco/SIR_110.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/fcos_fcos_dcn_r50_fpn_1x_coco/SIR_110.py
@@ -63,7 +63,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/fcos_fcos_dcn_r50_fpn_1x_coco/SIR_120.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/fcos_fcos_dcn_r50_fpn_1x_coco/SIR_120.py
@@ -63,7 +63,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/fcos_fcos_dcn_r50_fpn_1x_coco/SIR_59.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/fcos_fcos_dcn_r50_fpn_1x_coco/SIR_59.py
@@ -63,7 +63,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/fcos_fcos_dcn_r50_fpn_1x_coco/SIR_67.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/fcos_fcos_dcn_r50_fpn_1x_coco/SIR_67.py
@@ -63,7 +63,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/fcos_fcos_dcn_r50_fpn_1x_coco/SIR_92.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/fcos_fcos_dcn_r50_fpn_1x_coco/SIR_92.py
@@ -63,7 +63,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/fcos_fcos_r50_fpn_1x_coco/SIR_108.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/fcos_fcos_r50_fpn_1x_coco/SIR_108.py
@@ -78,7 +78,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/fcos_fcos_r50_fpn_1x_coco/SIR_117.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/fcos_fcos_r50_fpn_1x_coco/SIR_117.py
@@ -78,7 +78,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/fcos_fcos_r50_fpn_1x_coco/SIR_126.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/fcos_fcos_r50_fpn_1x_coco/SIR_126.py
@@ -78,7 +78,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/fcos_fcos_r50_fpn_1x_coco/SIR_33.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/fcos_fcos_r50_fpn_1x_coco/SIR_33.py
@@ -126,7 +126,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/fcos_fcos_r50_fpn_1x_coco/SIR_66.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/fcos_fcos_r50_fpn_1x_coco/SIR_66.py
@@ -78,7 +78,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/fcos_fcos_r50_fpn_1x_coco/SIR_91.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/fcos_fcos_r50_fpn_1x_coco/SIR_91.py
@@ -78,7 +78,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/fcos_fcos_r50_fpn_iou_1x_coco/SIR_108.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/fcos_fcos_r50_fpn_iou_1x_coco/SIR_108.py
@@ -78,7 +78,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/fcos_fcos_r50_fpn_iou_1x_coco/SIR_117.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/fcos_fcos_r50_fpn_iou_1x_coco/SIR_117.py
@@ -78,7 +78,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/fcos_fcos_r50_fpn_iou_1x_coco/SIR_33.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/fcos_fcos_r50_fpn_iou_1x_coco/SIR_33.py
@@ -126,7 +126,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/fcos_fcos_r50_fpn_iou_1x_coco/SIR_66.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/fcos_fcos_r50_fpn_iou_1x_coco/SIR_66.py
@@ -78,7 +78,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/fcos_fcos_r50_fpn_iou_1x_coco/SIR_91.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/fcos_fcos_r50_fpn_iou_1x_coco/SIR_91.py
@@ -78,7 +78,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/fcos_fcos_r50_fpn_multiscale_2x_coco/SIR_108.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/fcos_fcos_r50_fpn_multiscale_2x_coco/SIR_108.py
@@ -78,7 +78,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/fcos_fcos_r50_fpn_multiscale_2x_coco/SIR_117.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/fcos_fcos_r50_fpn_multiscale_2x_coco/SIR_117.py
@@ -78,7 +78,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/fcos_fcos_r50_fpn_multiscale_2x_coco/SIR_126.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/fcos_fcos_r50_fpn_multiscale_2x_coco/SIR_126.py
@@ -78,7 +78,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/fcos_fcos_r50_fpn_multiscale_2x_coco/SIR_33.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/fcos_fcos_r50_fpn_multiscale_2x_coco/SIR_33.py
@@ -126,7 +126,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/fcos_fcos_r50_fpn_multiscale_2x_coco/SIR_66.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/fcos_fcos_r50_fpn_multiscale_2x_coco/SIR_66.py
@@ -78,7 +78,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/fcos_fcos_r50_fpn_multiscale_2x_coco/SIR_91.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/fcos_fcos_r50_fpn_multiscale_2x_coco/SIR_91.py
@@ -78,7 +78,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/gfl_gfl_r101vd_fpn_mstrain_2x_coco/SIR_110.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/gfl_gfl_r101vd_fpn_mstrain_2x_coco/SIR_110.py
@@ -68,7 +68,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/gfl_gfl_r101vd_fpn_mstrain_2x_coco/SIR_119.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/gfl_gfl_r101vd_fpn_mstrain_2x_coco/SIR_119.py
@@ -68,7 +68,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/gfl_gfl_r101vd_fpn_mstrain_2x_coco/SIR_128.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/gfl_gfl_r101vd_fpn_mstrain_2x_coco/SIR_128.py
@@ -68,7 +68,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/gfl_gfl_r101vd_fpn_mstrain_2x_coco/SIR_145.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/gfl_gfl_r101vd_fpn_mstrain_2x_coco/SIR_145.py
@@ -55,7 +55,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/gfl_gfl_r101vd_fpn_mstrain_2x_coco/SIR_150.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/gfl_gfl_r101vd_fpn_mstrain_2x_coco/SIR_150.py
@@ -53,7 +53,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/gfl_gfl_r101vd_fpn_mstrain_2x_coco/SIR_151.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/gfl_gfl_r101vd_fpn_mstrain_2x_coco/SIR_151.py
@@ -55,7 +55,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/gfl_gfl_r101vd_fpn_mstrain_2x_coco/SIR_153.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/gfl_gfl_r101vd_fpn_mstrain_2x_coco/SIR_153.py
@@ -53,7 +53,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/gfl_gfl_r101vd_fpn_mstrain_2x_coco/SIR_154.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/gfl_gfl_r101vd_fpn_mstrain_2x_coco/SIR_154.py
@@ -55,7 +55,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/gfl_gfl_r101vd_fpn_mstrain_2x_coco/SIR_156.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/gfl_gfl_r101vd_fpn_mstrain_2x_coco/SIR_156.py
@@ -53,7 +53,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/gfl_gfl_r101vd_fpn_mstrain_2x_coco/SIR_157.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/gfl_gfl_r101vd_fpn_mstrain_2x_coco/SIR_157.py
@@ -55,7 +55,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/gfl_gfl_r101vd_fpn_mstrain_2x_coco/SIR_162.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/gfl_gfl_r101vd_fpn_mstrain_2x_coco/SIR_162.py
@@ -53,7 +53,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/gfl_gfl_r101vd_fpn_mstrain_2x_coco/SIR_163.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/gfl_gfl_r101vd_fpn_mstrain_2x_coco/SIR_163.py
@@ -55,7 +55,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/gfl_gfl_r101vd_fpn_mstrain_2x_coco/SIR_165.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/gfl_gfl_r101vd_fpn_mstrain_2x_coco/SIR_165.py
@@ -53,7 +53,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/gfl_gfl_r101vd_fpn_mstrain_2x_coco/SIR_35.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/gfl_gfl_r101vd_fpn_mstrain_2x_coco/SIR_35.py
@@ -126,7 +126,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/gfl_gfl_r101vd_fpn_mstrain_2x_coco/SIR_68.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/gfl_gfl_r101vd_fpn_mstrain_2x_coco/SIR_68.py
@@ -68,7 +68,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/gfl_gfl_r101vd_fpn_mstrain_2x_coco/SIR_93.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/gfl_gfl_r101vd_fpn_mstrain_2x_coco/SIR_93.py
@@ -68,7 +68,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/gfl_gfl_r18vd_1x_coco/SIR_150.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/gfl_gfl_r18vd_1x_coco/SIR_150.py
@@ -53,7 +53,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/gfl_gfl_r18vd_1x_coco/SIR_151.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/gfl_gfl_r18vd_1x_coco/SIR_151.py
@@ -55,7 +55,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/gfl_gfl_r18vd_1x_coco/SIR_35.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/gfl_gfl_r18vd_1x_coco/SIR_35.py
@@ -126,7 +126,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/gfl_gfl_r50_fpn_1x_coco/SIR_108.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/gfl_gfl_r50_fpn_1x_coco/SIR_108.py
@@ -68,7 +68,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/gfl_gfl_r50_fpn_1x_coco/SIR_117.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/gfl_gfl_r50_fpn_1x_coco/SIR_117.py
@@ -68,7 +68,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/gfl_gfl_r50_fpn_1x_coco/SIR_126.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/gfl_gfl_r50_fpn_1x_coco/SIR_126.py
@@ -68,7 +68,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/gfl_gfl_r50_fpn_1x_coco/SIR_140.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/gfl_gfl_r50_fpn_1x_coco/SIR_140.py
@@ -87,7 +87,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/gfl_gfl_r50_fpn_1x_coco/SIR_141.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/gfl_gfl_r50_fpn_1x_coco/SIR_141.py
@@ -67,7 +67,7 @@ class TestLayer(unittest.TestCase):
 
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({"FLAGS_prim_all": with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/gfl_gfl_r50_fpn_1x_coco/SIR_143.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/gfl_gfl_r50_fpn_1x_coco/SIR_143.py
@@ -55,7 +55,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/gfl_gfl_r50_fpn_1x_coco/SIR_148.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/gfl_gfl_r50_fpn_1x_coco/SIR_148.py
@@ -53,7 +53,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/gfl_gfl_r50_fpn_1x_coco/SIR_149.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/gfl_gfl_r50_fpn_1x_coco/SIR_149.py
@@ -55,7 +55,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/gfl_gfl_r50_fpn_1x_coco/SIR_151.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/gfl_gfl_r50_fpn_1x_coco/SIR_151.py
@@ -53,7 +53,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/gfl_gfl_r50_fpn_1x_coco/SIR_152.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/gfl_gfl_r50_fpn_1x_coco/SIR_152.py
@@ -55,7 +55,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/gfl_gfl_r50_fpn_1x_coco/SIR_154.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/gfl_gfl_r50_fpn_1x_coco/SIR_154.py
@@ -53,7 +53,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/gfl_gfl_r50_fpn_1x_coco/SIR_155.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/gfl_gfl_r50_fpn_1x_coco/SIR_155.py
@@ -55,7 +55,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/gfl_gfl_r50_fpn_1x_coco/SIR_160.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/gfl_gfl_r50_fpn_1x_coco/SIR_160.py
@@ -53,7 +53,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/gfl_gfl_r50_fpn_1x_coco/SIR_161.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/gfl_gfl_r50_fpn_1x_coco/SIR_161.py
@@ -55,7 +55,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/gfl_gfl_r50_fpn_1x_coco/SIR_163.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/gfl_gfl_r50_fpn_1x_coco/SIR_163.py
@@ -53,7 +53,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/gfl_gfl_r50_fpn_1x_coco/SIR_66.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/gfl_gfl_r50_fpn_1x_coco/SIR_66.py
@@ -68,7 +68,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/gfl_gfl_r50_fpn_1x_coco/SIR_91.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/gfl_gfl_r50_fpn_1x_coco/SIR_91.py
@@ -68,7 +68,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/gfl_gflv2_r50_fpn_1x_coco/SIR_112.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/gfl_gflv2_r50_fpn_1x_coco/SIR_112.py
@@ -69,7 +69,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/gfl_gflv2_r50_fpn_1x_coco/SIR_122.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/gfl_gflv2_r50_fpn_1x_coco/SIR_122.py
@@ -69,7 +69,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/gfl_gflv2_r50_fpn_1x_coco/SIR_132.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/gfl_gflv2_r50_fpn_1x_coco/SIR_132.py
@@ -69,7 +69,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/gfl_gflv2_r50_fpn_1x_coco/SIR_149.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/gfl_gflv2_r50_fpn_1x_coco/SIR_149.py
@@ -54,7 +54,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/gfl_gflv2_r50_fpn_1x_coco/SIR_155.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/gfl_gflv2_r50_fpn_1x_coco/SIR_155.py
@@ -54,7 +54,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/gfl_gflv2_r50_fpn_1x_coco/SIR_161.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/gfl_gflv2_r50_fpn_1x_coco/SIR_161.py
@@ -54,7 +54,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/gfl_gflv2_r50_fpn_1x_coco/SIR_167.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/gfl_gflv2_r50_fpn_1x_coco/SIR_167.py
@@ -54,7 +54,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/gfl_gflv2_r50_fpn_1x_coco/SIR_173.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/gfl_gflv2_r50_fpn_1x_coco/SIR_173.py
@@ -54,7 +54,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/gfl_gflv2_r50_fpn_1x_coco/SIR_68.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/gfl_gflv2_r50_fpn_1x_coco/SIR_68.py
@@ -69,7 +69,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/gfl_gflv2_r50_fpn_1x_coco/SIR_94.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/gfl_gflv2_r50_fpn_1x_coco/SIR_94.py
@@ -69,7 +69,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/gn_cascade_mask_rcnn_r50_fpn_gn_2x_coco/SIR_38.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/gn_cascade_mask_rcnn_r50_fpn_gn_2x_coco/SIR_38.py
@@ -74,7 +74,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/hrnet_faster_rcnn_hrnetv2p_w18_1x_coco/SIR_29.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/hrnet_faster_rcnn_hrnetv2p_w18_1x_coco/SIR_29.py
@@ -91,7 +91,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/hrnet_faster_rcnn_hrnetv2p_w18_1x_coco/SIR_38.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/hrnet_faster_rcnn_hrnetv2p_w18_1x_coco/SIR_38.py
@@ -125,7 +125,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/hrnet_faster_rcnn_hrnetv2p_w18_1x_coco/SIR_43.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/hrnet_faster_rcnn_hrnetv2p_w18_1x_coco/SIR_43.py
@@ -67,7 +67,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/hrnet_faster_rcnn_hrnetv2p_w18_1x_coco/SIR_49.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/hrnet_faster_rcnn_hrnetv2p_w18_1x_coco/SIR_49.py
@@ -56,7 +56,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/hrnet_faster_rcnn_hrnetv2p_w18_1x_coco/SIR_50.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/hrnet_faster_rcnn_hrnetv2p_w18_1x_coco/SIR_50.py
@@ -73,7 +73,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/hrnet_faster_rcnn_hrnetv2p_w18_2x_coco/SIR_29.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/hrnet_faster_rcnn_hrnetv2p_w18_2x_coco/SIR_29.py
@@ -91,7 +91,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/hrnet_faster_rcnn_hrnetv2p_w18_2x_coco/SIR_58.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/hrnet_faster_rcnn_hrnetv2p_w18_2x_coco/SIR_58.py
@@ -58,7 +58,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/hrnet_faster_rcnn_hrnetv2p_w18_2x_coco/SIR_60.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/hrnet_faster_rcnn_hrnetv2p_w18_2x_coco/SIR_60.py
@@ -63,7 +63,7 @@ class TestLayer(unittest.TestCase):
 
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({"FLAGS_prim_all": with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/keypoint_higherhrnet_higherhrnet_hrnet_w32_512_swahr/SIR_31.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/keypoint_higherhrnet_higherhrnet_hrnet_w32_512_swahr/SIR_31.py
@@ -51,7 +51,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/keypoint_higherhrnet_higherhrnet_hrnet_w32_512_swahr/SIR_41.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/keypoint_higherhrnet_higherhrnet_hrnet_w32_512_swahr/SIR_41.py
@@ -57,7 +57,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/keypoint_higherhrnet_higherhrnet_hrnet_w32_640/SIR_31.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/keypoint_higherhrnet_higherhrnet_hrnet_w32_640/SIR_31.py
@@ -51,7 +51,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/keypoint_higherhrnet_higherhrnet_hrnet_w32_640/SIR_41.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/keypoint_higherhrnet_higherhrnet_hrnet_w32_640/SIR_41.py
@@ -57,7 +57,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/keypoint_higherhrnet_higherhrnet_hrnet_w32_640/SIR_47.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/keypoint_higherhrnet_higherhrnet_hrnet_w32_640/SIR_47.py
@@ -49,7 +49,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/mask_rcnn_mask_rcnn_r101_fpn_1x_coco/SIR_106.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/mask_rcnn_mask_rcnn_r101_fpn_1x_coco/SIR_106.py
@@ -77,7 +77,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/mask_rcnn_mask_rcnn_r50_fpn_1x_coco/SIR_106.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/mask_rcnn_mask_rcnn_r50_fpn_1x_coco/SIR_106.py
@@ -77,7 +77,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/mask_rcnn_mask_rcnn_r50_fpn_1x_coco/SIR_54.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/mask_rcnn_mask_rcnn_r50_fpn_1x_coco/SIR_54.py
@@ -73,7 +73,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/mask_rcnn_mask_rcnn_r50_fpn_2x_coco/SIR_107.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/mask_rcnn_mask_rcnn_r50_fpn_2x_coco/SIR_107.py
@@ -62,7 +62,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/mask_rcnn_mask_rcnn_r50_fpn_2x_coco/SIR_109.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/mask_rcnn_mask_rcnn_r50_fpn_2x_coco/SIR_109.py
@@ -77,7 +77,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/mask_rcnn_mask_rcnn_r50_fpn_2x_coco/SIR_112.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/mask_rcnn_mask_rcnn_r50_fpn_2x_coco/SIR_112.py
@@ -71,7 +71,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/mask_rcnn_mask_rcnn_r50_vd_fpn_1x_coco/SIR_56.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/mask_rcnn_mask_rcnn_r50_vd_fpn_1x_coco/SIR_56.py
@@ -73,7 +73,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/mask_rcnn_mask_rcnn_x101_vd_64x4d_fpn_1x_coco/SIR_108.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/mask_rcnn_mask_rcnn_x101_vd_64x4d_fpn_1x_coco/SIR_108.py
@@ -77,7 +77,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/mask_rcnn_mask_rcnn_x101_vd_64x4d_fpn_2x_coco/SIR_106.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/mask_rcnn_mask_rcnn_x101_vd_64x4d_fpn_2x_coco/SIR_106.py
@@ -62,7 +62,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/mask_rcnn_mask_rcnn_x101_vd_64x4d_fpn_2x_coco/SIR_108.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/mask_rcnn_mask_rcnn_x101_vd_64x4d_fpn_2x_coco/SIR_108.py
@@ -77,7 +77,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/mask_rcnn_mask_rcnn_x101_vd_64x4d_fpn_2x_coco/SIR_111.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/mask_rcnn_mask_rcnn_x101_vd_64x4d_fpn_2x_coco/SIR_111.py
@@ -71,7 +71,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/mask_rcnn_mask_rcnn_x101_vd_64x4d_fpn_2x_coco/SIR_35.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/mask_rcnn_mask_rcnn_x101_vd_64x4d_fpn_2x_coco/SIR_35.py
@@ -132,7 +132,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/mask_rcnn_mask_rcnn_x101_vd_64x4d_fpn_2x_coco/SIR_44.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/mask_rcnn_mask_rcnn_x101_vd_64x4d_fpn_2x_coco/SIR_44.py
@@ -125,7 +125,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/mask_rcnn_mask_rcnn_x101_vd_64x4d_fpn_2x_coco/SIR_49.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/mask_rcnn_mask_rcnn_x101_vd_64x4d_fpn_2x_coco/SIR_49.py
@@ -67,7 +67,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/mask_rcnn_mask_rcnn_x101_vd_64x4d_fpn_2x_coco/SIR_55.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/mask_rcnn_mask_rcnn_x101_vd_64x4d_fpn_2x_coco/SIR_55.py
@@ -56,7 +56,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/mask_rcnn_mask_rcnn_x101_vd_64x4d_fpn_2x_coco/SIR_56.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/mask_rcnn_mask_rcnn_x101_vd_64x4d_fpn_2x_coco/SIR_56.py
@@ -73,7 +73,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/mask_rcnn_mask_rcnn_x101_vd_64x4d_fpn_2x_coco/SIR_71.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/mask_rcnn_mask_rcnn_x101_vd_64x4d_fpn_2x_coco/SIR_71.py
@@ -75,7 +75,7 @@ class TestLayer(unittest.TestCase):
 
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({"FLAGS_prim_all": with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/mot_fairmot_fairmot_dla34_30e_1088x608_bytetracker/SIR_79.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/mot_fairmot_fairmot_dla34_30e_1088x608_bytetracker/SIR_79.py
@@ -63,7 +63,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/mot_fairmot_fairmot_enhance_hardnet85_30e_1088x608/SIR_84.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/mot_fairmot_fairmot_enhance_hardnet85_30e_1088x608/SIR_84.py
@@ -47,7 +47,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/mot_fairmot_fairmot_enhance_hardnet85_30e_1088x608/SIR_96.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/mot_fairmot_fairmot_enhance_hardnet85_30e_1088x608/SIR_96.py
@@ -46,7 +46,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/mot_jde_jde_darknet53_30e_1088x608/SIR_51.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/mot_jde_jde_darknet53_30e_1088x608/SIR_51.py
@@ -76,7 +76,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/mot_jde_jde_darknet53_30e_1088x608/SIR_63.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/mot_jde_jde_darknet53_30e_1088x608/SIR_63.py
@@ -76,7 +76,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/mot_jde_jde_darknet53_30e_576x320/SIR_51.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/mot_jde_jde_darknet53_30e_576x320/SIR_51.py
@@ -76,7 +76,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/mot_jde_jde_darknet53_30e_576x320/SIR_63.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/mot_jde_jde_darknet53_30e_576x320/SIR_63.py
@@ -76,7 +76,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/mot_jde_jde_darknet53_30e_864x480/SIR_51.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/mot_jde_jde_darknet53_30e_864x480/SIR_51.py
@@ -76,7 +76,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/mot_jde_jde_darknet53_30e_864x480/SIR_63.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/mot_jde_jde_darknet53_30e_864x480/SIR_63.py
@@ -76,7 +76,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/mot_jde_jde_darknet53_30e_864x480/SIR_75.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/mot_jde_jde_darknet53_30e_864x480/SIR_75.py
@@ -172,7 +172,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/mot_mcfairmot_mcfairmot_hrnetv2_w18_dlafpn_30e_1088x608_visdrone/SIR_24.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/mot_mcfairmot_mcfairmot_hrnetv2_w18_dlafpn_30e_1088x608_visdrone/SIR_24.py
@@ -61,7 +61,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/mot_mcfairmot_mcfairmot_hrnetv2_w18_dlafpn_30e_576x320_visdrone/SIR_24.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/mot_mcfairmot_mcfairmot_hrnetv2_w18_dlafpn_30e_576x320_visdrone/SIR_24.py
@@ -61,7 +61,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/mot_mcfairmot_mcfairmot_hrnetv2_w18_dlafpn_30e_864x480_visdrone/SIR_24.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/mot_mcfairmot_mcfairmot_hrnetv2_w18_dlafpn_30e_864x480_visdrone/SIR_24.py
@@ -61,7 +61,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/mot_ocsort_ocsort_ppyoloe/SIR_105.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/mot_ocsort_ocsort_ppyoloe/SIR_105.py
@@ -58,7 +58,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/mot_ocsort_ocsort_ppyoloe/SIR_120.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/mot_ocsort_ocsort_ppyoloe/SIR_120.py
@@ -45,7 +45,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/mot_ocsort_ocsort_ppyoloe/SIR_164.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/mot_ocsort_ocsort_ppyoloe/SIR_164.py
@@ -59,7 +59,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/mot_ocsort_ocsort_ppyoloe/SIR_167.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/mot_ocsort_ocsort_ppyoloe/SIR_167.py
@@ -59,7 +59,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/mot_ocsort_ocsort_ppyoloe/SIR_170.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/mot_ocsort_ocsort_ppyoloe/SIR_170.py
@@ -59,7 +59,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/mot_ocsort_ocsort_ppyoloe/SIR_173.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/mot_ocsort_ocsort_ppyoloe/SIR_173.py
@@ -65,7 +65,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/mot_ocsort_ocsort_ppyoloe/SIR_178.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/mot_ocsort_ocsort_ppyoloe/SIR_178.py
@@ -154,7 +154,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/mot_ocsort_ocsort_ppyoloe/SIR_21.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/mot_ocsort_ocsort_ppyoloe/SIR_21.py
@@ -58,7 +58,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/mot_ocsort_ocsort_ppyoloe/SIR_60.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/mot_ocsort_ocsort_ppyoloe/SIR_60.py
@@ -58,7 +58,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/mot_ocsort_ocsort_ppyoloe/SIR_91.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/mot_ocsort_ocsort_ppyoloe/SIR_91.py
@@ -58,7 +58,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_more_config_picodet_mobilenetv3_large_1x_416_coco/SIR_194.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_more_config_picodet_mobilenetv3_large_1x_416_coco/SIR_194.py
@@ -53,7 +53,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_more_config_picodet_mobilenetv3_large_1x_416_coco/SIR_22.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_more_config_picodet_mobilenetv3_large_1x_416_coco/SIR_22.py
@@ -63,7 +63,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_more_config_picodet_mobilenetv3_large_1x_416_coco/SIR_229.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_more_config_picodet_mobilenetv3_large_1x_416_coco/SIR_229.py
@@ -53,7 +53,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_more_config_picodet_mobilenetv3_large_1x_416_coco/SIR_256.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_more_config_picodet_mobilenetv3_large_1x_416_coco/SIR_256.py
@@ -53,7 +53,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_more_config_picodet_mobilenetv3_large_1x_416_coco/SIR_275.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_more_config_picodet_mobilenetv3_large_1x_416_coco/SIR_275.py
@@ -53,7 +53,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_more_config_picodet_mobilenetv3_large_1x_416_coco/SIR_31.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_more_config_picodet_mobilenetv3_large_1x_416_coco/SIR_31.py
@@ -63,7 +63,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_more_config_picodet_mobilenetv3_large_1x_416_coco/SIR_64.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_more_config_picodet_mobilenetv3_large_1x_416_coco/SIR_64.py
@@ -63,7 +63,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_more_config_picodet_mobilenetv3_large_1x_416_coco/SIR_71.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_more_config_picodet_mobilenetv3_large_1x_416_coco/SIR_71.py
@@ -63,7 +63,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_more_config_picodet_mobilenetv3_large_1x_416_coco/SIR_74.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_more_config_picodet_mobilenetv3_large_1x_416_coco/SIR_74.py
@@ -63,7 +63,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_more_config_picodet_mobilenetv3_large_1x_416_coco/SIR_77.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_more_config_picodet_mobilenetv3_large_1x_416_coco/SIR_77.py
@@ -63,7 +63,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_l_320_coco/SIR_17.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_l_320_coco/SIR_17.py
@@ -63,7 +63,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_l_320_coco/SIR_205.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_l_320_coco/SIR_205.py
@@ -53,7 +53,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_l_320_coco/SIR_240.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_l_320_coco/SIR_240.py
@@ -53,7 +53,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_l_320_coco/SIR_267.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_l_320_coco/SIR_267.py
@@ -53,7 +53,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_l_320_coco/SIR_286.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_l_320_coco/SIR_286.py
@@ -53,7 +53,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_l_320_coco/SIR_34.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_l_320_coco/SIR_34.py
@@ -68,7 +68,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_l_320_coco/SIR_341.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_l_320_coco/SIR_341.py
@@ -87,7 +87,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_l_320_coco/SIR_342.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_l_320_coco/SIR_342.py
@@ -67,7 +67,7 @@ class TestLayer(unittest.TestCase):
 
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({"FLAGS_prim_all": with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_l_320_coco/SIR_41.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_l_320_coco/SIR_41.py
@@ -68,7 +68,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_l_320_coco/SIR_54.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_l_320_coco/SIR_54.py
@@ -63,7 +63,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_l_320_coco/SIR_69.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_l_320_coco/SIR_69.py
@@ -68,7 +68,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_l_320_coco/SIR_72.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_l_320_coco/SIR_72.py
@@ -68,7 +68,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_l_320_coco/SIR_75.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_l_320_coco/SIR_75.py
@@ -68,7 +68,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_l_320_coco/SIR_81.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_l_320_coco/SIR_81.py
@@ -63,7 +63,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_l_320_coco/SIR_88.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_l_320_coco/SIR_88.py
@@ -68,7 +68,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_l_320_coco/SIR_91.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_l_320_coco/SIR_91.py
@@ -68,7 +68,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_l_416_coco/SIR_17.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_l_416_coco/SIR_17.py
@@ -63,7 +63,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_l_416_coco/SIR_205.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_l_416_coco/SIR_205.py
@@ -53,7 +53,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_l_416_coco/SIR_240.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_l_416_coco/SIR_240.py
@@ -53,7 +53,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_l_416_coco/SIR_267.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_l_416_coco/SIR_267.py
@@ -53,7 +53,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_l_416_coco/SIR_286.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_l_416_coco/SIR_286.py
@@ -53,7 +53,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_l_416_coco/SIR_34.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_l_416_coco/SIR_34.py
@@ -68,7 +68,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_l_416_coco/SIR_41.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_l_416_coco/SIR_41.py
@@ -68,7 +68,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_l_416_coco/SIR_54.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_l_416_coco/SIR_54.py
@@ -63,7 +63,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_l_416_coco/SIR_69.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_l_416_coco/SIR_69.py
@@ -68,7 +68,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_l_416_coco/SIR_72.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_l_416_coco/SIR_72.py
@@ -68,7 +68,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_l_416_coco/SIR_75.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_l_416_coco/SIR_75.py
@@ -68,7 +68,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_l_416_coco/SIR_81.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_l_416_coco/SIR_81.py
@@ -63,7 +63,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_l_416_coco/SIR_88.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_l_416_coco/SIR_88.py
@@ -68,7 +68,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_l_416_coco/SIR_91.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_l_416_coco/SIR_91.py
@@ -68,7 +68,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_l_640_coco/SIR_17.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_l_640_coco/SIR_17.py
@@ -63,7 +63,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_l_640_coco/SIR_205.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_l_640_coco/SIR_205.py
@@ -53,7 +53,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_l_640_coco/SIR_240.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_l_640_coco/SIR_240.py
@@ -53,7 +53,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_l_640_coco/SIR_267.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_l_640_coco/SIR_267.py
@@ -53,7 +53,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_l_640_coco/SIR_286.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_l_640_coco/SIR_286.py
@@ -53,7 +53,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_l_640_coco/SIR_34.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_l_640_coco/SIR_34.py
@@ -68,7 +68,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_l_640_coco/SIR_41.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_l_640_coco/SIR_41.py
@@ -68,7 +68,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_l_640_coco/SIR_54.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_l_640_coco/SIR_54.py
@@ -63,7 +63,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_l_640_coco/SIR_69.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_l_640_coco/SIR_69.py
@@ -68,7 +68,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_l_640_coco/SIR_72.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_l_640_coco/SIR_72.py
@@ -68,7 +68,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_l_640_coco/SIR_75.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_l_640_coco/SIR_75.py
@@ -68,7 +68,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_l_640_coco/SIR_81.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_l_640_coco/SIR_81.py
@@ -63,7 +63,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_l_640_coco/SIR_88.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_l_640_coco/SIR_88.py
@@ -68,7 +68,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_l_640_coco/SIR_91.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_l_640_coco/SIR_91.py
@@ -68,7 +68,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_m_320_coco/SIR_17.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_m_320_coco/SIR_17.py
@@ -63,7 +63,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_m_320_coco/SIR_205.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_m_320_coco/SIR_205.py
@@ -53,7 +53,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_m_320_coco/SIR_240.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_m_320_coco/SIR_240.py
@@ -53,7 +53,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_m_320_coco/SIR_267.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_m_320_coco/SIR_267.py
@@ -53,7 +53,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_m_320_coco/SIR_286.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_m_320_coco/SIR_286.py
@@ -53,7 +53,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_m_320_coco/SIR_34.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_m_320_coco/SIR_34.py
@@ -68,7 +68,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_m_320_coco/SIR_41.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_m_320_coco/SIR_41.py
@@ -68,7 +68,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_m_320_coco/SIR_54.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_m_320_coco/SIR_54.py
@@ -63,7 +63,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_m_320_coco/SIR_69.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_m_320_coco/SIR_69.py
@@ -68,7 +68,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_m_320_coco/SIR_72.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_m_320_coco/SIR_72.py
@@ -68,7 +68,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_m_320_coco/SIR_75.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_m_320_coco/SIR_75.py
@@ -68,7 +68,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_m_320_coco/SIR_81.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_m_320_coco/SIR_81.py
@@ -63,7 +63,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_m_320_coco/SIR_88.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_m_320_coco/SIR_88.py
@@ -68,7 +68,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_m_320_coco/SIR_91.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_m_320_coco/SIR_91.py
@@ -68,7 +68,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_m_416_coco/SIR_17.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_m_416_coco/SIR_17.py
@@ -63,7 +63,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_m_416_coco/SIR_205.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_m_416_coco/SIR_205.py
@@ -53,7 +53,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_m_416_coco/SIR_240.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_m_416_coco/SIR_240.py
@@ -53,7 +53,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_m_416_coco/SIR_267.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_m_416_coco/SIR_267.py
@@ -53,7 +53,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_m_416_coco/SIR_286.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_m_416_coco/SIR_286.py
@@ -53,7 +53,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_m_416_coco/SIR_34.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_m_416_coco/SIR_34.py
@@ -68,7 +68,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_m_416_coco/SIR_348.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_m_416_coco/SIR_348.py
@@ -87,7 +87,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_m_416_coco/SIR_349.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_m_416_coco/SIR_349.py
@@ -67,7 +67,7 @@ class TestLayer(unittest.TestCase):
 
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({"FLAGS_prim_all": with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_m_416_coco/SIR_41.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_m_416_coco/SIR_41.py
@@ -68,7 +68,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_m_416_coco/SIR_54.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_m_416_coco/SIR_54.py
@@ -63,7 +63,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_m_416_coco/SIR_69.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_m_416_coco/SIR_69.py
@@ -68,7 +68,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_m_416_coco/SIR_72.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_m_416_coco/SIR_72.py
@@ -68,7 +68,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_m_416_coco/SIR_75.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_m_416_coco/SIR_75.py
@@ -68,7 +68,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_m_416_coco/SIR_81.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_m_416_coco/SIR_81.py
@@ -63,7 +63,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_m_416_coco/SIR_88.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_m_416_coco/SIR_88.py
@@ -68,7 +68,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_m_416_coco/SIR_91.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_m_416_coco/SIR_91.py
@@ -68,7 +68,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_s_320_coco/SIR_17.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_s_320_coco/SIR_17.py
@@ -63,7 +63,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_s_320_coco/SIR_183.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_s_320_coco/SIR_183.py
@@ -53,7 +53,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_s_320_coco/SIR_202.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_s_320_coco/SIR_202.py
@@ -53,7 +53,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_s_320_coco/SIR_221.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_s_320_coco/SIR_221.py
@@ -53,7 +53,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_s_320_coco/SIR_240.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_s_320_coco/SIR_240.py
@@ -53,7 +53,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_s_320_coco/SIR_34.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_s_320_coco/SIR_34.py
@@ -68,7 +68,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_s_320_coco/SIR_48.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_s_320_coco/SIR_48.py
@@ -63,7 +63,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_s_320_coco/SIR_65.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_s_320_coco/SIR_65.py
@@ -68,7 +68,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_s_320_coco/SIR_70.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_s_320_coco/SIR_70.py
@@ -68,7 +68,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_s_320_coco/SIR_77.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_s_320_coco/SIR_77.py
@@ -63,7 +63,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_s_320_coco/SIR_84.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_s_320_coco/SIR_84.py
@@ -68,7 +68,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_s_416_coco/SIR_17.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_s_416_coco/SIR_17.py
@@ -63,7 +63,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_s_416_coco/SIR_183.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_s_416_coco/SIR_183.py
@@ -53,7 +53,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_s_416_coco/SIR_202.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_s_416_coco/SIR_202.py
@@ -53,7 +53,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_s_416_coco/SIR_221.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_s_416_coco/SIR_221.py
@@ -53,7 +53,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_s_416_coco/SIR_240.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_s_416_coco/SIR_240.py
@@ -53,7 +53,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_s_416_coco/SIR_250.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_s_416_coco/SIR_250.py
@@ -48,7 +48,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_s_416_coco/SIR_285.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_s_416_coco/SIR_285.py
@@ -87,7 +87,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_s_416_coco/SIR_286.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_s_416_coco/SIR_286.py
@@ -67,7 +67,7 @@ class TestLayer(unittest.TestCase):
 
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({"FLAGS_prim_all": with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_s_416_coco/SIR_295.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_s_416_coco/SIR_295.py
@@ -87,7 +87,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_s_416_coco/SIR_296.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_s_416_coco/SIR_296.py
@@ -67,7 +67,7 @@ class TestLayer(unittest.TestCase):
 
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({"FLAGS_prim_all": with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_s_416_coco/SIR_34.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_s_416_coco/SIR_34.py
@@ -68,7 +68,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_s_416_coco/SIR_48.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_s_416_coco/SIR_48.py
@@ -63,7 +63,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_s_416_coco/SIR_65.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_s_416_coco/SIR_65.py
@@ -68,7 +68,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_s_416_coco/SIR_70.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_s_416_coco/SIR_70.py
@@ -68,7 +68,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_s_416_coco/SIR_77.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_s_416_coco/SIR_77.py
@@ -63,7 +63,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_s_416_coco/SIR_84.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/picodet_legacy_model_picodet_s_416_coco/SIR_84.py
@@ -68,7 +68,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyolo_ppyolo_mbv3_large_coco/SIR_77.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyolo_ppyolo_mbv3_large_coco/SIR_77.py
@@ -63,7 +63,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyolo_ppyolo_mbv3_large_coco/SIR_86.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyolo_ppyolo_mbv3_large_coco/SIR_86.py
@@ -45,7 +45,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyolo_ppyolo_mbv3_small_coco/SIR_14.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyolo_ppyolo_mbv3_small_coco/SIR_14.py
@@ -63,7 +63,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyolo_ppyolo_mbv3_small_coco/SIR_40.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyolo_ppyolo_mbv3_small_coco/SIR_40.py
@@ -63,7 +63,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyolo_ppyolo_mbv3_small_coco/SIR_49.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyolo_ppyolo_mbv3_small_coco/SIR_49.py
@@ -63,7 +63,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyolo_ppyolo_mbv3_small_coco/SIR_59.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyolo_ppyolo_mbv3_small_coco/SIR_59.py
@@ -63,7 +63,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyolo_ppyolo_mbv3_small_coco/SIR_66.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyolo_ppyolo_mbv3_small_coco/SIR_66.py
@@ -63,7 +63,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyolo_ppyolo_mbv3_small_coco/SIR_69.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyolo_ppyolo_mbv3_small_coco/SIR_69.py
@@ -63,7 +63,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyolo_ppyolo_mbv3_small_coco/SIR_72.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyolo_ppyolo_mbv3_small_coco/SIR_72.py
@@ -63,7 +63,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyolo_ppyolo_mbv3_small_coco/SIR_81.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyolo_ppyolo_mbv3_small_coco/SIR_81.py
@@ -45,7 +45,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyolo_ppyolo_r50vd_dcn_1x_coco/SIR_52.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyolo_ppyolo_r50vd_dcn_1x_coco/SIR_52.py
@@ -76,7 +76,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyolo_ppyolo_r50vd_dcn_1x_coco/SIR_58.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyolo_ppyolo_r50vd_dcn_1x_coco/SIR_58.py
@@ -93,7 +93,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyolo_ppyolo_r50vd_dcn_1x_coco/SIR_59.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyolo_ppyolo_r50vd_dcn_1x_coco/SIR_59.py
@@ -96,7 +96,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyolo_ppyolo_r50vd_dcn_1x_coco/SIR_64.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyolo_ppyolo_r50vd_dcn_1x_coco/SIR_64.py
@@ -93,7 +93,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyolo_ppyolo_r50vd_dcn_1x_coco/SIR_65.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyolo_ppyolo_r50vd_dcn_1x_coco/SIR_65.py
@@ -96,7 +96,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyolo_ppyolo_r50vd_dcn_1x_coco/SIR_70.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyolo_ppyolo_r50vd_dcn_1x_coco/SIR_70.py
@@ -93,7 +93,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyolo_ppyolo_r50vd_dcn_1x_coco/SIR_71.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyolo_ppyolo_r50vd_dcn_1x_coco/SIR_71.py
@@ -96,7 +96,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyolo_ppyolo_r50vd_dcn_2x_coco/SIR_52.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyolo_ppyolo_r50vd_dcn_2x_coco/SIR_52.py
@@ -76,7 +76,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyolo_ppyolo_r50vd_dcn_2x_coco/SIR_58.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyolo_ppyolo_r50vd_dcn_2x_coco/SIR_58.py
@@ -93,7 +93,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyolo_ppyolo_r50vd_dcn_2x_coco/SIR_59.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyolo_ppyolo_r50vd_dcn_2x_coco/SIR_59.py
@@ -96,7 +96,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyolo_ppyolo_r50vd_dcn_2x_coco/SIR_64.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyolo_ppyolo_r50vd_dcn_2x_coco/SIR_64.py
@@ -93,7 +93,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyolo_ppyolo_r50vd_dcn_2x_coco/SIR_65.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyolo_ppyolo_r50vd_dcn_2x_coco/SIR_65.py
@@ -96,7 +96,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyolo_ppyolo_r50vd_dcn_2x_coco/SIR_70.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyolo_ppyolo_r50vd_dcn_2x_coco/SIR_70.py
@@ -93,7 +93,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyolo_ppyolo_r50vd_dcn_2x_coco/SIR_71.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyolo_ppyolo_r50vd_dcn_2x_coco/SIR_71.py
@@ -96,7 +96,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyolo_ppyolo_r50vd_dcn_voc/SIR_52.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyolo_ppyolo_r50vd_dcn_voc/SIR_52.py
@@ -76,7 +76,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyolo_ppyolo_r50vd_dcn_voc/SIR_58.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyolo_ppyolo_r50vd_dcn_voc/SIR_58.py
@@ -93,7 +93,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyolo_ppyolo_r50vd_dcn_voc/SIR_59.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyolo_ppyolo_r50vd_dcn_voc/SIR_59.py
@@ -96,7 +96,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyolo_ppyolo_r50vd_dcn_voc/SIR_64.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyolo_ppyolo_r50vd_dcn_voc/SIR_64.py
@@ -93,7 +93,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyolo_ppyolo_r50vd_dcn_voc/SIR_65.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyolo_ppyolo_r50vd_dcn_voc/SIR_65.py
@@ -96,7 +96,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyolo_ppyolo_r50vd_dcn_voc/SIR_70.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyolo_ppyolo_r50vd_dcn_voc/SIR_70.py
@@ -93,7 +93,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyolo_ppyolo_r50vd_dcn_voc/SIR_71.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyolo_ppyolo_r50vd_dcn_voc/SIR_71.py
@@ -96,7 +96,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyolo_ppyolo_tiny_650e_coco/SIR_22.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyolo_ppyolo_tiny_650e_coco/SIR_22.py
@@ -63,7 +63,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyolo_ppyolo_tiny_650e_coco/SIR_31.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyolo_ppyolo_tiny_650e_coco/SIR_31.py
@@ -63,7 +63,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyolo_ppyolo_tiny_650e_coco/SIR_64.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyolo_ppyolo_tiny_650e_coco/SIR_64.py
@@ -63,7 +63,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyolo_ppyolo_tiny_650e_coco/SIR_71.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyolo_ppyolo_tiny_650e_coco/SIR_71.py
@@ -63,7 +63,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyolo_ppyolo_tiny_650e_coco/SIR_74.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyolo_ppyolo_tiny_650e_coco/SIR_74.py
@@ -63,7 +63,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyolo_ppyolo_tiny_650e_coco/SIR_77.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyolo_ppyolo_tiny_650e_coco/SIR_77.py
@@ -63,7 +63,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyolo_ppyolo_tiny_650e_coco/SIR_84.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyolo_ppyolo_tiny_650e_coco/SIR_84.py
@@ -45,7 +45,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyolo_ppyolov2_r101vd_dcn_365e_coco/SIR_69.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyolo_ppyolov2_r101vd_dcn_365e_coco/SIR_69.py
@@ -76,7 +76,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyolo_ppyolov2_r101vd_dcn_365e_coco/SIR_75.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyolo_ppyolov2_r101vd_dcn_365e_coco/SIR_75.py
@@ -93,7 +93,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyolo_ppyolov2_r101vd_dcn_365e_coco/SIR_76.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyolo_ppyolov2_r101vd_dcn_365e_coco/SIR_76.py
@@ -96,7 +96,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyolo_ppyolov2_r101vd_dcn_365e_coco/SIR_81.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyolo_ppyolov2_r101vd_dcn_365e_coco/SIR_81.py
@@ -93,7 +93,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyolo_ppyolov2_r101vd_dcn_365e_coco/SIR_82.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyolo_ppyolov2_r101vd_dcn_365e_coco/SIR_82.py
@@ -96,7 +96,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyolo_ppyolov2_r101vd_dcn_365e_coco/SIR_87.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyolo_ppyolov2_r101vd_dcn_365e_coco/SIR_87.py
@@ -93,7 +93,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyolo_ppyolov2_r101vd_dcn_365e_coco/SIR_88.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyolo_ppyolov2_r101vd_dcn_365e_coco/SIR_88.py
@@ -96,7 +96,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyolo_ppyolov2_r50vd_dcn_365e_coco/SIR_69.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyolo_ppyolov2_r50vd_dcn_365e_coco/SIR_69.py
@@ -76,7 +76,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyolo_ppyolov2_r50vd_dcn_365e_coco/SIR_75.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyolo_ppyolov2_r50vd_dcn_365e_coco/SIR_75.py
@@ -93,7 +93,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyolo_ppyolov2_r50vd_dcn_365e_coco/SIR_76.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyolo_ppyolov2_r50vd_dcn_365e_coco/SIR_76.py
@@ -96,7 +96,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyolo_ppyolov2_r50vd_dcn_365e_coco/SIR_81.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyolo_ppyolov2_r50vd_dcn_365e_coco/SIR_81.py
@@ -93,7 +93,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyolo_ppyolov2_r50vd_dcn_365e_coco/SIR_82.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyolo_ppyolov2_r50vd_dcn_365e_coco/SIR_82.py
@@ -96,7 +96,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyolo_ppyolov2_r50vd_dcn_365e_coco/SIR_87.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyolo_ppyolov2_r50vd_dcn_365e_coco/SIR_87.py
@@ -93,7 +93,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyolo_ppyolov2_r50vd_dcn_365e_coco/SIR_88.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyolo_ppyolov2_r50vd_dcn_365e_coco/SIR_88.py
@@ -96,7 +96,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_ppyoloe_crn_l_300e_coco/SIR_105.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_ppyoloe_crn_l_300e_coco/SIR_105.py
@@ -58,7 +58,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_ppyoloe_crn_l_300e_coco/SIR_121.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_ppyoloe_crn_l_300e_coco/SIR_121.py
@@ -45,7 +45,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_ppyoloe_crn_l_300e_coco/SIR_161.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_ppyoloe_crn_l_300e_coco/SIR_161.py
@@ -59,7 +59,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_ppyoloe_crn_l_300e_coco/SIR_164.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_ppyoloe_crn_l_300e_coco/SIR_164.py
@@ -59,7 +59,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_ppyoloe_crn_l_300e_coco/SIR_167.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_ppyoloe_crn_l_300e_coco/SIR_167.py
@@ -59,7 +59,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_ppyoloe_crn_l_300e_coco/SIR_170.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_ppyoloe_crn_l_300e_coco/SIR_170.py
@@ -65,7 +65,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_ppyoloe_crn_l_300e_coco/SIR_179.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_ppyoloe_crn_l_300e_coco/SIR_179.py
@@ -154,7 +154,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_ppyoloe_crn_l_300e_coco/SIR_21.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_ppyoloe_crn_l_300e_coco/SIR_21.py
@@ -58,7 +58,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_ppyoloe_crn_l_300e_coco/SIR_60.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_ppyoloe_crn_l_300e_coco/SIR_60.py
@@ -58,7 +58,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_ppyoloe_crn_l_300e_coco/SIR_91.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_ppyoloe_crn_l_300e_coco/SIR_91.py
@@ -58,7 +58,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_ppyoloe_crn_m_300e_coco/SIR_112.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_ppyoloe_crn_m_300e_coco/SIR_112.py
@@ -58,7 +58,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_ppyoloe_crn_m_300e_coco/SIR_124.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_ppyoloe_crn_m_300e_coco/SIR_124.py
@@ -45,7 +45,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_ppyoloe_crn_m_300e_coco/SIR_162.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_ppyoloe_crn_m_300e_coco/SIR_162.py
@@ -59,7 +59,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_ppyoloe_crn_m_300e_coco/SIR_165.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_ppyoloe_crn_m_300e_coco/SIR_165.py
@@ -59,7 +59,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_ppyoloe_crn_m_300e_coco/SIR_168.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_ppyoloe_crn_m_300e_coco/SIR_168.py
@@ -59,7 +59,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_ppyoloe_crn_m_300e_coco/SIR_21.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_ppyoloe_crn_m_300e_coco/SIR_21.py
@@ -58,7 +58,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_ppyoloe_crn_m_300e_coco/SIR_54.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_ppyoloe_crn_m_300e_coco/SIR_54.py
@@ -58,7 +58,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_ppyoloe_crn_m_300e_coco/SIR_85.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_ppyoloe_crn_m_300e_coco/SIR_85.py
@@ -58,7 +58,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_ppyoloe_crn_s_300e_coco/SIR_113.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_ppyoloe_crn_s_300e_coco/SIR_113.py
@@ -45,7 +45,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_ppyoloe_crn_s_300e_coco/SIR_163.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_ppyoloe_crn_s_300e_coco/SIR_163.py
@@ -59,7 +59,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_ppyoloe_crn_s_300e_coco/SIR_166.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_ppyoloe_crn_s_300e_coco/SIR_166.py
@@ -59,7 +59,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_ppyoloe_crn_s_300e_coco/SIR_169.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_ppyoloe_crn_s_300e_coco/SIR_169.py
@@ -59,7 +59,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_ppyoloe_crn_s_300e_coco/SIR_172.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_ppyoloe_crn_s_300e_coco/SIR_172.py
@@ -65,7 +65,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_ppyoloe_crn_s_300e_coco/SIR_181.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_ppyoloe_crn_s_300e_coco/SIR_181.py
@@ -154,7 +154,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_ppyoloe_crn_s_300e_coco/SIR_21.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_ppyoloe_crn_s_300e_coco/SIR_21.py
@@ -58,7 +58,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_ppyoloe_crn_s_300e_coco/SIR_48.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_ppyoloe_crn_s_300e_coco/SIR_48.py
@@ -58,7 +58,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_ppyoloe_crn_s_300e_coco/SIR_73.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_ppyoloe_crn_s_300e_coco/SIR_73.py
@@ -58,7 +58,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_ppyoloe_crn_s_300e_coco/SIR_95.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_ppyoloe_crn_s_300e_coco/SIR_95.py
@@ -58,7 +58,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_ppyoloe_crn_s_400e_coco/SIR_113.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_ppyoloe_crn_s_400e_coco/SIR_113.py
@@ -45,7 +45,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_ppyoloe_crn_s_400e_coco/SIR_163.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_ppyoloe_crn_s_400e_coco/SIR_163.py
@@ -59,7 +59,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_ppyoloe_crn_s_400e_coco/SIR_166.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_ppyoloe_crn_s_400e_coco/SIR_166.py
@@ -59,7 +59,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_ppyoloe_crn_s_400e_coco/SIR_169.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_ppyoloe_crn_s_400e_coco/SIR_169.py
@@ -59,7 +59,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_ppyoloe_crn_s_400e_coco/SIR_172.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_ppyoloe_crn_s_400e_coco/SIR_172.py
@@ -65,7 +65,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_ppyoloe_crn_s_400e_coco/SIR_181.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_ppyoloe_crn_s_400e_coco/SIR_181.py
@@ -154,7 +154,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_ppyoloe_crn_s_400e_coco/SIR_21.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_ppyoloe_crn_s_400e_coco/SIR_21.py
@@ -58,7 +58,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_ppyoloe_crn_s_400e_coco/SIR_48.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_ppyoloe_crn_s_400e_coco/SIR_48.py
@@ -58,7 +58,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_ppyoloe_crn_s_400e_coco/SIR_73.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_ppyoloe_crn_s_400e_coco/SIR_73.py
@@ -58,7 +58,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_ppyoloe_crn_s_400e_coco/SIR_95.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_ppyoloe_crn_s_400e_coco/SIR_95.py
@@ -58,7 +58,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_ppyoloe_plus_crn_l_80e_coco/SIR_101.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_ppyoloe_plus_crn_l_80e_coco/SIR_101.py
@@ -58,7 +58,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_ppyoloe_plus_crn_l_80e_coco/SIR_115.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_ppyoloe_plus_crn_l_80e_coco/SIR_115.py
@@ -58,7 +58,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_ppyoloe_plus_crn_l_80e_coco/SIR_131.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_ppyoloe_plus_crn_l_80e_coco/SIR_131.py
@@ -45,7 +45,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_ppyoloe_plus_crn_l_80e_coco/SIR_167.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_ppyoloe_plus_crn_l_80e_coco/SIR_167.py
@@ -100,7 +100,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_ppyoloe_plus_crn_l_80e_coco/SIR_171.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_ppyoloe_plus_crn_l_80e_coco/SIR_171.py
@@ -59,7 +59,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_ppyoloe_plus_crn_l_80e_coco/SIR_174.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_ppyoloe_plus_crn_l_80e_coco/SIR_174.py
@@ -59,7 +59,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_ppyoloe_plus_crn_l_80e_coco/SIR_177.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_ppyoloe_plus_crn_l_80e_coco/SIR_177.py
@@ -59,7 +59,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_ppyoloe_plus_crn_l_80e_coco/SIR_180.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_ppyoloe_plus_crn_l_80e_coco/SIR_180.py
@@ -65,7 +65,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_ppyoloe_plus_crn_l_80e_coco/SIR_189.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_ppyoloe_plus_crn_l_80e_coco/SIR_189.py
@@ -154,7 +154,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_ppyoloe_plus_crn_l_80e_coco/SIR_190.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_ppyoloe_plus_crn_l_80e_coco/SIR_190.py
@@ -54,7 +54,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_ppyoloe_plus_crn_l_80e_coco/SIR_21.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_ppyoloe_plus_crn_l_80e_coco/SIR_21.py
@@ -58,7 +58,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_ppyoloe_plus_crn_l_80e_coco/SIR_66.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_ppyoloe_plus_crn_l_80e_coco/SIR_66.py
@@ -58,7 +58,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_ppyoloe_plus_crn_m_80e_coco/SIR_122.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_ppyoloe_plus_crn_m_80e_coco/SIR_122.py
@@ -58,7 +58,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_ppyoloe_plus_crn_m_80e_coco/SIR_134.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_ppyoloe_plus_crn_m_80e_coco/SIR_134.py
@@ -45,7 +45,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_ppyoloe_plus_crn_m_80e_coco/SIR_172.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_ppyoloe_plus_crn_m_80e_coco/SIR_172.py
@@ -59,7 +59,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_ppyoloe_plus_crn_m_80e_coco/SIR_175.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_ppyoloe_plus_crn_m_80e_coco/SIR_175.py
@@ -59,7 +59,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_ppyoloe_plus_crn_m_80e_coco/SIR_178.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_ppyoloe_plus_crn_m_80e_coco/SIR_178.py
@@ -59,7 +59,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_ppyoloe_plus_crn_m_80e_coco/SIR_181.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_ppyoloe_plus_crn_m_80e_coco/SIR_181.py
@@ -65,7 +65,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_ppyoloe_plus_crn_m_80e_coco/SIR_190.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_ppyoloe_plus_crn_m_80e_coco/SIR_190.py
@@ -155,7 +155,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_ppyoloe_plus_crn_m_80e_coco/SIR_21.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_ppyoloe_plus_crn_m_80e_coco/SIR_21.py
@@ -58,7 +58,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_ppyoloe_plus_crn_m_80e_coco/SIR_58.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_ppyoloe_plus_crn_m_80e_coco/SIR_58.py
@@ -58,7 +58,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_ppyoloe_plus_crn_m_80e_coco/SIR_93.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_ppyoloe_plus_crn_m_80e_coco/SIR_93.py
@@ -58,7 +58,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_ppyoloe_plus_crn_s_80e_coco/SIR_118.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_ppyoloe_plus_crn_s_80e_coco/SIR_118.py
@@ -45,7 +45,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_ppyoloe_plus_crn_s_80e_coco/SIR_168.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_ppyoloe_plus_crn_s_80e_coco/SIR_168.py
@@ -59,7 +59,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_ppyoloe_plus_crn_s_80e_coco/SIR_171.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_ppyoloe_plus_crn_s_80e_coco/SIR_171.py
@@ -59,7 +59,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_ppyoloe_plus_crn_s_80e_coco/SIR_174.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_ppyoloe_plus_crn_s_80e_coco/SIR_174.py
@@ -59,7 +59,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_ppyoloe_plus_crn_s_80e_coco/SIR_177.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_ppyoloe_plus_crn_s_80e_coco/SIR_177.py
@@ -65,7 +65,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_ppyoloe_plus_crn_s_80e_coco/SIR_186.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_ppyoloe_plus_crn_s_80e_coco/SIR_186.py
@@ -154,7 +154,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_ppyoloe_plus_crn_x_80e_coco/SIR_101.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_ppyoloe_plus_crn_x_80e_coco/SIR_101.py
@@ -58,7 +58,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_ppyoloe_plus_crn_x_80e_coco/SIR_115.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_ppyoloe_plus_crn_x_80e_coco/SIR_115.py
@@ -58,7 +58,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_ppyoloe_plus_crn_x_80e_coco/SIR_131.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_ppyoloe_plus_crn_x_80e_coco/SIR_131.py
@@ -45,7 +45,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_ppyoloe_plus_crn_x_80e_coco/SIR_171.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_ppyoloe_plus_crn_x_80e_coco/SIR_171.py
@@ -59,7 +59,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_ppyoloe_plus_crn_x_80e_coco/SIR_174.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_ppyoloe_plus_crn_x_80e_coco/SIR_174.py
@@ -59,7 +59,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_ppyoloe_plus_crn_x_80e_coco/SIR_177.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_ppyoloe_plus_crn_x_80e_coco/SIR_177.py
@@ -59,7 +59,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_ppyoloe_plus_crn_x_80e_coco/SIR_180.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_ppyoloe_plus_crn_x_80e_coco/SIR_180.py
@@ -65,7 +65,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_ppyoloe_plus_crn_x_80e_coco/SIR_189.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_ppyoloe_plus_crn_x_80e_coco/SIR_189.py
@@ -154,7 +154,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_ppyoloe_plus_crn_x_80e_coco/SIR_21.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_ppyoloe_plus_crn_x_80e_coco/SIR_21.py
@@ -58,7 +58,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_ppyoloe_plus_crn_x_80e_coco/SIR_74.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_ppyoloe_plus_crn_x_80e_coco/SIR_74.py
@@ -58,7 +58,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_voc_ppyoloe_plus_crn_l_30e_voc/SIR_171.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_voc_ppyoloe_plus_crn_l_30e_voc/SIR_171.py
@@ -59,7 +59,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_voc_ppyoloe_plus_crn_l_30e_voc/SIR_174.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_voc_ppyoloe_plus_crn_l_30e_voc/SIR_174.py
@@ -59,7 +59,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_voc_ppyoloe_plus_crn_l_30e_voc/SIR_177.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_voc_ppyoloe_plus_crn_l_30e_voc/SIR_177.py
@@ -59,7 +59,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_voc_ppyoloe_plus_crn_l_30e_voc/SIR_182.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_voc_ppyoloe_plus_crn_l_30e_voc/SIR_182.py
@@ -98,7 +98,7 @@ class TestLayer(unittest.TestCase):
 
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({"FLAGS_prim_all": with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_voc_ppyoloe_plus_crn_l_30e_voc/SIR_185.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_voc_ppyoloe_plus_crn_l_30e_voc/SIR_185.py
@@ -154,7 +154,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_voc_ppyoloe_plus_crn_s_30e_voc/SIR_100.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_voc_ppyoloe_plus_crn_s_30e_voc/SIR_100.py
@@ -58,7 +58,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_voc_ppyoloe_plus_crn_s_30e_voc/SIR_118.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_voc_ppyoloe_plus_crn_s_30e_voc/SIR_118.py
@@ -45,7 +45,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_voc_ppyoloe_plus_crn_s_30e_voc/SIR_168.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_voc_ppyoloe_plus_crn_s_30e_voc/SIR_168.py
@@ -59,7 +59,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_voc_ppyoloe_plus_crn_s_30e_voc/SIR_171.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_voc_ppyoloe_plus_crn_s_30e_voc/SIR_171.py
@@ -59,7 +59,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_voc_ppyoloe_plus_crn_s_30e_voc/SIR_174.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_voc_ppyoloe_plus_crn_s_30e_voc/SIR_174.py
@@ -59,7 +59,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_voc_ppyoloe_plus_crn_s_30e_voc/SIR_177.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_voc_ppyoloe_plus_crn_s_30e_voc/SIR_177.py
@@ -65,7 +65,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_voc_ppyoloe_plus_crn_s_30e_voc/SIR_179.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_voc_ppyoloe_plus_crn_s_30e_voc/SIR_179.py
@@ -97,7 +97,7 @@ class TestLayer(unittest.TestCase):
 
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({"FLAGS_prim_all": with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_voc_ppyoloe_plus_crn_s_30e_voc/SIR_182.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_voc_ppyoloe_plus_crn_s_30e_voc/SIR_182.py
@@ -154,7 +154,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_voc_ppyoloe_plus_crn_s_30e_voc/SIR_21.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_voc_ppyoloe_plus_crn_s_30e_voc/SIR_21.py
@@ -58,7 +58,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_voc_ppyoloe_plus_crn_s_30e_voc/SIR_50.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_voc_ppyoloe_plus_crn_s_30e_voc/SIR_50.py
@@ -58,7 +58,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_voc_ppyoloe_plus_crn_s_30e_voc/SIR_77.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ppyoloe_voc_ppyoloe_plus_crn_s_30e_voc/SIR_77.py
@@ -58,7 +58,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rcnn_enhance_faster_rcnn_enhance_3x_coco/SIR_101.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rcnn_enhance_faster_rcnn_enhance_3x_coco/SIR_101.py
@@ -50,7 +50,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rcnn_enhance_faster_rcnn_enhance_3x_coco/SIR_103.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rcnn_enhance_faster_rcnn_enhance_3x_coco/SIR_103.py
@@ -69,7 +69,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rcnn_enhance_faster_rcnn_enhance_3x_coco/SIR_104.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rcnn_enhance_faster_rcnn_enhance_3x_coco/SIR_104.py
@@ -50,7 +50,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rcnn_enhance_faster_rcnn_enhance_3x_coco/SIR_106.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rcnn_enhance_faster_rcnn_enhance_3x_coco/SIR_106.py
@@ -69,7 +69,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rcnn_enhance_faster_rcnn_enhance_3x_coco/SIR_107.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rcnn_enhance_faster_rcnn_enhance_3x_coco/SIR_107.py
@@ -129,7 +129,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rcnn_enhance_faster_rcnn_enhance_3x_coco/SIR_35.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rcnn_enhance_faster_rcnn_enhance_3x_coco/SIR_35.py
@@ -132,7 +132,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rcnn_enhance_faster_rcnn_enhance_3x_coco/SIR_44.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rcnn_enhance_faster_rcnn_enhance_3x_coco/SIR_44.py
@@ -125,7 +125,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rcnn_enhance_faster_rcnn_enhance_3x_coco/SIR_49.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rcnn_enhance_faster_rcnn_enhance_3x_coco/SIR_49.py
@@ -67,7 +67,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rcnn_enhance_faster_rcnn_enhance_3x_coco/SIR_55.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rcnn_enhance_faster_rcnn_enhance_3x_coco/SIR_55.py
@@ -56,7 +56,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rcnn_enhance_faster_rcnn_enhance_3x_coco/SIR_56.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rcnn_enhance_faster_rcnn_enhance_3x_coco/SIR_56.py
@@ -73,7 +73,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rcnn_enhance_faster_rcnn_enhance_3x_coco/SIR_96.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rcnn_enhance_faster_rcnn_enhance_3x_coco/SIR_96.py
@@ -77,7 +77,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rcnn_enhance_faster_rcnn_enhance_3x_coco/SIR_97.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rcnn_enhance_faster_rcnn_enhance_3x_coco/SIR_97.py
@@ -62,7 +62,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/res2net_mask_rcnn_res2net50_vd_26w_4s_fpn_2x_coco/SIR_130.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/res2net_mask_rcnn_res2net50_vd_26w_4s_fpn_2x_coco/SIR_130.py
@@ -62,7 +62,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/res2net_mask_rcnn_res2net50_vd_26w_4s_fpn_2x_coco/SIR_132.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/res2net_mask_rcnn_res2net50_vd_26w_4s_fpn_2x_coco/SIR_132.py
@@ -77,7 +77,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/res2net_mask_rcnn_res2net50_vd_26w_4s_fpn_2x_coco/SIR_135.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/res2net_mask_rcnn_res2net50_vd_26w_4s_fpn_2x_coco/SIR_135.py
@@ -71,7 +71,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/retinanet_retinanet_r101_fpn_2x_coco/SIR_33.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/retinanet_retinanet_r101_fpn_2x_coco/SIR_33.py
@@ -126,7 +126,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/retinanet_retinanet_r101_fpn_2x_coco/SIR_34.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/retinanet_retinanet_r101_fpn_2x_coco/SIR_34.py
@@ -227,7 +227,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/retinanet_retinanet_r101_fpn_2x_coco/SIR_42.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/retinanet_retinanet_r101_fpn_2x_coco/SIR_42.py
@@ -50,7 +50,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/retinanet_retinanet_r50_fpn_1x_coco/SIR_33.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/retinanet_retinanet_r50_fpn_1x_coco/SIR_33.py
@@ -126,7 +126,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/retinanet_retinanet_r50_fpn_1x_coco/SIR_34.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/retinanet_retinanet_r50_fpn_1x_coco/SIR_34.py
@@ -227,7 +227,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/retinanet_retinanet_r50_fpn_1x_coco/SIR_42.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/retinanet_retinanet_r50_fpn_1x_coco/SIR_42.py
@@ -50,7 +50,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/retinanet_retinanet_r50_fpn_2x_coco/SIR_42.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/retinanet_retinanet_r50_fpn_2x_coco/SIR_42.py
@@ -50,7 +50,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rotate_fcosr_fcosr_x50_3x_dota/SIR_33.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rotate_fcosr_fcosr_x50_3x_dota/SIR_33.py
@@ -126,7 +126,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rotate_fcosr_fcosr_x50_3x_dota/SIR_35.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rotate_fcosr_fcosr_x50_3x_dota/SIR_35.py
@@ -159,7 +159,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rotate_fcosr_fcosr_x50_3x_dota/SIR_41.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rotate_fcosr_fcosr_x50_3x_dota/SIR_41.py
@@ -53,7 +53,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rotate_fcosr_fcosr_x50_3x_dota/SIR_44.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rotate_fcosr_fcosr_x50_3x_dota/SIR_44.py
@@ -92,7 +92,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rotate_fcosr_fcosr_x50_3x_dota/SIR_47.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rotate_fcosr_fcosr_x50_3x_dota/SIR_47.py
@@ -53,7 +53,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rotate_fcosr_fcosr_x50_3x_dota/SIR_50.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rotate_fcosr_fcosr_x50_3x_dota/SIR_50.py
@@ -92,7 +92,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rotate_fcosr_fcosr_x50_3x_dota/SIR_53.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rotate_fcosr_fcosr_x50_3x_dota/SIR_53.py
@@ -53,7 +53,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rotate_fcosr_fcosr_x50_3x_dota/SIR_56.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rotate_fcosr_fcosr_x50_3x_dota/SIR_56.py
@@ -92,7 +92,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rotate_fcosr_fcosr_x50_3x_dota/SIR_57.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rotate_fcosr_fcosr_x50_3x_dota/SIR_57.py
@@ -53,7 +53,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rotate_fcosr_fcosr_x50_3x_dota/SIR_62.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rotate_fcosr_fcosr_x50_3x_dota/SIR_62.py
@@ -92,7 +92,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rotate_fcosr_fcosr_x50_3x_dota/SIR_63.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rotate_fcosr_fcosr_x50_3x_dota/SIR_63.py
@@ -53,7 +53,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rotate_fcosr_fcosr_x50_3x_dota/SIR_68.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rotate_fcosr_fcosr_x50_3x_dota/SIR_68.py
@@ -92,7 +92,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rotate_fcosr_fcosr_x50_3x_dota/SIR_73.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rotate_fcosr_fcosr_x50_3x_dota/SIR_73.py
@@ -91,7 +91,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rotate_fcosr_fcosr_x50_3x_dota/SIR_92.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rotate_fcosr_fcosr_x50_3x_dota/SIR_92.py
@@ -56,7 +56,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rotate_ppyoloe_r_ppyoloe_r_crn_l_3x_dota/SIR_101.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rotate_ppyoloe_r_ppyoloe_r_crn_l_3x_dota/SIR_101.py
@@ -58,7 +58,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rotate_ppyoloe_r_ppyoloe_r_crn_l_3x_dota/SIR_115.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rotate_ppyoloe_r_ppyoloe_r_crn_l_3x_dota/SIR_115.py
@@ -58,7 +58,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rotate_ppyoloe_r_ppyoloe_r_crn_l_3x_dota/SIR_131.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rotate_ppyoloe_r_ppyoloe_r_crn_l_3x_dota/SIR_131.py
@@ -45,7 +45,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rotate_ppyoloe_r_ppyoloe_r_crn_l_3x_dota/SIR_167.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rotate_ppyoloe_r_ppyoloe_r_crn_l_3x_dota/SIR_167.py
@@ -111,7 +111,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rotate_ppyoloe_r_ppyoloe_r_crn_l_3x_dota/SIR_169.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rotate_ppyoloe_r_ppyoloe_r_crn_l_3x_dota/SIR_169.py
@@ -56,7 +56,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rotate_ppyoloe_r_ppyoloe_r_crn_l_3x_dota/SIR_172.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rotate_ppyoloe_r_ppyoloe_r_crn_l_3x_dota/SIR_172.py
@@ -65,7 +65,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rotate_ppyoloe_r_ppyoloe_r_crn_l_3x_dota/SIR_174.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rotate_ppyoloe_r_ppyoloe_r_crn_l_3x_dota/SIR_174.py
@@ -56,7 +56,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rotate_ppyoloe_r_ppyoloe_r_crn_l_3x_dota/SIR_177.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rotate_ppyoloe_r_ppyoloe_r_crn_l_3x_dota/SIR_177.py
@@ -65,7 +65,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rotate_ppyoloe_r_ppyoloe_r_crn_l_3x_dota/SIR_179.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rotate_ppyoloe_r_ppyoloe_r_crn_l_3x_dota/SIR_179.py
@@ -56,7 +56,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rotate_ppyoloe_r_ppyoloe_r_crn_l_3x_dota/SIR_182.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rotate_ppyoloe_r_ppyoloe_r_crn_l_3x_dota/SIR_182.py
@@ -65,7 +65,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rotate_ppyoloe_r_ppyoloe_r_crn_l_3x_dota/SIR_21.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rotate_ppyoloe_r_ppyoloe_r_crn_l_3x_dota/SIR_21.py
@@ -58,7 +58,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rotate_ppyoloe_r_ppyoloe_r_crn_l_3x_dota/SIR_66.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rotate_ppyoloe_r_ppyoloe_r_crn_l_3x_dota/SIR_66.py
@@ -58,7 +58,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rotate_ppyoloe_r_ppyoloe_r_crn_m_3x_dota_ms/SIR_122.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rotate_ppyoloe_r_ppyoloe_r_crn_m_3x_dota_ms/SIR_122.py
@@ -58,7 +58,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rotate_ppyoloe_r_ppyoloe_r_crn_m_3x_dota_ms/SIR_134.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rotate_ppyoloe_r_ppyoloe_r_crn_m_3x_dota_ms/SIR_134.py
@@ -45,7 +45,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rotate_ppyoloe_r_ppyoloe_r_crn_m_3x_dota_ms/SIR_168.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rotate_ppyoloe_r_ppyoloe_r_crn_m_3x_dota_ms/SIR_168.py
@@ -111,7 +111,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rotate_ppyoloe_r_ppyoloe_r_crn_m_3x_dota_ms/SIR_170.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rotate_ppyoloe_r_ppyoloe_r_crn_m_3x_dota_ms/SIR_170.py
@@ -56,7 +56,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rotate_ppyoloe_r_ppyoloe_r_crn_m_3x_dota_ms/SIR_173.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rotate_ppyoloe_r_ppyoloe_r_crn_m_3x_dota_ms/SIR_173.py
@@ -65,7 +65,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rotate_ppyoloe_r_ppyoloe_r_crn_m_3x_dota_ms/SIR_175.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rotate_ppyoloe_r_ppyoloe_r_crn_m_3x_dota_ms/SIR_175.py
@@ -56,7 +56,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rotate_ppyoloe_r_ppyoloe_r_crn_m_3x_dota_ms/SIR_178.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rotate_ppyoloe_r_ppyoloe_r_crn_m_3x_dota_ms/SIR_178.py
@@ -65,7 +65,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rotate_ppyoloe_r_ppyoloe_r_crn_m_3x_dota_ms/SIR_180.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rotate_ppyoloe_r_ppyoloe_r_crn_m_3x_dota_ms/SIR_180.py
@@ -56,7 +56,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rotate_ppyoloe_r_ppyoloe_r_crn_m_3x_dota_ms/SIR_183.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rotate_ppyoloe_r_ppyoloe_r_crn_m_3x_dota_ms/SIR_183.py
@@ -65,7 +65,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rotate_ppyoloe_r_ppyoloe_r_crn_m_3x_dota_ms/SIR_185.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rotate_ppyoloe_r_ppyoloe_r_crn_m_3x_dota_ms/SIR_185.py
@@ -75,7 +75,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rotate_ppyoloe_r_ppyoloe_r_crn_m_3x_dota_ms/SIR_207.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rotate_ppyoloe_r_ppyoloe_r_crn_m_3x_dota_ms/SIR_207.py
@@ -54,7 +54,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rotate_ppyoloe_r_ppyoloe_r_crn_m_3x_dota_ms/SIR_21.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rotate_ppyoloe_r_ppyoloe_r_crn_m_3x_dota_ms/SIR_21.py
@@ -58,7 +58,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rotate_ppyoloe_r_ppyoloe_r_crn_m_3x_dota_ms/SIR_58.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rotate_ppyoloe_r_ppyoloe_r_crn_m_3x_dota_ms/SIR_58.py
@@ -58,7 +58,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rotate_ppyoloe_r_ppyoloe_r_crn_m_3x_dota_ms/SIR_93.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rotate_ppyoloe_r_ppyoloe_r_crn_m_3x_dota_ms/SIR_93.py
@@ -58,7 +58,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rotate_ppyoloe_r_ppyoloe_r_crn_s_3x_dota/SIR_100.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rotate_ppyoloe_r_ppyoloe_r_crn_s_3x_dota/SIR_100.py
@@ -58,7 +58,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rotate_ppyoloe_r_ppyoloe_r_crn_s_3x_dota/SIR_119.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rotate_ppyoloe_r_ppyoloe_r_crn_s_3x_dota/SIR_119.py
@@ -45,7 +45,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rotate_ppyoloe_r_ppyoloe_r_crn_s_3x_dota/SIR_169.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rotate_ppyoloe_r_ppyoloe_r_crn_s_3x_dota/SIR_169.py
@@ -111,7 +111,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rotate_ppyoloe_r_ppyoloe_r_crn_s_3x_dota/SIR_171.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rotate_ppyoloe_r_ppyoloe_r_crn_s_3x_dota/SIR_171.py
@@ -56,7 +56,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rotate_ppyoloe_r_ppyoloe_r_crn_s_3x_dota/SIR_174.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rotate_ppyoloe_r_ppyoloe_r_crn_s_3x_dota/SIR_174.py
@@ -65,7 +65,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rotate_ppyoloe_r_ppyoloe_r_crn_s_3x_dota/SIR_176.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rotate_ppyoloe_r_ppyoloe_r_crn_s_3x_dota/SIR_176.py
@@ -56,7 +56,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rotate_ppyoloe_r_ppyoloe_r_crn_s_3x_dota/SIR_179.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rotate_ppyoloe_r_ppyoloe_r_crn_s_3x_dota/SIR_179.py
@@ -65,7 +65,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rotate_ppyoloe_r_ppyoloe_r_crn_s_3x_dota/SIR_181.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rotate_ppyoloe_r_ppyoloe_r_crn_s_3x_dota/SIR_181.py
@@ -56,7 +56,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rotate_ppyoloe_r_ppyoloe_r_crn_s_3x_dota/SIR_184.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rotate_ppyoloe_r_ppyoloe_r_crn_s_3x_dota/SIR_184.py
@@ -65,7 +65,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rotate_ppyoloe_r_ppyoloe_r_crn_s_3x_dota/SIR_21.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rotate_ppyoloe_r_ppyoloe_r_crn_s_3x_dota/SIR_21.py
@@ -58,7 +58,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rotate_ppyoloe_r_ppyoloe_r_crn_s_3x_dota/SIR_50.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rotate_ppyoloe_r_ppyoloe_r_crn_s_3x_dota/SIR_50.py
@@ -58,7 +58,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rotate_ppyoloe_r_ppyoloe_r_crn_s_3x_dota/SIR_77.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rotate_ppyoloe_r_ppyoloe_r_crn_s_3x_dota/SIR_77.py
@@ -58,7 +58,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rotate_ppyoloe_r_ppyoloe_r_crn_x_3x_dota/SIR_101.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rotate_ppyoloe_r_ppyoloe_r_crn_x_3x_dota/SIR_101.py
@@ -58,7 +58,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rotate_ppyoloe_r_ppyoloe_r_crn_x_3x_dota/SIR_115.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rotate_ppyoloe_r_ppyoloe_r_crn_x_3x_dota/SIR_115.py
@@ -58,7 +58,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rotate_ppyoloe_r_ppyoloe_r_crn_x_3x_dota/SIR_131.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rotate_ppyoloe_r_ppyoloe_r_crn_x_3x_dota/SIR_131.py
@@ -45,7 +45,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rotate_ppyoloe_r_ppyoloe_r_crn_x_3x_dota/SIR_167.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rotate_ppyoloe_r_ppyoloe_r_crn_x_3x_dota/SIR_167.py
@@ -111,7 +111,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rotate_ppyoloe_r_ppyoloe_r_crn_x_3x_dota/SIR_169.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rotate_ppyoloe_r_ppyoloe_r_crn_x_3x_dota/SIR_169.py
@@ -56,7 +56,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rotate_ppyoloe_r_ppyoloe_r_crn_x_3x_dota/SIR_172.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rotate_ppyoloe_r_ppyoloe_r_crn_x_3x_dota/SIR_172.py
@@ -65,7 +65,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rotate_ppyoloe_r_ppyoloe_r_crn_x_3x_dota/SIR_174.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rotate_ppyoloe_r_ppyoloe_r_crn_x_3x_dota/SIR_174.py
@@ -56,7 +56,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rotate_ppyoloe_r_ppyoloe_r_crn_x_3x_dota/SIR_177.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rotate_ppyoloe_r_ppyoloe_r_crn_x_3x_dota/SIR_177.py
@@ -65,7 +65,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rotate_ppyoloe_r_ppyoloe_r_crn_x_3x_dota/SIR_179.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rotate_ppyoloe_r_ppyoloe_r_crn_x_3x_dota/SIR_179.py
@@ -56,7 +56,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rotate_ppyoloe_r_ppyoloe_r_crn_x_3x_dota/SIR_182.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rotate_ppyoloe_r_ppyoloe_r_crn_x_3x_dota/SIR_182.py
@@ -65,7 +65,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rotate_ppyoloe_r_ppyoloe_r_crn_x_3x_dota/SIR_21.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rotate_ppyoloe_r_ppyoloe_r_crn_x_3x_dota/SIR_21.py
@@ -58,7 +58,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rotate_ppyoloe_r_ppyoloe_r_crn_x_3x_dota/SIR_74.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rotate_ppyoloe_r_ppyoloe_r_crn_x_3x_dota/SIR_74.py
@@ -58,7 +58,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rotate_s2anet_s2anet_conv_2x_dota/SIR_105.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rotate_s2anet_s2anet_conv_2x_dota/SIR_105.py
@@ -53,7 +53,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rotate_s2anet_s2anet_conv_2x_dota/SIR_106.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rotate_s2anet_s2anet_conv_2x_dota/SIR_106.py
@@ -53,7 +53,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rotate_s2anet_s2anet_conv_2x_dota/SIR_107.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rotate_s2anet_s2anet_conv_2x_dota/SIR_107.py
@@ -53,7 +53,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rotate_s2anet_s2anet_conv_2x_dota/SIR_108.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rotate_s2anet_s2anet_conv_2x_dota/SIR_108.py
@@ -53,7 +53,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rotate_s2anet_s2anet_conv_2x_dota/SIR_109.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rotate_s2anet_s2anet_conv_2x_dota/SIR_109.py
@@ -53,7 +53,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rotate_s2anet_s2anet_conv_2x_dota/SIR_33.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/rotate_s2anet_s2anet_conv_2x_dota/SIR_33.py
@@ -125,7 +125,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/semi_det_baseline_fcos_r50_fpn_2x_coco_sup005/SIR_108.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/semi_det_baseline_fcos_r50_fpn_2x_coco_sup005/SIR_108.py
@@ -78,7 +78,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/semi_det_baseline_fcos_r50_fpn_2x_coco_sup005/SIR_117.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/semi_det_baseline_fcos_r50_fpn_2x_coco_sup005/SIR_117.py
@@ -78,7 +78,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/semi_det_baseline_fcos_r50_fpn_2x_coco_sup005/SIR_126.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/semi_det_baseline_fcos_r50_fpn_2x_coco_sup005/SIR_126.py
@@ -78,7 +78,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/semi_det_baseline_fcos_r50_fpn_2x_coco_sup005/SIR_33.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/semi_det_baseline_fcos_r50_fpn_2x_coco_sup005/SIR_33.py
@@ -126,7 +126,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/semi_det_baseline_fcos_r50_fpn_2x_coco_sup005/SIR_66.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/semi_det_baseline_fcos_r50_fpn_2x_coco_sup005/SIR_66.py
@@ -78,7 +78,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/semi_det_baseline_fcos_r50_fpn_2x_coco_sup005/SIR_91.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/semi_det_baseline_fcos_r50_fpn_2x_coco_sup005/SIR_91.py
@@ -78,7 +78,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/semi_det_baseline_fcos_r50_fpn_2x_coco_sup010/SIR_108.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/semi_det_baseline_fcos_r50_fpn_2x_coco_sup010/SIR_108.py
@@ -78,7 +78,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/semi_det_baseline_fcos_r50_fpn_2x_coco_sup010/SIR_117.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/semi_det_baseline_fcos_r50_fpn_2x_coco_sup010/SIR_117.py
@@ -78,7 +78,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/semi_det_baseline_fcos_r50_fpn_2x_coco_sup010/SIR_66.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/semi_det_baseline_fcos_r50_fpn_2x_coco_sup010/SIR_66.py
@@ -78,7 +78,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/semi_det_baseline_fcos_r50_fpn_2x_coco_sup010/SIR_91.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/semi_det_baseline_fcos_r50_fpn_2x_coco_sup010/SIR_91.py
@@ -78,7 +78,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/semi_det_baseline_ppyoloe_plus_crn_s_80e_coco_sup005/SIR_100.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/semi_det_baseline_ppyoloe_plus_crn_s_80e_coco_sup005/SIR_100.py
@@ -58,7 +58,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/semi_det_baseline_ppyoloe_plus_crn_s_80e_coco_sup005/SIR_118.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/semi_det_baseline_ppyoloe_plus_crn_s_80e_coco_sup005/SIR_118.py
@@ -45,7 +45,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/semi_det_baseline_ppyoloe_plus_crn_s_80e_coco_sup005/SIR_168.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/semi_det_baseline_ppyoloe_plus_crn_s_80e_coco_sup005/SIR_168.py
@@ -59,7 +59,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/semi_det_baseline_ppyoloe_plus_crn_s_80e_coco_sup005/SIR_171.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/semi_det_baseline_ppyoloe_plus_crn_s_80e_coco_sup005/SIR_171.py
@@ -59,7 +59,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/semi_det_baseline_ppyoloe_plus_crn_s_80e_coco_sup005/SIR_174.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/semi_det_baseline_ppyoloe_plus_crn_s_80e_coco_sup005/SIR_174.py
@@ -59,7 +59,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/semi_det_baseline_ppyoloe_plus_crn_s_80e_coco_sup005/SIR_177.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/semi_det_baseline_ppyoloe_plus_crn_s_80e_coco_sup005/SIR_177.py
@@ -65,7 +65,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/semi_det_baseline_ppyoloe_plus_crn_s_80e_coco_sup005/SIR_186.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/semi_det_baseline_ppyoloe_plus_crn_s_80e_coco_sup005/SIR_186.py
@@ -154,7 +154,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/semi_det_baseline_ppyoloe_plus_crn_s_80e_coco_sup005/SIR_21.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/semi_det_baseline_ppyoloe_plus_crn_s_80e_coco_sup005/SIR_21.py
@@ -58,7 +58,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/semi_det_baseline_ppyoloe_plus_crn_s_80e_coco_sup005/SIR_50.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/semi_det_baseline_ppyoloe_plus_crn_s_80e_coco_sup005/SIR_50.py
@@ -58,7 +58,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/semi_det_baseline_ppyoloe_plus_crn_s_80e_coco_sup005/SIR_77.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/semi_det_baseline_ppyoloe_plus_crn_s_80e_coco_sup005/SIR_77.py
@@ -58,7 +58,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/semi_det_baseline_retinanet_r50_fpn_2x_coco_sup010/SIR_33.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/semi_det_baseline_retinanet_r50_fpn_2x_coco_sup010/SIR_33.py
@@ -135,7 +135,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/semi_det_baseline_retinanet_r50_fpn_2x_coco_sup010/SIR_34.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/semi_det_baseline_retinanet_r50_fpn_2x_coco_sup010/SIR_34.py
@@ -227,7 +227,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/semi_det_baseline_retinanet_r50_fpn_2x_coco_sup010/SIR_42.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/semi_det_baseline_retinanet_r50_fpn_2x_coco_sup010/SIR_42.py
@@ -50,7 +50,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/smalldet_ppyoloe_plus_sod_crn_l_80e_coco/SIR_101.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/smalldet_ppyoloe_plus_sod_crn_l_80e_coco/SIR_101.py
@@ -58,7 +58,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/smalldet_ppyoloe_plus_sod_crn_l_80e_coco/SIR_115.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/smalldet_ppyoloe_plus_sod_crn_l_80e_coco/SIR_115.py
@@ -58,7 +58,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/smalldet_ppyoloe_plus_sod_crn_l_80e_coco/SIR_127.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/smalldet_ppyoloe_plus_sod_crn_l_80e_coco/SIR_127.py
@@ -88,7 +88,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/smalldet_ppyoloe_plus_sod_crn_l_80e_coco/SIR_138.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/smalldet_ppyoloe_plus_sod_crn_l_80e_coco/SIR_138.py
@@ -45,7 +45,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/smalldet_ppyoloe_plus_sod_crn_l_80e_coco/SIR_163.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/smalldet_ppyoloe_plus_sod_crn_l_80e_coco/SIR_163.py
@@ -59,7 +59,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/smalldet_ppyoloe_plus_sod_crn_l_80e_coco/SIR_166.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/smalldet_ppyoloe_plus_sod_crn_l_80e_coco/SIR_166.py
@@ -59,7 +59,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/smalldet_ppyoloe_plus_sod_crn_l_80e_coco/SIR_169.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/smalldet_ppyoloe_plus_sod_crn_l_80e_coco/SIR_169.py
@@ -59,7 +59,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/smalldet_ppyoloe_plus_sod_crn_l_80e_coco/SIR_172.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/smalldet_ppyoloe_plus_sod_crn_l_80e_coco/SIR_172.py
@@ -65,7 +65,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/smalldet_ppyoloe_plus_sod_crn_l_80e_coco/SIR_174.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/smalldet_ppyoloe_plus_sod_crn_l_80e_coco/SIR_174.py
@@ -97,7 +97,7 @@ class TestLayer(unittest.TestCase):
 
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({"FLAGS_prim_all": with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/smalldet_ppyoloe_plus_sod_crn_l_80e_coco/SIR_177.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/smalldet_ppyoloe_plus_sod_crn_l_80e_coco/SIR_177.py
@@ -154,7 +154,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/smalldet_ppyoloe_plus_sod_crn_l_80e_coco/SIR_21.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/smalldet_ppyoloe_plus_sod_crn_l_80e_coco/SIR_21.py
@@ -58,7 +58,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/smalldet_ppyoloe_plus_sod_crn_l_80e_coco/SIR_66.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/smalldet_ppyoloe_plus_sod_crn_l_80e_coco/SIR_66.py
@@ -58,7 +58,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/sniper_faster_rcnn_r50_fpn_1x_sniper_visdrone/SIR_33.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/sniper_faster_rcnn_r50_fpn_1x_sniper_visdrone/SIR_33.py
@@ -132,7 +132,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/sniper_faster_rcnn_r50_fpn_1x_sniper_visdrone/SIR_42.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/sniper_faster_rcnn_r50_fpn_1x_sniper_visdrone/SIR_42.py
@@ -125,7 +125,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/sniper_faster_rcnn_r50_fpn_1x_sniper_visdrone/SIR_47.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/sniper_faster_rcnn_r50_fpn_1x_sniper_visdrone/SIR_47.py
@@ -67,7 +67,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/sniper_faster_rcnn_r50_fpn_1x_sniper_visdrone/SIR_53.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/sniper_faster_rcnn_r50_fpn_1x_sniper_visdrone/SIR_53.py
@@ -56,7 +56,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/sniper_faster_rcnn_r50_fpn_1x_sniper_visdrone/SIR_54.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/sniper_faster_rcnn_r50_fpn_1x_sniper_visdrone/SIR_54.py
@@ -73,7 +73,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/sniper_faster_rcnn_r50_fpn_1x_sniper_visdrone/SIR_62.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/sniper_faster_rcnn_r50_fpn_1x_sniper_visdrone/SIR_62.py
@@ -58,7 +58,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/sniper_faster_rcnn_r50_fpn_1x_sniper_visdrone/SIR_64.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/sniper_faster_rcnn_r50_fpn_1x_sniper_visdrone/SIR_64.py
@@ -58,7 +58,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/sniper_faster_rcnn_r50_fpn_1x_sniper_visdrone/SIR_69.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/sniper_faster_rcnn_r50_fpn_1x_sniper_visdrone/SIR_69.py
@@ -77,7 +77,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/sniper_faster_rcnn_r50_fpn_1x_visdrone/SIR_33.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/sniper_faster_rcnn_r50_fpn_1x_visdrone/SIR_33.py
@@ -132,7 +132,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/sniper_faster_rcnn_r50_fpn_1x_visdrone/SIR_42.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/sniper_faster_rcnn_r50_fpn_1x_visdrone/SIR_42.py
@@ -125,7 +125,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/sniper_faster_rcnn_r50_fpn_1x_visdrone/SIR_47.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/sniper_faster_rcnn_r50_fpn_1x_visdrone/SIR_47.py
@@ -67,7 +67,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/sniper_faster_rcnn_r50_fpn_1x_visdrone/SIR_53.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/sniper_faster_rcnn_r50_fpn_1x_visdrone/SIR_53.py
@@ -56,7 +56,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/sniper_faster_rcnn_r50_fpn_1x_visdrone/SIR_54.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/sniper_faster_rcnn_r50_fpn_1x_visdrone/SIR_54.py
@@ -73,7 +73,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/sniper_faster_rcnn_r50_fpn_1x_visdrone/SIR_62.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/sniper_faster_rcnn_r50_fpn_1x_visdrone/SIR_62.py
@@ -58,7 +58,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/sniper_faster_rcnn_r50_fpn_1x_visdrone/SIR_64.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/sniper_faster_rcnn_r50_fpn_1x_visdrone/SIR_64.py
@@ -58,7 +58,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/sniper_faster_rcnn_r50_fpn_1x_visdrone/SIR_69.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/sniper_faster_rcnn_r50_fpn_1x_visdrone/SIR_69.py
@@ -77,7 +77,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/solov2_solov2_r101_vd_fpn_3x_coco/SIR_100.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/solov2_solov2_r101_vd_fpn_3x_coco/SIR_100.py
@@ -63,7 +63,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/solov2_solov2_r101_vd_fpn_3x_coco/SIR_114.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/solov2_solov2_r101_vd_fpn_3x_coco/SIR_114.py
@@ -63,7 +63,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/solov2_solov2_r101_vd_fpn_3x_coco/SIR_116.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/solov2_solov2_r101_vd_fpn_3x_coco/SIR_116.py
@@ -63,7 +63,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/solov2_solov2_r101_vd_fpn_3x_coco/SIR_126.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/solov2_solov2_r101_vd_fpn_3x_coco/SIR_126.py
@@ -63,7 +63,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/solov2_solov2_r101_vd_fpn_3x_coco/SIR_128.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/solov2_solov2_r101_vd_fpn_3x_coco/SIR_128.py
@@ -63,7 +63,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/solov2_solov2_r101_vd_fpn_3x_coco/SIR_138.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/solov2_solov2_r101_vd_fpn_3x_coco/SIR_138.py
@@ -63,7 +63,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/solov2_solov2_r101_vd_fpn_3x_coco/SIR_140.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/solov2_solov2_r101_vd_fpn_3x_coco/SIR_140.py
@@ -63,7 +63,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/solov2_solov2_r101_vd_fpn_3x_coco/SIR_37.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/solov2_solov2_r101_vd_fpn_3x_coco/SIR_37.py
@@ -63,7 +63,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/solov2_solov2_r101_vd_fpn_3x_coco/SIR_42.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/solov2_solov2_r101_vd_fpn_3x_coco/SIR_42.py
@@ -63,7 +63,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/solov2_solov2_r101_vd_fpn_3x_coco/SIR_47.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/solov2_solov2_r101_vd_fpn_3x_coco/SIR_47.py
@@ -63,7 +63,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/solov2_solov2_r101_vd_fpn_3x_coco/SIR_52.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/solov2_solov2_r101_vd_fpn_3x_coco/SIR_52.py
@@ -56,7 +56,7 @@ class TestLayer(unittest.TestCase):
 
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({"FLAGS_prim_all": with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/solov2_solov2_r101_vd_fpn_3x_coco/SIR_54.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/solov2_solov2_r101_vd_fpn_3x_coco/SIR_54.py
@@ -63,7 +63,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/solov2_solov2_r101_vd_fpn_3x_coco/SIR_56.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/solov2_solov2_r101_vd_fpn_3x_coco/SIR_56.py
@@ -63,7 +63,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/solov2_solov2_r101_vd_fpn_3x_coco/SIR_58.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/solov2_solov2_r101_vd_fpn_3x_coco/SIR_58.py
@@ -63,7 +63,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/solov2_solov2_r101_vd_fpn_3x_coco/SIR_62.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/solov2_solov2_r101_vd_fpn_3x_coco/SIR_62.py
@@ -63,7 +63,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/solov2_solov2_r101_vd_fpn_3x_coco/SIR_70.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/solov2_solov2_r101_vd_fpn_3x_coco/SIR_70.py
@@ -63,7 +63,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/solov2_solov2_r101_vd_fpn_3x_coco/SIR_75.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/solov2_solov2_r101_vd_fpn_3x_coco/SIR_75.py
@@ -63,7 +63,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/solov2_solov2_r101_vd_fpn_3x_coco/SIR_95.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/solov2_solov2_r101_vd_fpn_3x_coco/SIR_95.py
@@ -63,7 +63,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/solov2_solov2_r50_enhance_coco/SIR_105.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/solov2_solov2_r50_enhance_coco/SIR_105.py
@@ -63,7 +63,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/solov2_solov2_r50_enhance_coco/SIR_113.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/solov2_solov2_r50_enhance_coco/SIR_113.py
@@ -63,7 +63,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/solov2_solov2_r50_enhance_coco/SIR_123.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/solov2_solov2_r50_enhance_coco/SIR_123.py
@@ -63,7 +63,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/solov2_solov2_r50_enhance_coco/SIR_133.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/solov2_solov2_r50_enhance_coco/SIR_133.py
@@ -63,7 +63,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/solov2_solov2_r50_enhance_coco/SIR_34.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/solov2_solov2_r50_enhance_coco/SIR_34.py
@@ -132,7 +132,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/solov2_solov2_r50_enhance_coco/SIR_37.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/solov2_solov2_r50_enhance_coco/SIR_37.py
@@ -63,7 +63,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/solov2_solov2_r50_enhance_coco/SIR_42.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/solov2_solov2_r50_enhance_coco/SIR_42.py
@@ -63,7 +63,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/solov2_solov2_r50_enhance_coco/SIR_47.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/solov2_solov2_r50_enhance_coco/SIR_47.py
@@ -63,7 +63,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/solov2_solov2_r50_enhance_coco/SIR_52.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/solov2_solov2_r50_enhance_coco/SIR_52.py
@@ -56,7 +56,7 @@ class TestLayer(unittest.TestCase):
 
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({"FLAGS_prim_all": with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/solov2_solov2_r50_enhance_coco/SIR_54.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/solov2_solov2_r50_enhance_coco/SIR_54.py
@@ -63,7 +63,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/solov2_solov2_r50_enhance_coco/SIR_56.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/solov2_solov2_r50_enhance_coco/SIR_56.py
@@ -63,7 +63,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/solov2_solov2_r50_enhance_coco/SIR_58.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/solov2_solov2_r50_enhance_coco/SIR_58.py
@@ -63,7 +63,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/solov2_solov2_r50_enhance_coco/SIR_62.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/solov2_solov2_r50_enhance_coco/SIR_62.py
@@ -63,7 +63,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/solov2_solov2_r50_enhance_coco/SIR_75.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/solov2_solov2_r50_enhance_coco/SIR_75.py
@@ -63,7 +63,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/solov2_solov2_r50_fpn_1x_coco/SIR_50.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/solov2_solov2_r50_fpn_1x_coco/SIR_50.py
@@ -56,7 +56,7 @@ class TestLayer(unittest.TestCase):
 
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({"FLAGS_prim_all": with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/solov2_solov2_r50_fpn_3x_coco/SIR_50.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/solov2_solov2_r50_fpn_3x_coco/SIR_50.py
@@ -56,7 +56,7 @@ class TestLayer(unittest.TestCase):
 
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({"FLAGS_prim_all": with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/sparse_rcnn_sparse_rcnn_r50_fpn_3x_pro100_coco/SIR_36.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/sparse_rcnn_sparse_rcnn_r50_fpn_3x_pro100_coco/SIR_36.py
@@ -83,7 +83,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/sparse_rcnn_sparse_rcnn_r50_fpn_3x_pro100_coco/SIR_42.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/sparse_rcnn_sparse_rcnn_r50_fpn_3x_pro100_coco/SIR_42.py
@@ -83,7 +83,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/sparse_rcnn_sparse_rcnn_r50_fpn_3x_pro100_coco/SIR_61.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/sparse_rcnn_sparse_rcnn_r50_fpn_3x_pro100_coco/SIR_61.py
@@ -55,7 +55,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/sparse_rcnn_sparse_rcnn_r50_fpn_3x_pro100_coco/SIR_62.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/sparse_rcnn_sparse_rcnn_r50_fpn_3x_pro100_coco/SIR_62.py
@@ -90,7 +90,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/sparse_rcnn_sparse_rcnn_r50_fpn_3x_pro300_coco/SIR_33.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/sparse_rcnn_sparse_rcnn_r50_fpn_3x_pro300_coco/SIR_33.py
@@ -142,7 +142,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/sparse_rcnn_sparse_rcnn_r50_fpn_3x_pro300_coco/SIR_34.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/sparse_rcnn_sparse_rcnn_r50_fpn_3x_pro300_coco/SIR_34.py
@@ -70,7 +70,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/sparse_rcnn_sparse_rcnn_r50_fpn_3x_pro300_coco/SIR_36.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/sparse_rcnn_sparse_rcnn_r50_fpn_3x_pro300_coco/SIR_36.py
@@ -83,7 +83,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/sparse_rcnn_sparse_rcnn_r50_fpn_3x_pro300_coco/SIR_42.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/sparse_rcnn_sparse_rcnn_r50_fpn_3x_pro300_coco/SIR_42.py
@@ -83,7 +83,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/sparse_rcnn_sparse_rcnn_r50_fpn_3x_pro300_coco/SIR_61.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/sparse_rcnn_sparse_rcnn_r50_fpn_3x_pro300_coco/SIR_61.py
@@ -55,7 +55,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/sparse_rcnn_sparse_rcnn_r50_fpn_3x_pro300_coco/SIR_62.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/sparse_rcnn_sparse_rcnn_r50_fpn_3x_pro300_coco/SIR_62.py
@@ -90,7 +90,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ssd_ssd_vgg16_300_240e_voc/SIR_2.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ssd_ssd_vgg16_300_240e_voc/SIR_2.py
@@ -285,7 +285,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ssd_ssd_vgg16_300_240e_voc/SIR_3.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ssd_ssd_vgg16_300_240e_voc/SIR_3.py
@@ -193,7 +193,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ssd_ssd_vgg16_300_240e_voc/SIR_37.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ssd_ssd_vgg16_300_240e_voc/SIR_37.py
@@ -66,7 +66,7 @@ class TestLayer(unittest.TestCase):
 
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({"FLAGS_prim_all": with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ssd_ssd_vgg16_300_240e_voc/SIR_42.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ssd_ssd_vgg16_300_240e_voc/SIR_42.py
@@ -63,7 +63,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ssd_ssdlite_ghostnet_320_coco/SIR_26.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ssd_ssdlite_ghostnet_320_coco/SIR_26.py
@@ -65,7 +65,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ssd_ssdlite_ghostnet_320_coco/SIR_45.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ssd_ssdlite_ghostnet_320_coco/SIR_45.py
@@ -65,7 +65,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ssd_ssdlite_ghostnet_320_coco/SIR_80.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ssd_ssdlite_ghostnet_320_coco/SIR_80.py
@@ -65,7 +65,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ssd_ssdlite_ghostnet_320_coco/SIR_85.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ssd_ssdlite_ghostnet_320_coco/SIR_85.py
@@ -65,7 +65,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ssd_ssdlite_ghostnet_320_coco/SIR_88.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ssd_ssdlite_ghostnet_320_coco/SIR_88.py
@@ -65,7 +65,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ssd_ssdlite_ghostnet_320_coco/SIR_95.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ssd_ssdlite_ghostnet_320_coco/SIR_95.py
@@ -65,7 +65,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ssd_ssdlite_mobilenet_v3_large_320_coco/SIR_164.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ssd_ssdlite_mobilenet_v3_large_320_coco/SIR_164.py
@@ -66,7 +66,7 @@ class TestLayer(unittest.TestCase):
 
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({"FLAGS_prim_all": with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ssd_ssdlite_mobilenet_v3_large_320_coco/SIR_169.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ssd_ssdlite_mobilenet_v3_large_320_coco/SIR_169.py
@@ -63,7 +63,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ssd_ssdlite_mobilenet_v3_large_320_coco/SIR_22.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ssd_ssdlite_mobilenet_v3_large_320_coco/SIR_22.py
@@ -63,7 +63,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ssd_ssdlite_mobilenet_v3_large_320_coco/SIR_31.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ssd_ssdlite_mobilenet_v3_large_320_coco/SIR_31.py
@@ -63,7 +63,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ssd_ssdlite_mobilenet_v3_large_320_coco/SIR_64.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ssd_ssdlite_mobilenet_v3_large_320_coco/SIR_64.py
@@ -63,7 +63,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ssd_ssdlite_mobilenet_v3_large_320_coco/SIR_71.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ssd_ssdlite_mobilenet_v3_large_320_coco/SIR_71.py
@@ -63,7 +63,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ssd_ssdlite_mobilenet_v3_large_320_coco/SIR_74.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ssd_ssdlite_mobilenet_v3_large_320_coco/SIR_74.py
@@ -63,7 +63,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ssd_ssdlite_mobilenet_v3_large_320_coco/SIR_77.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ssd_ssdlite_mobilenet_v3_large_320_coco/SIR_77.py
@@ -63,7 +63,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/tood_tood_r50_fpn_1x_coco/SIR_34.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/tood_tood_r50_fpn_1x_coco/SIR_34.py
@@ -147,7 +147,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ttfnet_pafnet_lite_mobilenet_v3_20x_coco/SIR_22.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ttfnet_pafnet_lite_mobilenet_v3_20x_coco/SIR_22.py
@@ -63,7 +63,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ttfnet_pafnet_lite_mobilenet_v3_20x_coco/SIR_31.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ttfnet_pafnet_lite_mobilenet_v3_20x_coco/SIR_31.py
@@ -63,7 +63,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ttfnet_pafnet_lite_mobilenet_v3_20x_coco/SIR_65.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ttfnet_pafnet_lite_mobilenet_v3_20x_coco/SIR_65.py
@@ -63,7 +63,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ttfnet_pafnet_lite_mobilenet_v3_20x_coco/SIR_72.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ttfnet_pafnet_lite_mobilenet_v3_20x_coco/SIR_72.py
@@ -63,7 +63,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ttfnet_pafnet_lite_mobilenet_v3_20x_coco/SIR_75.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ttfnet_pafnet_lite_mobilenet_v3_20x_coco/SIR_75.py
@@ -63,7 +63,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ttfnet_pafnet_lite_mobilenet_v3_20x_coco/SIR_78.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/ttfnet_pafnet_lite_mobilenet_v3_20x_coco/SIR_78.py
@@ -63,7 +63,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/vitdet_ppyoloe_vit_base_csppan_cae_36e_coco/SIR_135.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/vitdet_ppyoloe_vit_base_csppan_cae_36e_coco/SIR_135.py
@@ -59,7 +59,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/vitdet_ppyoloe_vit_base_csppan_cae_36e_coco/SIR_140.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/vitdet_ppyoloe_vit_base_csppan_cae_36e_coco/SIR_140.py
@@ -59,7 +59,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/vitdet_ppyoloe_vit_base_csppan_cae_36e_coco/SIR_6.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/vitdet_ppyoloe_vit_base_csppan_cae_36e_coco/SIR_6.py
@@ -98,7 +98,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/yolov3_yolov3_mobilenet_v1_roadsign/SIR_45.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/yolov3_yolov3_mobilenet_v1_roadsign/SIR_45.py
@@ -76,7 +76,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/yolov3_yolov3_mobilenet_v3_large_270e_coco/SIR_22.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/yolov3_yolov3_mobilenet_v3_large_270e_coco/SIR_22.py
@@ -63,7 +63,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/yolov3_yolov3_mobilenet_v3_large_270e_coco/SIR_31.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/yolov3_yolov3_mobilenet_v3_large_270e_coco/SIR_31.py
@@ -63,7 +63,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/yolov3_yolov3_mobilenet_v3_large_270e_coco/SIR_64.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/yolov3_yolov3_mobilenet_v3_large_270e_coco/SIR_64.py
@@ -63,7 +63,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/yolov3_yolov3_mobilenet_v3_large_270e_coco/SIR_71.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/yolov3_yolov3_mobilenet_v3_large_270e_coco/SIR_71.py
@@ -63,7 +63,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/yolov3_yolov3_mobilenet_v3_large_270e_coco/SIR_74.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/yolov3_yolov3_mobilenet_v3_large_270e_coco/SIR_74.py
@@ -63,7 +63,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/yolov3_yolov3_mobilenet_v3_large_270e_coco/SIR_77.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/yolov3_yolov3_mobilenet_v3_large_270e_coco/SIR_77.py
@@ -63,7 +63,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/yolov3_yolov3_mobilenet_v3_large_ssld_270e_voc/SIR_22.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/yolov3_yolov3_mobilenet_v3_large_ssld_270e_voc/SIR_22.py
@@ -63,7 +63,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/yolov3_yolov3_mobilenet_v3_large_ssld_270e_voc/SIR_31.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/yolov3_yolov3_mobilenet_v3_large_ssld_270e_voc/SIR_31.py
@@ -63,7 +63,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/yolov3_yolov3_mobilenet_v3_large_ssld_270e_voc/SIR_64.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/yolov3_yolov3_mobilenet_v3_large_ssld_270e_voc/SIR_64.py
@@ -63,7 +63,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/yolov3_yolov3_mobilenet_v3_large_ssld_270e_voc/SIR_71.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/yolov3_yolov3_mobilenet_v3_large_ssld_270e_voc/SIR_71.py
@@ -63,7 +63,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/yolov3_yolov3_mobilenet_v3_large_ssld_270e_voc/SIR_74.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/yolov3_yolov3_mobilenet_v3_large_ssld_270e_voc/SIR_74.py
@@ -63,7 +63,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/yolov3_yolov3_mobilenet_v3_large_ssld_270e_voc/SIR_77.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/yolov3_yolov3_mobilenet_v3_large_ssld_270e_voc/SIR_77.py
@@ -63,7 +63,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/yolox_yolox_cdn_tiny_300e_coco/SIR_112.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/yolox_yolox_cdn_tiny_300e_coco/SIR_112.py
@@ -56,7 +56,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/yolox_yolox_cdn_tiny_300e_coco/SIR_118.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/yolox_yolox_cdn_tiny_300e_coco/SIR_118.py
@@ -56,7 +56,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/yolox_yolox_cdn_tiny_300e_coco/SIR_124.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/yolox_yolox_cdn_tiny_300e_coco/SIR_124.py
@@ -56,7 +56,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/yolox_yolox_cdn_tiny_300e_coco/SIR_125.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/yolox_yolox_cdn_tiny_300e_coco/SIR_125.py
@@ -164,7 +164,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/yolox_yolox_crn_s_300e_coco/SIR_108.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/yolox_yolox_crn_s_300e_coco/SIR_108.py
@@ -58,7 +58,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/yolox_yolox_crn_s_300e_coco/SIR_184.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/yolox_yolox_crn_s_300e_coco/SIR_184.py
@@ -56,7 +56,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/yolox_yolox_crn_s_300e_coco/SIR_190.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/yolox_yolox_crn_s_300e_coco/SIR_190.py
@@ -56,7 +56,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/yolox_yolox_crn_s_300e_coco/SIR_200.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/yolox_yolox_crn_s_300e_coco/SIR_200.py
@@ -56,7 +56,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/yolox_yolox_crn_s_300e_coco/SIR_201.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/yolox_yolox_crn_s_300e_coco/SIR_201.py
@@ -164,7 +164,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/yolox_yolox_crn_s_300e_coco/SIR_38.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/yolox_yolox_crn_s_300e_coco/SIR_38.py
@@ -58,7 +58,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/yolox_yolox_crn_s_300e_coco/SIR_6.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/yolox_yolox_crn_s_300e_coco/SIR_6.py
@@ -43,7 +43,7 @@ class TestLayer(unittest.TestCase):
 
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({"FLAGS_prim_all": with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/yolox_yolox_crn_s_300e_coco/SIR_63.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/yolox_yolox_crn_s_300e_coco/SIR_63.py
@@ -58,7 +58,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/yolox_yolox_crn_s_300e_coco/SIR_88.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/yolox_yolox_crn_s_300e_coco/SIR_88.py
@@ -58,7 +58,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/yolox_yolox_m_300e_coco/SIR_110.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/yolox_yolox_m_300e_coco/SIR_110.py
@@ -56,7 +56,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/yolox_yolox_m_300e_coco/SIR_116.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/yolox_yolox_m_300e_coco/SIR_116.py
@@ -56,7 +56,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/yolox_yolox_m_300e_coco/SIR_122.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/yolox_yolox_m_300e_coco/SIR_122.py
@@ -56,7 +56,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/yolox_yolox_m_300e_coco/SIR_123.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/yolox_yolox_m_300e_coco/SIR_123.py
@@ -164,7 +164,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/yolox_yolox_nano_300e_coco/SIR_113.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/yolox_yolox_nano_300e_coco/SIR_113.py
@@ -56,7 +56,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/yolox_yolox_nano_300e_coco/SIR_119.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/yolox_yolox_nano_300e_coco/SIR_119.py
@@ -56,7 +56,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/yolox_yolox_nano_300e_coco/SIR_125.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/yolox_yolox_nano_300e_coco/SIR_125.py
@@ -56,7 +56,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/yolox_yolox_nano_300e_coco/SIR_126.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/yolox_yolox_nano_300e_coco/SIR_126.py
@@ -164,7 +164,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/yolox_yolox_x_300e_coco/SIR_109.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/yolox_yolox_x_300e_coco/SIR_109.py
@@ -56,7 +56,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/yolox_yolox_x_300e_coco/SIR_115.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/yolox_yolox_x_300e_coco/SIR_115.py
@@ -56,7 +56,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/yolox_yolox_x_300e_coco/SIR_121.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/yolox_yolox_x_300e_coco/SIR_121.py
@@ -56,7 +56,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/yolox_yolox_x_300e_coco/SIR_122.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Det_cases/yolox_yolox_x_300e_coco/SIR_122.py
@@ -164,7 +164,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Ocr_cases/det_ch_PP_OCRv3_ch_PP_OCRv3_det_cml/SIR_30.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Ocr_cases/det_ch_PP_OCRv3_ch_PP_OCRv3_det_cml/SIR_30.py
@@ -287,7 +287,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Ocr_cases/det_ch_PP_OCRv3_ch_PP_OCRv3_det_cml/SIR_33.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Ocr_cases/det_ch_PP_OCRv3_ch_PP_OCRv3_det_cml/SIR_33.py
@@ -51,7 +51,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Ocr_cases/det_ch_PP_OCRv3_ch_PP_OCRv3_det_cml/SIR_43.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Ocr_cases/det_ch_PP_OCRv3_ch_PP_OCRv3_det_cml/SIR_43.py
@@ -141,7 +141,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Ocr_cases/det_ch_PP_OCRv3_ch_PP_OCRv3_det_cml/SIR_53.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Ocr_cases/det_ch_PP_OCRv3_ch_PP_OCRv3_det_cml/SIR_53.py
@@ -287,7 +287,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Ocr_cases/det_ch_PP_OCRv3_ch_PP_OCRv3_det_cml/SIR_56.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Ocr_cases/det_ch_PP_OCRv3_ch_PP_OCRv3_det_cml/SIR_56.py
@@ -141,7 +141,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Ocr_cases/rec_rec_svtrnet/SIR_15.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Ocr_cases/rec_rec_svtrnet/SIR_15.py
@@ -50,7 +50,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Ocr_cases/rec_rec_svtrnet/SIR_30.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Ocr_cases/rec_rec_svtrnet/SIR_30.py
@@ -88,7 +88,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Ocr_cases/rec_rec_svtrnet/SIR_41.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Ocr_cases/rec_rec_svtrnet/SIR_41.py
@@ -63,7 +63,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Ocr_cases/rec_rec_svtrnet/SIR_43.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Ocr_cases/rec_rec_svtrnet/SIR_43.py
@@ -88,7 +88,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Ocr_cases/rec_rec_svtrnet/SIR_57.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Ocr_cases/rec_rec_svtrnet/SIR_57.py
@@ -83,7 +83,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Ocr_cases/rec_rec_svtrnet/SIR_70.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Ocr_cases/rec_rec_svtrnet/SIR_70.py
@@ -63,7 +63,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Ocr_cases/rec_rec_svtrnet/SIR_72.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Ocr_cases/rec_rec_svtrnet/SIR_72.py
@@ -83,7 +83,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Ocr_cases/rec_rec_svtrnet/SIR_87.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Ocr_cases/rec_rec_svtrnet/SIR_87.py
@@ -52,7 +52,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Ocr_cases/rec_rec_svtrnet_ch/SIR_13.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Ocr_cases/rec_rec_svtrnet_ch/SIR_13.py
@@ -88,7 +88,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Ocr_cases/rec_rec_svtrnet_ch/SIR_24.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Ocr_cases/rec_rec_svtrnet_ch/SIR_24.py
@@ -63,7 +63,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Ocr_cases/rec_rec_svtrnet_ch/SIR_26.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Ocr_cases/rec_rec_svtrnet_ch/SIR_26.py
@@ -88,7 +88,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Ocr_cases/rec_rec_svtrnet_ch/SIR_40.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Ocr_cases/rec_rec_svtrnet_ch/SIR_40.py
@@ -83,7 +83,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Ocr_cases/rec_rec_svtrnet_ch/SIR_53.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Ocr_cases/rec_rec_svtrnet_ch/SIR_53.py
@@ -63,7 +63,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Ocr_cases/rec_rec_svtrnet_ch/SIR_55.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Ocr_cases/rec_rec_svtrnet_ch/SIR_55.py
@@ -83,7 +83,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Ocr_cases/rec_rec_svtrnet_ch/SIR_70.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Ocr_cases/rec_rec_svtrnet_ch/SIR_70.py
@@ -52,7 +52,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Ocr_cases/table_SLANet/SIR_23.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Ocr_cases/table_SLANet/SIR_23.py
@@ -46,7 +46,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/danet_danet_resnet50_os8_cityscapes_1024x512_80k/SIR_31.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/danet_danet_resnet50_os8_cityscapes_1024x512_80k/SIR_31.py
@@ -61,7 +61,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/danet_danet_resnet50_os8_cityscapes_1024x512_80k/SIR_33.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/danet_danet_resnet50_os8_cityscapes_1024x512_80k/SIR_33.py
@@ -86,7 +86,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/danet_danet_resnet50_os8_cityscapes_1024x512_80k/SIR_34.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/danet_danet_resnet50_os8_cityscapes_1024x512_80k/SIR_34.py
@@ -83,7 +83,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/danet_danet_resnet50_os8_voc12aug_512x512_40k/SIR_31.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/danet_danet_resnet50_os8_voc12aug_512x512_40k/SIR_31.py
@@ -61,7 +61,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/danet_danet_resnet50_os8_voc12aug_512x512_40k/SIR_33.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/danet_danet_resnet50_os8_voc12aug_512x512_40k/SIR_33.py
@@ -86,7 +86,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/danet_danet_resnet50_os8_voc12aug_512x512_40k/SIR_34.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/danet_danet_resnet50_os8_voc12aug_512x512_40k/SIR_34.py
@@ -83,7 +83,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/dmnet_dmnet_resnet101_os8_cityscapes_1024x512_80k/SIR_32.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/dmnet_dmnet_resnet101_os8_cityscapes_1024x512_80k/SIR_32.py
@@ -49,7 +49,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/dmnet_dmnet_resnet101_os8_cityscapes_1024x512_80k/SIR_37.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/dmnet_dmnet_resnet101_os8_cityscapes_1024x512_80k/SIR_37.py
@@ -49,7 +49,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/dmnet_dmnet_resnet101_os8_cityscapes_1024x512_80k/SIR_41.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/dmnet_dmnet_resnet101_os8_cityscapes_1024x512_80k/SIR_41.py
@@ -49,7 +49,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/dmnet_dmnet_resnet101_os8_cityscapes_1024x512_80k/SIR_45.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/dmnet_dmnet_resnet101_os8_cityscapes_1024x512_80k/SIR_45.py
@@ -49,7 +49,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/dnlnet_dnlnet_resnet101_os8_cityscapes_1024x512_80k/SIR_34.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/dnlnet_dnlnet_resnet101_os8_cityscapes_1024x512_80k/SIR_34.py
@@ -52,7 +52,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/emanet_emanet_resnet101_os8_cityscapes_1024x512_80k/SIR_35.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/emanet_emanet_resnet101_os8_cityscapes_1024x512_80k/SIR_35.py
@@ -52,7 +52,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/emanet_emanet_resnet101_os8_voc12aug_512x512_40k/SIR_35.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/emanet_emanet_resnet101_os8_voc12aug_512x512_40k/SIR_35.py
@@ -52,7 +52,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/enet_enet_cityscapes_1024x512_80k/SIR_10.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/enet_enet_cityscapes_1024x512_80k/SIR_10.py
@@ -43,7 +43,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/enet_enet_cityscapes_1024x512_80k/SIR_20.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/enet_enet_cityscapes_1024x512_80k/SIR_20.py
@@ -48,7 +48,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/enet_enet_cityscapes_1024x512_80k/SIR_40.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/enet_enet_cityscapes_1024x512_80k/SIR_40.py
@@ -43,7 +43,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/enet_enet_cityscapes_1024x512_80k/SIR_46.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/enet_enet_cityscapes_1024x512_80k/SIR_46.py
@@ -48,7 +48,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/espnet_espnet_cityscapes_1024x512_120k/SIR_116.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/espnet_espnet_cityscapes_1024x512_120k/SIR_116.py
@@ -65,7 +65,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/espnet_espnet_cityscapes_1024x512_120k/SIR_12.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/espnet_espnet_cityscapes_1024x512_120k/SIR_12.py
@@ -65,7 +65,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/espnet_espnet_cityscapes_1024x512_120k/SIR_143.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/espnet_espnet_cityscapes_1024x512_120k/SIR_143.py
@@ -62,7 +62,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/espnet_espnet_cityscapes_1024x512_120k/SIR_20.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/espnet_espnet_cityscapes_1024x512_120k/SIR_20.py
@@ -59,7 +59,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/espnet_espnet_cityscapes_1024x512_120k/SIR_33.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/espnet_espnet_cityscapes_1024x512_120k/SIR_33.py
@@ -65,7 +65,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/espnet_espnet_cityscapes_1024x512_120k/SIR_38.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/espnet_espnet_cityscapes_1024x512_120k/SIR_38.py
@@ -59,7 +59,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/espnet_espnet_cityscapes_1024x512_120k/SIR_64.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/espnet_espnet_cityscapes_1024x512_120k/SIR_64.py
@@ -65,7 +65,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/espnet_espnet_cityscapes_1024x512_120k/SIR_75.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/espnet_espnet_cityscapes_1024x512_120k/SIR_75.py
@@ -59,7 +59,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/fastfcn_fastfcn_resnet50_os8_ade20k_480x480_120k/SIR_50.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/fastfcn_fastfcn_resnet50_os8_ade20k_480x480_120k/SIR_50.py
@@ -55,7 +55,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/ginet_ginet_resnet101_os8_ade20k_520x520_150k/SIR_41.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/ginet_ginet_resnet101_os8_ade20k_520x520_150k/SIR_41.py
@@ -48,7 +48,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/ginet_ginet_resnet101_os8_voc12aug_512x512_40k/SIR_41.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/ginet_ginet_resnet101_os8_voc12aug_512x512_40k/SIR_41.py
@@ -48,7 +48,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/ginet_ginet_resnet50_os8_cityscapes_1024x512_80k/SIR_41.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/ginet_ginet_resnet50_os8_cityscapes_1024x512_80k/SIR_41.py
@@ -48,7 +48,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/hardnet_hardnet_cityscapes_1024x1024_160k/SIR_126.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/hardnet_hardnet_cityscapes_1024x1024_160k/SIR_126.py
@@ -63,7 +63,7 @@ class TestLayer(unittest.TestCase):
 
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({"FLAGS_prim_all": with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/isanet_isanet_resnet101_os8_voc12aug_512x512_40k/SIR_33.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/isanet_isanet_resnet101_os8_voc12aug_512x512_40k/SIR_33.py
@@ -49,7 +49,7 @@ class TestLayer(unittest.TestCase):
 
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({"FLAGS_prim_all": with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/isanet_isanet_resnet101_os8_voc12aug_512x512_40k/SIR_34.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/isanet_isanet_resnet101_os8_voc12aug_512x512_40k/SIR_34.py
@@ -50,7 +50,7 @@ class TestLayer(unittest.TestCase):
 
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({"FLAGS_prim_all": with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/isanet_isanet_resnet101_os8_voc12aug_512x512_40k/SIR_35.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/isanet_isanet_resnet101_os8_voc12aug_512x512_40k/SIR_35.py
@@ -56,7 +56,7 @@ class TestLayer(unittest.TestCase):
 
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({"FLAGS_prim_all": with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/isanet_isanet_resnet101_os8_voc12aug_512x512_40k/SIR_38.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/isanet_isanet_resnet101_os8_voc12aug_512x512_40k/SIR_38.py
@@ -52,7 +52,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/isanet_isanet_resnet50_os8_cityscapes_769x769_80k/SIR_32.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/isanet_isanet_resnet50_os8_cityscapes_769x769_80k/SIR_32.py
@@ -63,7 +63,7 @@ class TestLayer(unittest.TestCase):
 
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({"FLAGS_prim_all": with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/isanet_isanet_resnet50_os8_cityscapes_769x769_80k/SIR_33.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/isanet_isanet_resnet50_os8_cityscapes_769x769_80k/SIR_33.py
@@ -50,7 +50,7 @@ class TestLayer(unittest.TestCase):
 
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({"FLAGS_prim_all": with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/isanet_isanet_resnet50_os8_cityscapes_769x769_80k/SIR_34.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/isanet_isanet_resnet50_os8_cityscapes_769x769_80k/SIR_34.py
@@ -56,7 +56,7 @@ class TestLayer(unittest.TestCase):
 
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({"FLAGS_prim_all": with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/isanet_isanet_resnet50_os8_cityscapes_769x769_80k/SIR_35.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/isanet_isanet_resnet50_os8_cityscapes_769x769_80k/SIR_35.py
@@ -58,7 +58,7 @@ class TestLayer(unittest.TestCase):
 
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({"FLAGS_prim_all": with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/isanet_isanet_resnet50_os8_cityscapes_769x769_80k/SIR_36.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/isanet_isanet_resnet50_os8_cityscapes_769x769_80k/SIR_36.py
@@ -52,7 +52,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/mobileseg_mobileseg_ghostnet_cityscapes_1024x512_80k/SIR_24.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/mobileseg_mobileseg_ghostnet_cityscapes_1024x512_80k/SIR_24.py
@@ -65,7 +65,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/mobileseg_mobileseg_ghostnet_cityscapes_1024x512_80k/SIR_29.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/mobileseg_mobileseg_ghostnet_cityscapes_1024x512_80k/SIR_29.py
@@ -65,7 +65,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/mobileseg_mobileseg_ghostnet_cityscapes_1024x512_80k/SIR_38.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/mobileseg_mobileseg_ghostnet_cityscapes_1024x512_80k/SIR_38.py
@@ -65,7 +65,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/mobileseg_mobileseg_ghostnet_cityscapes_1024x512_80k/SIR_43.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/mobileseg_mobileseg_ghostnet_cityscapes_1024x512_80k/SIR_43.py
@@ -65,7 +65,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/mobileseg_mobileseg_ghostnet_cityscapes_1024x512_80k/SIR_46.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/mobileseg_mobileseg_ghostnet_cityscapes_1024x512_80k/SIR_46.py
@@ -65,7 +65,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/mobileseg_mobileseg_ghostnet_cityscapes_1024x512_80k/SIR_53.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/mobileseg_mobileseg_ghostnet_cityscapes_1024x512_80k/SIR_53.py
@@ -65,7 +65,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/mobileseg_mobileseg_litehrnet18_cityscapes_1024x512_80k/SIR_111.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/mobileseg_mobileseg_litehrnet18_cityscapes_1024x512_80k/SIR_111.py
@@ -58,7 +58,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/mobileseg_mobileseg_litehrnet18_cityscapes_1024x512_80k/SIR_18.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/mobileseg_mobileseg_litehrnet18_cityscapes_1024x512_80k/SIR_18.py
@@ -53,7 +53,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/mobileseg_mobileseg_litehrnet18_cityscapes_1024x512_80k/SIR_199.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/mobileseg_mobileseg_litehrnet18_cityscapes_1024x512_80k/SIR_199.py
@@ -151,7 +151,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/mobileseg_mobileseg_litehrnet18_cityscapes_1024x512_80k/SIR_228.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/mobileseg_mobileseg_litehrnet18_cityscapes_1024x512_80k/SIR_228.py
@@ -65,7 +65,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/mobileseg_mobileseg_litehrnet18_cityscapes_1024x512_80k/SIR_284.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/mobileseg_mobileseg_litehrnet18_cityscapes_1024x512_80k/SIR_284.py
@@ -175,7 +175,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/mobileseg_mobileseg_litehrnet18_cityscapes_1024x512_80k/SIR_59.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/mobileseg_mobileseg_litehrnet18_cityscapes_1024x512_80k/SIR_59.py
@@ -113,7 +113,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/mobileseg_mobileseg_shufflenetv2_cityscapes_1024x512_80k/SIR_18.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/mobileseg_mobileseg_shufflenetv2_cityscapes_1024x512_80k/SIR_18.py
@@ -53,7 +53,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/mobileseg_mobileseg_shufflenetv2_cityscapes_1024x512_80k/SIR_27.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/mobileseg_mobileseg_shufflenetv2_cityscapes_1024x512_80k/SIR_27.py
@@ -53,7 +53,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/mobileseg_mobileseg_shufflenetv2_cityscapes_1024x512_80k/SIR_40.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/mobileseg_mobileseg_shufflenetv2_cityscapes_1024x512_80k/SIR_40.py
@@ -53,7 +53,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/ocrnet_ocrnet_hrnetw18_voc12aug_512x512_40k/SIR_36.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/ocrnet_ocrnet_hrnetw18_voc12aug_512x512_40k/SIR_36.py
@@ -52,7 +52,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/ocrnet_ocrnet_hrnetw48_cityscapes_1024x512_40k/SIR_36.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/ocrnet_ocrnet_hrnetw48_cityscapes_1024x512_40k/SIR_36.py
@@ -52,7 +52,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/pfpn_pfpn_resnet101_os8_cityscapes_512x1024_40k/SIR_68.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/pfpn_pfpn_resnet101_os8_cityscapes_512x1024_40k/SIR_68.py
@@ -52,7 +52,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/pp_humanseg_lite_pp_humanseg_lite_mini_supervisely/SIR_18.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/pp_humanseg_lite_pp_humanseg_lite_mini_supervisely/SIR_18.py
@@ -52,7 +52,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/pp_humanseg_lite_pp_humanseg_lite_mini_supervisely/SIR_37.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/pp_humanseg_lite_pp_humanseg_lite_mini_supervisely/SIR_37.py
@@ -52,7 +52,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/rtformer_rtformer_base_cityscapes_1024x512_120k/SIR_42.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/rtformer_rtformer_base_cityscapes_1024x512_120k/SIR_42.py
@@ -47,7 +47,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/rtformer_rtformer_slim_ade20k_512x512_160k/SIR_42.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/rtformer_rtformer_slim_ade20k_512x512_160k/SIR_42.py
@@ -47,7 +47,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/rtformer_rtformer_slim_cityscapes_1024x512_120k/SIR_42.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/rtformer_rtformer_slim_cityscapes_1024x512_120k/SIR_42.py
@@ -47,7 +47,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/segformer_segformer_b0_cityscapes_1024x1024_160k/SIR_12.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/segformer_segformer_b0_cityscapes_1024x1024_160k/SIR_12.py
@@ -96,7 +96,7 @@ class TestLayer(unittest.TestCase):
 
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({"FLAGS_prim_all": with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/segformer_segformer_b0_cityscapes_1024x1024_160k/SIR_14.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/segformer_segformer_b0_cityscapes_1024x1024_160k/SIR_14.py
@@ -140,7 +140,7 @@ class TestLayer(unittest.TestCase):
 
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({"FLAGS_prim_all": with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/segformer_segformer_b0_cityscapes_1024x1024_160k/SIR_2.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/segformer_segformer_b0_cityscapes_1024x1024_160k/SIR_2.py
@@ -66,7 +66,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/segformer_segformer_b0_cityscapes_1024x1024_160k/SIR_24.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/segformer_segformer_b0_cityscapes_1024x1024_160k/SIR_24.py
@@ -96,7 +96,7 @@ class TestLayer(unittest.TestCase):
 
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({"FLAGS_prim_all": with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/segformer_segformer_b0_cityscapes_1024x1024_160k/SIR_26.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/segformer_segformer_b0_cityscapes_1024x1024_160k/SIR_26.py
@@ -140,7 +140,7 @@ class TestLayer(unittest.TestCase):
 
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({"FLAGS_prim_all": with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/segformer_segformer_b0_cityscapes_1024x1024_160k/SIR_36.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/segformer_segformer_b0_cityscapes_1024x1024_160k/SIR_36.py
@@ -96,7 +96,7 @@ class TestLayer(unittest.TestCase):
 
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({"FLAGS_prim_all": with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/segformer_segformer_b0_cityscapes_1024x1024_160k/SIR_38.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/segformer_segformer_b0_cityscapes_1024x1024_160k/SIR_38.py
@@ -96,7 +96,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/segformer_segformer_b0_cityscapes_1024x1024_160k/SIR_5.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/segformer_segformer_b0_cityscapes_1024x1024_160k/SIR_5.py
@@ -140,7 +140,7 @@ class TestLayer(unittest.TestCase):
 
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({"FLAGS_prim_all": with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/segformer_segformer_b0_cityscapes_1024x512_160k/SIR_12.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/segformer_segformer_b0_cityscapes_1024x512_160k/SIR_12.py
@@ -96,7 +96,7 @@ class TestLayer(unittest.TestCase):
 
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({"FLAGS_prim_all": with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/segformer_segformer_b0_cityscapes_1024x512_160k/SIR_14.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/segformer_segformer_b0_cityscapes_1024x512_160k/SIR_14.py
@@ -140,7 +140,7 @@ class TestLayer(unittest.TestCase):
 
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({"FLAGS_prim_all": with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/segformer_segformer_b0_cityscapes_1024x512_160k/SIR_2.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/segformer_segformer_b0_cityscapes_1024x512_160k/SIR_2.py
@@ -66,7 +66,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/segformer_segformer_b0_cityscapes_1024x512_160k/SIR_24.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/segformer_segformer_b0_cityscapes_1024x512_160k/SIR_24.py
@@ -96,7 +96,7 @@ class TestLayer(unittest.TestCase):
 
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({"FLAGS_prim_all": with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/segformer_segformer_b0_cityscapes_1024x512_160k/SIR_26.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/segformer_segformer_b0_cityscapes_1024x512_160k/SIR_26.py
@@ -142,7 +142,7 @@ class TestLayer(unittest.TestCase):
 
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({"FLAGS_prim_all": with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/segformer_segformer_b0_cityscapes_1024x512_160k/SIR_36.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/segformer_segformer_b0_cityscapes_1024x512_160k/SIR_36.py
@@ -96,7 +96,7 @@ class TestLayer(unittest.TestCase):
 
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({"FLAGS_prim_all": with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/segformer_segformer_b0_cityscapes_1024x512_160k/SIR_38.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/segformer_segformer_b0_cityscapes_1024x512_160k/SIR_38.py
@@ -96,7 +96,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/segformer_segformer_b0_cityscapes_1024x512_160k/SIR_5.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/segformer_segformer_b0_cityscapes_1024x512_160k/SIR_5.py
@@ -142,7 +142,7 @@ class TestLayer(unittest.TestCase):
 
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({"FLAGS_prim_all": with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/segformer_segformer_b3_cityscapes_1024x1024_160k/SIR_104.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/segformer_segformer_b3_cityscapes_1024x1024_160k/SIR_104.py
@@ -96,7 +96,7 @@ class TestLayer(unittest.TestCase):
 
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({"FLAGS_prim_all": with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/segformer_segformer_b3_cityscapes_1024x1024_160k/SIR_106.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/segformer_segformer_b3_cityscapes_1024x1024_160k/SIR_106.py
@@ -96,7 +96,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/segformer_segformer_b3_cityscapes_1024x1024_160k/SIR_16.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/segformer_segformer_b3_cityscapes_1024x1024_160k/SIR_16.py
@@ -96,7 +96,7 @@ class TestLayer(unittest.TestCase):
 
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({"FLAGS_prim_all": with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/segformer_segformer_b3_cityscapes_1024x1024_160k/SIR_18.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/segformer_segformer_b3_cityscapes_1024x1024_160k/SIR_18.py
@@ -144,7 +144,7 @@ class TestLayer(unittest.TestCase):
 
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({"FLAGS_prim_all": with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/segformer_segformer_b3_cityscapes_1024x1024_160k/SIR_36.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/segformer_segformer_b3_cityscapes_1024x1024_160k/SIR_36.py
@@ -96,7 +96,7 @@ class TestLayer(unittest.TestCase):
 
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({"FLAGS_prim_all": with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/segformer_segformer_b3_cityscapes_1024x1024_160k/SIR_38.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/segformer_segformer_b3_cityscapes_1024x1024_160k/SIR_38.py
@@ -140,7 +140,7 @@ class TestLayer(unittest.TestCase):
 
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({"FLAGS_prim_all": with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/segformer_segformer_b3_cityscapes_1024x1024_160k/SIR_5.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/segformer_segformer_b3_cityscapes_1024x1024_160k/SIR_5.py
@@ -142,7 +142,7 @@ class TestLayer(unittest.TestCase):
 
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({"FLAGS_prim_all": with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/segformer_segformer_b3_cityscapes_1024x512_160k/SIR_104.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/segformer_segformer_b3_cityscapes_1024x512_160k/SIR_104.py
@@ -96,7 +96,7 @@ class TestLayer(unittest.TestCase):
 
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({"FLAGS_prim_all": with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/segformer_segformer_b3_cityscapes_1024x512_160k/SIR_106.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/segformer_segformer_b3_cityscapes_1024x512_160k/SIR_106.py
@@ -96,7 +96,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/segformer_segformer_b3_cityscapes_1024x512_160k/SIR_16.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/segformer_segformer_b3_cityscapes_1024x512_160k/SIR_16.py
@@ -96,7 +96,7 @@ class TestLayer(unittest.TestCase):
 
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({"FLAGS_prim_all": with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/segformer_segformer_b3_cityscapes_1024x512_160k/SIR_18.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/segformer_segformer_b3_cityscapes_1024x512_160k/SIR_18.py
@@ -140,7 +140,7 @@ class TestLayer(unittest.TestCase):
 
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({"FLAGS_prim_all": with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/segformer_segformer_b3_cityscapes_1024x512_160k/SIR_36.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/segformer_segformer_b3_cityscapes_1024x512_160k/SIR_36.py
@@ -96,7 +96,7 @@ class TestLayer(unittest.TestCase):
 
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({"FLAGS_prim_all": with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/segformer_segformer_b3_cityscapes_1024x512_160k/SIR_38.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/segformer_segformer_b3_cityscapes_1024x512_160k/SIR_38.py
@@ -142,7 +142,7 @@ class TestLayer(unittest.TestCase):
 
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({"FLAGS_prim_all": with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/segformer_segformer_b3_cityscapes_1024x512_160k/SIR_5.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/segformer_segformer_b3_cityscapes_1024x512_160k/SIR_5.py
@@ -144,7 +144,7 @@ class TestLayer(unittest.TestCase):
 
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({"FLAGS_prim_all": with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/segformer_segformer_b4_cityscapes_1024x1024_160k/SIR_152.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/segformer_segformer_b4_cityscapes_1024x1024_160k/SIR_152.py
@@ -71,7 +71,7 @@ class TestLayer(unittest.TestCase):
 
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({"FLAGS_prim_all": with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/segformer_segformer_b5_cityscapes_1024x512_160k/SIR_148.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/segformer_segformer_b5_cityscapes_1024x512_160k/SIR_148.py
@@ -71,7 +71,7 @@ class TestLayer(unittest.TestCase):
 
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({"FLAGS_prim_all": with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/segmenter_segmenter_vit_base_linear_ade20k_512x512_160k/SIR_63.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/segmenter_segmenter_vit_base_linear_ade20k_512x512_160k/SIR_63.py
@@ -68,7 +68,7 @@ class TestLayer(unittest.TestCase):
 
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({"FLAGS_prim_all": with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/segmenter_segmenter_vit_base_mask_ade20k_512x512_160k/SIR_1.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/segmenter_segmenter_vit_base_mask_ade20k_512x512_160k/SIR_1.py
@@ -63,7 +63,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/segmenter_segmenter_vit_base_mask_ade20k_512x512_160k/SIR_5.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/segmenter_segmenter_vit_base_mask_ade20k_512x512_160k/SIR_5.py
@@ -87,7 +87,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/segmenter_segmenter_vit_base_mask_ade20k_512x512_160k/SIR_63.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/segmenter_segmenter_vit_base_mask_ade20k_512x512_160k/SIR_63.py
@@ -58,7 +58,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/segmenter_segmenter_vit_base_mask_ade20k_512x512_160k/SIR_66.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/segmenter_segmenter_vit_base_mask_ade20k_512x512_160k/SIR_66.py
@@ -83,7 +83,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/segmenter_segmenter_vit_small_linear_ade20k_512x512_160k/SIR_63.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/segmenter_segmenter_vit_small_linear_ade20k_512x512_160k/SIR_63.py
@@ -68,7 +68,7 @@ class TestLayer(unittest.TestCase):
 
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({"FLAGS_prim_all": with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/segmenter_segmenter_vit_small_mask_ade20k_512x512_160k/SIR_5.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/segmenter_segmenter_vit_small_mask_ade20k_512x512_160k/SIR_5.py
@@ -87,7 +87,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/segmenter_segmenter_vit_small_mask_ade20k_512x512_160k/SIR_63.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/segmenter_segmenter_vit_small_mask_ade20k_512x512_160k/SIR_63.py
@@ -58,7 +58,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/segmenter_segmenter_vit_small_mask_ade20k_512x512_160k/SIR_66.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/segmenter_segmenter_vit_small_mask_ade20k_512x512_160k/SIR_66.py
@@ -83,7 +83,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/topformer_topformer_base_ade20k_512x512_160k/SIR_47.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/topformer_topformer_base_ade20k_512x512_160k/SIR_47.py
@@ -58,7 +58,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/topformer_topformer_small_ade20k_512x512_160k/SIR_128.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/topformer_topformer_small_ade20k_512x512_160k/SIR_128.py
@@ -52,7 +52,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/topformer_topformer_small_ade20k_512x512_160k/SIR_47.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/topformer_topformer_small_ade20k_512x512_160k/SIR_47.py
@@ -58,7 +58,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/topformer_topformer_tiny_ade20k_512x512_160k/SIR_126.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/topformer_topformer_tiny_ade20k_512x512_160k/SIR_126.py
@@ -52,7 +52,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/topformer_topformer_tiny_ade20k_512x512_160k/SIR_45.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/topformer_topformer_tiny_ade20k_512x512_160k/SIR_45.py
@@ -58,7 +58,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/uhrnet_fcn_uhrnetw18_small_cityscapes_1024x512_120k_bs3/SIR_40.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/uhrnet_fcn_uhrnetw18_small_cityscapes_1024x512_120k_bs3/SIR_40.py
@@ -52,7 +52,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/uhrnet_fcn_uhrnetw18_small_cityscapes_1024x512_120k_bs3/SIR_46.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/uhrnet_fcn_uhrnetw18_small_cityscapes_1024x512_120k_bs3/SIR_46.py
@@ -52,7 +52,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/uhrnet_fcn_uhrnetw18_small_cityscapes_1024x512_120k_bs3/SIR_52.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/uhrnet_fcn_uhrnetw18_small_cityscapes_1024x512_120k_bs3/SIR_52.py
@@ -52,7 +52,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/uhrnet_fcn_uhrnetw48_cityscapes_1024x512_120k_bs3/SIR_40.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/uhrnet_fcn_uhrnetw48_cityscapes_1024x512_120k_bs3/SIR_40.py
@@ -52,7 +52,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/uhrnet_fcn_uhrnetw48_cityscapes_1024x512_120k_bs3/SIR_46.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/uhrnet_fcn_uhrnetw48_cityscapes_1024x512_120k_bs3/SIR_46.py
@@ -52,7 +52,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/uhrnet_fcn_uhrnetw48_cityscapes_1024x512_120k_bs3/SIR_52.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/uhrnet_fcn_uhrnetw48_cityscapes_1024x512_120k_bs3/SIR_52.py
@@ -52,7 +52,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/unet_plusplus_unet_plusplus_cityscapes_1024x512_160k/SIR_22.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer1000/Seg_cases/unet_plusplus_unet_plusplus_cityscapes_1024x512_160k/SIR_22.py
@@ -93,7 +93,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Clas_cases/CSWinTransformer_CSWinTransformer_base_384/SIR_116.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Clas_cases/CSWinTransformer_CSWinTransformer_base_384/SIR_116.py
@@ -44,7 +44,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Clas_cases/CSWinTransformer_CSWinTransformer_base_384/SIR_178.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Clas_cases/CSWinTransformer_CSWinTransformer_base_384/SIR_178.py
@@ -38,7 +38,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Clas_cases/CSWinTransformer_CSWinTransformer_base_384/SIR_233.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Clas_cases/CSWinTransformer_CSWinTransformer_base_384/SIR_233.py
@@ -56,7 +56,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Clas_cases/CSWinTransformer_CSWinTransformer_base_384/SIR_283.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Clas_cases/CSWinTransformer_CSWinTransformer_base_384/SIR_283.py
@@ -54,7 +54,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Clas_cases/DLA_DLA102/SIR_24.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Clas_cases/DLA_DLA102/SIR_24.py
@@ -45,7 +45,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Clas_cases/DeiT_DeiT_tiny_distilled_patch16_224/SIR_4.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Clas_cases/DeiT_DeiT_tiny_distilled_patch16_224/SIR_4.py
@@ -75,7 +75,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Clas_cases/DeiT_DeiT_tiny_distilled_patch16_224/SIR_92.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Clas_cases/DeiT_DeiT_tiny_distilled_patch16_224/SIR_92.py
@@ -57,7 +57,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Clas_cases/Distillation_resnet34_distill_resnet18_afd/SIR_101.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Clas_cases/Distillation_resnet34_distill_resnet18_afd/SIR_101.py
@@ -88,7 +88,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Clas_cases/EfficientNet_EfficientNetB0/SIR_116.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Clas_cases/EfficientNet_EfficientNetB0/SIR_116.py
@@ -57,7 +57,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Clas_cases/EfficientNet_EfficientNetB0/SIR_128.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Clas_cases/EfficientNet_EfficientNetB0/SIR_128.py
@@ -45,7 +45,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Clas_cases/EfficientNet_EfficientNetB0/SIR_202.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Clas_cases/EfficientNet_EfficientNetB0/SIR_202.py
@@ -56,7 +56,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Clas_cases/EfficientNet_EfficientNetB0/SIR_96.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Clas_cases/EfficientNet_EfficientNetB0/SIR_96.py
@@ -46,7 +46,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Clas_cases/Inception_InceptionV4/SIR_40.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Clas_cases/Inception_InceptionV4/SIR_40.py
@@ -46,7 +46,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Clas_cases/LeViT_LeViT_128/SIR_32.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Clas_cases/LeViT_LeViT_128/SIR_32.py
@@ -40,7 +40,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Clas_cases/LeViT_LeViT_128/SIR_63.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Clas_cases/LeViT_LeViT_128/SIR_63.py
@@ -83,7 +83,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Clas_cases/LeViT_LeViT_128/SIR_74.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Clas_cases/LeViT_LeViT_128/SIR_74.py
@@ -86,7 +86,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Clas_cases/MixNet_MixNet_S/SIR_116.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Clas_cases/MixNet_MixNet_S/SIR_116.py
@@ -51,7 +51,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Clas_cases/MixNet_MixNet_S/SIR_80.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Clas_cases/MixNet_MixNet_S/SIR_80.py
@@ -58,7 +58,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Clas_cases/MixNet_MixNet_S/SIR_84.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Clas_cases/MixNet_MixNet_S/SIR_84.py
@@ -65,7 +65,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Clas_cases/MixNet_MixNet_S/SIR_93.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Clas_cases/MixNet_MixNet_S/SIR_93.py
@@ -72,7 +72,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Clas_cases/MobileViT_MobileViT_XXS/SIR_26.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Clas_cases/MobileViT_MobileViT_XXS/SIR_26.py
@@ -46,7 +46,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Clas_cases/PPHGNet_PPHGNet_tiny/SIR_82.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Clas_cases/PPHGNet_PPHGNet_tiny/SIR_82.py
@@ -50,7 +50,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Clas_cases/PeleeNet_PeleeNet/SIR_41.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Clas_cases/PeleeNet_PeleeNet/SIR_41.py
@@ -46,7 +46,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Clas_cases/ReXNet_ReXNet_3_0/SIR_60.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Clas_cases/ReXNet_ReXNet_3_0/SIR_60.py
@@ -46,7 +46,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Clas_cases/RedNet_RedNet38/SIR_35.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Clas_cases/RedNet_RedNet38/SIR_35.py
@@ -53,7 +53,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Clas_cases/Res2Net_Res2Net50_14w_8s/SIR_101.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Clas_cases/Res2Net_Res2Net50_14w_8s/SIR_101.py
@@ -43,7 +43,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Clas_cases/ResNet_ResNet50_amp_O1/SIR_28.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Clas_cases/ResNet_ResNet50_amp_O1/SIR_28.py
@@ -45,7 +45,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Clas_cases/SqueezeNet_SqueezeNet1_0/SIR_0.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Clas_cases/SqueezeNet_SqueezeNet1_0/SIR_0.py
@@ -308,7 +308,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Clas_cases/TNT_TNT_small/SIR_40.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Clas_cases/TNT_TNT_small/SIR_40.py
@@ -51,7 +51,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Clas_cases/Twins_alt_gvt_base/SIR_103.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Clas_cases/Twins_alt_gvt_base/SIR_103.py
@@ -81,7 +81,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Clas_cases/Twins_alt_gvt_base/SIR_114.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Clas_cases/Twins_alt_gvt_base/SIR_114.py
@@ -48,7 +48,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Clas_cases/Twins_alt_gvt_base/SIR_17.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Clas_cases/Twins_alt_gvt_base/SIR_17.py
@@ -51,7 +51,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Clas_cases/Twins_alt_gvt_base/SIR_209.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Clas_cases/Twins_alt_gvt_base/SIR_209.py
@@ -59,7 +59,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Clas_cases/Twins_alt_gvt_base/SIR_84.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Clas_cases/Twins_alt_gvt_base/SIR_84.py
@@ -55,7 +55,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Clas_cases/Xception_Xception65_deeplab/SIR_35.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Clas_cases/Xception_Xception65_deeplab/SIR_35.py
@@ -46,7 +46,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/faster_rcnn_faster_rcnn_swin_tiny_fpn_1x_coco/SIR_3.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/faster_rcnn_faster_rcnn_swin_tiny_fpn_1x_coco/SIR_3.py
@@ -59,7 +59,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/faster_rcnn_faster_rcnn_x101_vd_64x4d_fpn_2x_coco/SIR_35.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/faster_rcnn_faster_rcnn_x101_vd_64x4d_fpn_2x_coco/SIR_35.py
@@ -122,7 +122,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/faster_rcnn_faster_rcnn_x101_vd_64x4d_fpn_2x_coco/SIR_44.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/faster_rcnn_faster_rcnn_x101_vd_64x4d_fpn_2x_coco/SIR_44.py
@@ -104,7 +104,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/faster_rcnn_faster_rcnn_x101_vd_64x4d_fpn_2x_coco/SIR_49.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/faster_rcnn_faster_rcnn_x101_vd_64x4d_fpn_2x_coco/SIR_49.py
@@ -57,7 +57,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/faster_rcnn_faster_rcnn_x101_vd_64x4d_fpn_2x_coco/SIR_55.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/faster_rcnn_faster_rcnn_x101_vd_64x4d_fpn_2x_coco/SIR_55.py
@@ -47,7 +47,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/faster_rcnn_faster_rcnn_x101_vd_64x4d_fpn_2x_coco/SIR_56.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/faster_rcnn_faster_rcnn_x101_vd_64x4d_fpn_2x_coco/SIR_56.py
@@ -61,7 +61,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/faster_rcnn_faster_rcnn_x101_vd_64x4d_fpn_2x_coco/SIR_64.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/faster_rcnn_faster_rcnn_x101_vd_64x4d_fpn_2x_coco/SIR_64.py
@@ -48,7 +48,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/faster_rcnn_faster_rcnn_x101_vd_64x4d_fpn_2x_coco/SIR_66.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/faster_rcnn_faster_rcnn_x101_vd_64x4d_fpn_2x_coco/SIR_66.py
@@ -49,7 +49,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/faster_rcnn_faster_rcnn_x101_vd_64x4d_fpn_2x_coco/SIR_71.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/faster_rcnn_faster_rcnn_x101_vd_64x4d_fpn_2x_coco/SIR_71.py
@@ -65,7 +65,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/faster_rcnn_faster_rcnn_x101_vd_64x4d_fpn_2x_coco/SIR_72.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/faster_rcnn_faster_rcnn_x101_vd_64x4d_fpn_2x_coco/SIR_72.py
@@ -55,7 +55,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/fcos_fcos_r50_fpn_1x_coco/SIR_108.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/fcos_fcos_r50_fpn_1x_coco/SIR_108.py
@@ -70,7 +70,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/gfl_gfl_r101vd_fpn_mstrain_2x_coco/SIR_110.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/gfl_gfl_r101vd_fpn_mstrain_2x_coco/SIR_110.py
@@ -60,7 +60,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/gfl_gfl_r101vd_fpn_mstrain_2x_coco/SIR_143.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/gfl_gfl_r101vd_fpn_mstrain_2x_coco/SIR_143.py
@@ -55,7 +55,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/gfl_gfl_r101vd_fpn_mstrain_2x_coco/SIR_150.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/gfl_gfl_r101vd_fpn_mstrain_2x_coco/SIR_150.py
@@ -44,7 +44,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/gfl_gfl_r101vd_fpn_mstrain_2x_coco/SIR_158.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/gfl_gfl_r101vd_fpn_mstrain_2x_coco/SIR_158.py
@@ -79,7 +79,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/gfl_gfl_r101vd_fpn_mstrain_2x_coco/SIR_166.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/gfl_gfl_r101vd_fpn_mstrain_2x_coco/SIR_166.py
@@ -47,7 +47,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/gfl_gfl_r101vd_fpn_mstrain_2x_coco/SIR_35.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/gfl_gfl_r101vd_fpn_mstrain_2x_coco/SIR_35.py
@@ -117,7 +117,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/gfl_gflv2_r50_fpn_1x_coco/SIR_132.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/gfl_gflv2_r50_fpn_1x_coco/SIR_132.py
@@ -62,7 +62,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/gfl_gflv2_r50_fpn_1x_coco/SIR_149.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/gfl_gflv2_r50_fpn_1x_coco/SIR_149.py
@@ -46,7 +46,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/gn_cascade_rcnn_r50_fpn_gn_2x_coco/SIR_37.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/gn_cascade_rcnn_r50_fpn_gn_2x_coco/SIR_37.py
@@ -56,7 +56,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/hrnet_faster_rcnn_hrnetv2p_w18_1x_coco/SIR_29.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/hrnet_faster_rcnn_hrnetv2p_w18_1x_coco/SIR_29.py
@@ -81,7 +81,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/keypoint_higherhrnet_higherhrnet_hrnet_w32_512_swahr/SIR_31.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/keypoint_higherhrnet_higherhrnet_hrnet_w32_512_swahr/SIR_31.py
@@ -44,7 +44,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/keypoint_higherhrnet_higherhrnet_hrnet_w32_512_swahr/SIR_51.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/keypoint_higherhrnet_higherhrnet_hrnet_w32_512_swahr/SIR_51.py
@@ -49,7 +49,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/mask_rcnn_mask_rcnn_r50_fpn_2x_coco/SIR_116.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/mask_rcnn_mask_rcnn_r50_fpn_2x_coco/SIR_116.py
@@ -51,7 +51,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/mask_rcnn_mask_rcnn_r50_fpn_2x_coco/SIR_121.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/mask_rcnn_mask_rcnn_r50_fpn_2x_coco/SIR_121.py
@@ -61,7 +61,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/mot_fairmot_fairmot_enhance_hardnet85_30e_1088x608/SIR_84.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/mot_fairmot_fairmot_enhance_hardnet85_30e_1088x608/SIR_84.py
@@ -40,7 +40,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/mot_fairmot_fairmot_enhance_hardnet85_30e_1088x608/SIR_96.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/mot_fairmot_fairmot_enhance_hardnet85_30e_1088x608/SIR_96.py
@@ -39,7 +39,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/mot_jde_jde_darknet53_30e_864x480/SIR_75.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/mot_jde_jde_darknet53_30e_864x480/SIR_75.py
@@ -157,7 +157,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/mot_mcfairmot_mcfairmot_hrnetv2_w18_dlafpn_30e_1088x608_visdrone/SIR_24.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/mot_mcfairmot_mcfairmot_hrnetv2_w18_dlafpn_30e_1088x608_visdrone/SIR_24.py
@@ -52,7 +52,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/mot_ocsort_ocsort_ppyoloe/SIR_120.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/mot_ocsort_ocsort_ppyoloe/SIR_120.py
@@ -38,7 +38,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/mot_ocsort_ocsort_ppyoloe/SIR_160.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/mot_ocsort_ocsort_ppyoloe/SIR_160.py
@@ -94,7 +94,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/mot_ocsort_ocsort_ppyoloe/SIR_167.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/mot_ocsort_ocsort_ppyoloe/SIR_167.py
@@ -51,7 +51,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/mot_ocsort_ocsort_ppyoloe/SIR_173.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/mot_ocsort_ocsort_ppyoloe/SIR_173.py
@@ -57,7 +57,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/mot_ocsort_ocsort_ppyoloe/SIR_178.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/mot_ocsort_ocsort_ppyoloe/SIR_178.py
@@ -141,7 +141,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/mot_ocsort_ocsort_ppyoloe/SIR_179.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/mot_ocsort_ocsort_ppyoloe/SIR_179.py
@@ -45,7 +45,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/mot_ocsort_ocsort_ppyoloe/SIR_21.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/mot_ocsort_ocsort_ppyoloe/SIR_21.py
@@ -50,7 +50,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/mot_vehicle_fairmot_dla34_30e_1088x608_bdd100kmot_vehicle/SIR_79.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/mot_vehicle_fairmot_dla34_30e_1088x608_bdd100kmot_vehicle/SIR_79.py
@@ -55,7 +55,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/picodet_legacy_model_picodet_l_416_coco/SIR_17.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/picodet_legacy_model_picodet_l_416_coco/SIR_17.py
@@ -56,7 +56,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/picodet_legacy_model_picodet_l_416_coco/SIR_205.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/picodet_legacy_model_picodet_l_416_coco/SIR_205.py
@@ -46,7 +46,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/picodet_legacy_model_picodet_l_416_coco/SIR_296.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/picodet_legacy_model_picodet_l_416_coco/SIR_296.py
@@ -42,7 +42,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/picodet_legacy_model_picodet_l_416_coco/SIR_75.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/picodet_legacy_model_picodet_l_416_coco/SIR_75.py
@@ -60,7 +60,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/ppyolo_ppyolov2_r101vd_dcn_365e_coco/SIR_69.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/ppyolo_ppyolov2_r101vd_dcn_365e_coco/SIR_69.py
@@ -67,7 +67,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/ppyolo_ppyolov2_r101vd_dcn_365e_coco/SIR_75.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/ppyolo_ppyolov2_r101vd_dcn_365e_coco/SIR_75.py
@@ -79,7 +79,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/ppyolo_ppyolov2_r101vd_dcn_365e_coco/SIR_82.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/ppyolo_ppyolov2_r101vd_dcn_365e_coco/SIR_82.py
@@ -81,7 +81,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/rcnn_enhance_faster_rcnn_enhance_3x_coco/SIR_101.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/rcnn_enhance_faster_rcnn_enhance_3x_coco/SIR_101.py
@@ -43,7 +43,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/rcnn_enhance_faster_rcnn_enhance_3x_coco/SIR_106.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/rcnn_enhance_faster_rcnn_enhance_3x_coco/SIR_106.py
@@ -59,7 +59,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/rcnn_enhance_faster_rcnn_enhance_3x_coco/SIR_107.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/rcnn_enhance_faster_rcnn_enhance_3x_coco/SIR_107.py
@@ -121,7 +121,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/retinanet_retinanet_r101_distill_r50_2x_coco/SIR_34.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/retinanet_retinanet_r101_distill_r50_2x_coco/SIR_34.py
@@ -216,7 +216,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/retinanet_retinanet_r101_distill_r50_2x_coco/SIR_42.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/retinanet_retinanet_r101_distill_r50_2x_coco/SIR_42.py
@@ -42,7 +42,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/rotate_fcosr_fcosr_x50_3x_dota/SIR_35.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/rotate_fcosr_fcosr_x50_3x_dota/SIR_35.py
@@ -148,7 +148,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/rotate_fcosr_fcosr_x50_3x_dota/SIR_47.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/rotate_fcosr_fcosr_x50_3x_dota/SIR_47.py
@@ -46,7 +46,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/rotate_fcosr_fcosr_x50_3x_dota/SIR_68.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/rotate_fcosr_fcosr_x50_3x_dota/SIR_68.py
@@ -84,7 +84,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/rotate_fcosr_fcosr_x50_3x_dota/SIR_73.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/rotate_fcosr_fcosr_x50_3x_dota/SIR_73.py
@@ -82,7 +82,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/rotate_fcosr_fcosr_x50_3x_dota/SIR_92.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/rotate_fcosr_fcosr_x50_3x_dota/SIR_92.py
@@ -47,7 +47,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/rotate_ppyoloe_r_ppyoloe_r_crn_l_3x_dota/SIR_167.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/rotate_ppyoloe_r_ppyoloe_r_crn_l_3x_dota/SIR_167.py
@@ -102,7 +102,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/rotate_ppyoloe_r_ppyoloe_r_crn_l_3x_dota/SIR_174.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/rotate_ppyoloe_r_ppyoloe_r_crn_l_3x_dota/SIR_174.py
@@ -48,7 +48,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/rotate_ppyoloe_r_ppyoloe_r_crn_l_3x_dota/SIR_177.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/rotate_ppyoloe_r_ppyoloe_r_crn_l_3x_dota/SIR_177.py
@@ -56,7 +56,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/rotate_ppyoloe_r_ppyoloe_r_crn_l_3x_dota/SIR_184.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/rotate_ppyoloe_r_ppyoloe_r_crn_l_3x_dota/SIR_184.py
@@ -63,7 +63,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/rotate_s2anet_s2anet_conv_2x_dota/SIR_108.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/rotate_s2anet_s2anet_conv_2x_dota/SIR_108.py
@@ -45,7 +45,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/rotate_s2anet_s2anet_conv_2x_dota/SIR_33.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/rotate_s2anet_s2anet_conv_2x_dota/SIR_33.py
@@ -116,7 +116,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/smalldet_ppyoloe_plus_sod_crn_l_80e_coco/SIR_127.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/smalldet_ppyoloe_plus_sod_crn_l_80e_coco/SIR_127.py
@@ -79,7 +79,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/smalldet_ppyoloe_plus_sod_crn_l_80e_coco/SIR_174.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/smalldet_ppyoloe_plus_sod_crn_l_80e_coco/SIR_174.py
@@ -79,7 +79,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/solov2_solov2_r101_vd_fpn_3x_coco/SIR_47.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/solov2_solov2_r101_vd_fpn_3x_coco/SIR_47.py
@@ -56,7 +56,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/solov2_solov2_r50_fpn_1x_coco/SIR_50.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/solov2_solov2_r50_fpn_1x_coco/SIR_50.py
@@ -53,7 +53,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/sparse_rcnn_sparse_rcnn_r50_fpn_3x_pro300_coco/SIR_34.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/sparse_rcnn_sparse_rcnn_r50_fpn_3x_pro300_coco/SIR_34.py
@@ -63,7 +63,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/sparse_rcnn_sparse_rcnn_r50_fpn_3x_pro300_coco/SIR_36.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/sparse_rcnn_sparse_rcnn_r50_fpn_3x_pro300_coco/SIR_36.py
@@ -71,7 +71,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/sparse_rcnn_sparse_rcnn_r50_fpn_3x_pro300_coco/SIR_61.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/sparse_rcnn_sparse_rcnn_r50_fpn_3x_pro300_coco/SIR_61.py
@@ -46,7 +46,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/sparse_rcnn_sparse_rcnn_r50_fpn_3x_pro300_coco/SIR_62.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/sparse_rcnn_sparse_rcnn_r50_fpn_3x_pro300_coco/SIR_62.py
@@ -78,7 +78,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/ssd_ssd_vgg16_300_240e_voc/SIR_2.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/ssd_ssd_vgg16_300_240e_voc/SIR_2.py
@@ -278,7 +278,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/ssd_ssd_vgg16_300_240e_voc/SIR_3.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/ssd_ssd_vgg16_300_240e_voc/SIR_3.py
@@ -181,7 +181,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/ssd_ssdlite_ghostnet_320_coco/SIR_80.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/ssd_ssdlite_ghostnet_320_coco/SIR_80.py
@@ -58,7 +58,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/ssd_ssdlite_mobilenet_v3_small_320_coco/SIR_158.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/ssd_ssdlite_mobilenet_v3_small_320_coco/SIR_158.py
@@ -53,7 +53,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/ssd_ssdlite_mobilenet_v3_small_320_coco/SIR_163.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/ssd_ssdlite_mobilenet_v3_small_320_coco/SIR_163.py
@@ -53,7 +53,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/tood_tood_r50_fpn_1x_coco/SIR_34.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/tood_tood_r50_fpn_1x_coco/SIR_34.py
@@ -141,7 +141,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/vitdet_ppyoloe_vit_base_csppan_cae_36e_coco/SIR_6.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/vitdet_ppyoloe_vit_base_csppan_cae_36e_coco/SIR_6.py
@@ -90,7 +90,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/yolox_yolox_cdn_tiny_300e_coco/SIR_117.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/yolox_yolox_cdn_tiny_300e_coco/SIR_117.py
@@ -48,7 +48,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/yolox_yolox_cdn_tiny_300e_coco/SIR_124.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/yolox_yolox_cdn_tiny_300e_coco/SIR_124.py
@@ -149,7 +149,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/yolox_yolox_cdn_tiny_300e_coco/SIR_6.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Det_cases/yolox_yolox_cdn_tiny_300e_coco/SIR_6.py
@@ -39,7 +39,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Ocr_cases/det_ch_PP_OCRv3_ch_PP_OCRv3_det_cml/SIR_30.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Ocr_cases/det_ch_PP_OCRv3_ch_PP_OCRv3_det_cml/SIR_30.py
@@ -277,7 +277,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Ocr_cases/det_ch_PP_OCRv3_ch_PP_OCRv3_det_cml/SIR_33.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Ocr_cases/det_ch_PP_OCRv3_ch_PP_OCRv3_det_cml/SIR_33.py
@@ -43,7 +43,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Ocr_cases/det_ch_PP_OCRv3_ch_PP_OCRv3_det_cml/SIR_43.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Ocr_cases/det_ch_PP_OCRv3_ch_PP_OCRv3_det_cml/SIR_43.py
@@ -131,7 +131,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Ocr_cases/rec_rec_svtrnet/SIR_15.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Ocr_cases/rec_rec_svtrnet/SIR_15.py
@@ -42,7 +42,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Ocr_cases/rec_rec_svtrnet/SIR_41.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Ocr_cases/rec_rec_svtrnet/SIR_41.py
@@ -56,7 +56,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Ocr_cases/rec_rec_svtrnet/SIR_43.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Ocr_cases/rec_rec_svtrnet/SIR_43.py
@@ -79,7 +79,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Ocr_cases/rec_rec_svtrnet/SIR_57.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Ocr_cases/rec_rec_svtrnet/SIR_57.py
@@ -75,7 +75,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Ocr_cases/rec_rec_svtrnet/SIR_87.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Ocr_cases/rec_rec_svtrnet/SIR_87.py
@@ -45,7 +45,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Ocr_cases/table_SLANet/SIR_23.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Ocr_cases/table_SLANet/SIR_23.py
@@ -39,7 +39,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Seg_cases/danet_danet_resnet101_os8_cityscapes_1024x512_80k/SIR_31.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Seg_cases/danet_danet_resnet101_os8_cityscapes_1024x512_80k/SIR_31.py
@@ -54,7 +54,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Seg_cases/danet_danet_resnet101_os8_cityscapes_1024x512_80k/SIR_33.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Seg_cases/danet_danet_resnet101_os8_cityscapes_1024x512_80k/SIR_33.py
@@ -79,7 +79,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Seg_cases/danet_danet_resnet101_os8_cityscapes_1024x512_80k/SIR_34.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Seg_cases/danet_danet_resnet101_os8_cityscapes_1024x512_80k/SIR_34.py
@@ -73,7 +73,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Seg_cases/dmnet_dmnet_resnet101_os8_cityscapes_1024x512_80k/SIR_41.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Seg_cases/dmnet_dmnet_resnet101_os8_cityscapes_1024x512_80k/SIR_41.py
@@ -41,7 +41,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Seg_cases/enet_enet_cityscapes_1024x512_80k/SIR_40.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Seg_cases/enet_enet_cityscapes_1024x512_80k/SIR_40.py
@@ -35,7 +35,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Seg_cases/enet_enet_cityscapes_1024x512_80k/SIR_46.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Seg_cases/enet_enet_cityscapes_1024x512_80k/SIR_46.py
@@ -39,7 +39,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Seg_cases/espnet_espnet_cityscapes_1024x512_120k/SIR_116.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Seg_cases/espnet_espnet_cityscapes_1024x512_120k/SIR_116.py
@@ -58,7 +58,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Seg_cases/espnet_espnet_cityscapes_1024x512_120k/SIR_143.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Seg_cases/espnet_espnet_cityscapes_1024x512_120k/SIR_143.py
@@ -52,7 +52,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Seg_cases/espnet_espnet_cityscapes_1024x512_120k/SIR_75.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Seg_cases/espnet_espnet_cityscapes_1024x512_120k/SIR_75.py
@@ -50,7 +50,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Seg_cases/ginet_ginet_resnet50_os8_cityscapes_1024x512_80k/SIR_41.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Seg_cases/ginet_ginet_resnet50_os8_cityscapes_1024x512_80k/SIR_41.py
@@ -40,7 +40,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Seg_cases/hardnet_hardnet_cityscapes_1024x1024_160k/SIR_126.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Seg_cases/hardnet_hardnet_cityscapes_1024x1024_160k/SIR_126.py
@@ -47,7 +47,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Seg_cases/isanet_isanet_resnet101_os8_voc12aug_512x512_40k/SIR_33.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Seg_cases/isanet_isanet_resnet101_os8_voc12aug_512x512_40k/SIR_33.py
@@ -47,7 +47,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Seg_cases/isanet_isanet_resnet101_os8_voc12aug_512x512_40k/SIR_34.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Seg_cases/isanet_isanet_resnet101_os8_voc12aug_512x512_40k/SIR_34.py
@@ -48,7 +48,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Seg_cases/isanet_isanet_resnet101_os8_voc12aug_512x512_40k/SIR_35.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Seg_cases/isanet_isanet_resnet101_os8_voc12aug_512x512_40k/SIR_35.py
@@ -54,7 +54,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Seg_cases/isanet_isanet_resnet50_os8_cityscapes_769x769_80k/SIR_32.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Seg_cases/isanet_isanet_resnet50_os8_cityscapes_769x769_80k/SIR_32.py
@@ -63,7 +63,7 @@ class TestLayer(unittest.TestCase):
 
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({"FLAGS_prim_all": with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Seg_cases/isanet_isanet_resnet50_os8_cityscapes_769x769_80k/SIR_35.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Seg_cases/isanet_isanet_resnet50_os8_cityscapes_769x769_80k/SIR_35.py
@@ -58,7 +58,7 @@ class TestLayer(unittest.TestCase):
 
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({"FLAGS_prim_all": with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Seg_cases/mobileseg_mobileseg_litehrnet18_cityscapes_1024x512_80k/SIR_111.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Seg_cases/mobileseg_mobileseg_litehrnet18_cityscapes_1024x512_80k/SIR_111.py
@@ -49,7 +49,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Seg_cases/mobileseg_mobileseg_litehrnet18_cityscapes_1024x512_80k/SIR_18.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Seg_cases/mobileseg_mobileseg_litehrnet18_cityscapes_1024x512_80k/SIR_18.py
@@ -45,7 +45,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Seg_cases/mobileseg_mobileseg_litehrnet18_cityscapes_1024x512_80k/SIR_197.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Seg_cases/mobileseg_mobileseg_litehrnet18_cityscapes_1024x512_80k/SIR_197.py
@@ -139,7 +139,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Seg_cases/mobileseg_mobileseg_litehrnet18_cityscapes_1024x512_80k/SIR_228.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Seg_cases/mobileseg_mobileseg_litehrnet18_cityscapes_1024x512_80k/SIR_228.py
@@ -55,7 +55,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Seg_cases/mobileseg_mobileseg_litehrnet18_cityscapes_1024x512_80k/SIR_282.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Seg_cases/mobileseg_mobileseg_litehrnet18_cityscapes_1024x512_80k/SIR_282.py
@@ -175,7 +175,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Seg_cases/mobileseg_mobileseg_litehrnet18_cityscapes_1024x512_80k/SIR_82.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Seg_cases/mobileseg_mobileseg_litehrnet18_cityscapes_1024x512_80k/SIR_82.py
@@ -103,7 +103,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Seg_cases/ocrnet_ocrnet_hrnetw18_voc12aug_512x512_40k/SIR_36.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Seg_cases/ocrnet_ocrnet_hrnetw18_voc12aug_512x512_40k/SIR_36.py
@@ -44,7 +44,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Seg_cases/pp_humanseg_lite_pp_humanseg_lite_mini_supervisely/SIR_18.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Seg_cases/pp_humanseg_lite_pp_humanseg_lite_mini_supervisely/SIR_18.py
@@ -44,7 +44,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Seg_cases/rtformer_rtformer_slim_cityscapes_1024x512_120k/SIR_34.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Seg_cases/rtformer_rtformer_slim_cityscapes_1024x512_120k/SIR_34.py
@@ -40,7 +40,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Seg_cases/segformer_segformer_b2_cityscapes_1024x1024_160k/SIR_18.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Seg_cases/segformer_segformer_b2_cityscapes_1024x1024_160k/SIR_18.py
@@ -116,7 +116,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Seg_cases/segformer_segformer_b2_cityscapes_1024x1024_160k/SIR_2.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Seg_cases/segformer_segformer_b2_cityscapes_1024x1024_160k/SIR_2.py
@@ -59,7 +59,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Seg_cases/segformer_segformer_b2_cityscapes_1024x1024_160k/SIR_64.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Seg_cases/segformer_segformer_b2_cityscapes_1024x1024_160k/SIR_64.py
@@ -77,7 +77,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Seg_cases/segformer_segformer_b2_cityscapes_1024x1024_160k/SIR_66.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Seg_cases/segformer_segformer_b2_cityscapes_1024x1024_160k/SIR_66.py
@@ -88,7 +88,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Seg_cases/segformer_segformer_b5_cityscapes_1024x512_160k/SIR_148.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Seg_cases/segformer_segformer_b5_cityscapes_1024x512_160k/SIR_148.py
@@ -56,7 +56,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Seg_cases/segmenter_segmenter_vit_base_linear_ade20k_512x512_160k/SIR_63.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Seg_cases/segmenter_segmenter_vit_base_linear_ade20k_512x512_160k/SIR_63.py
@@ -52,7 +52,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Seg_cases/segmenter_segmenter_vit_small_mask_ade20k_512x512_160k/SIR_1.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Seg_cases/segmenter_segmenter_vit_small_mask_ade20k_512x512_160k/SIR_1.py
@@ -56,7 +56,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Seg_cases/segmenter_segmenter_vit_small_mask_ade20k_512x512_160k/SIR_63.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Seg_cases/segmenter_segmenter_vit_small_mask_ade20k_512x512_160k/SIR_63.py
@@ -51,7 +51,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Seg_cases/segmenter_segmenter_vit_small_mask_ade20k_512x512_160k/SIR_66.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Seg_cases/segmenter_segmenter_vit_small_mask_ade20k_512x512_160k/SIR_66.py
@@ -75,7 +75,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Seg_cases/topformer_topformer_tiny_ade20k_512x512_160k/SIR_126.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Seg_cases/topformer_topformer_tiny_ade20k_512x512_160k/SIR_126.py
@@ -44,7 +44,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Seg_cases/topformer_topformer_tiny_ade20k_512x512_160k/SIR_45.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Seg_cases/topformer_topformer_tiny_ade20k_512x512_160k/SIR_45.py
@@ -48,7 +48,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Seg_cases/uhrnet_fcn_uhrnetw18_small_cityscapes_1024x512_120k_bs3/SIR_52.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Seg_cases/uhrnet_fcn_uhrnetw18_small_cityscapes_1024x512_120k_bs3/SIR_52.py
@@ -44,7 +44,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer160/Seg_cases/unet_plusplus_unet_plusplus_cityscapes_1024x512_160k/SIR_22.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer160/Seg_cases/unet_plusplus_unet_plusplus_cityscapes_1024x512_160k/SIR_22.py
@@ -83,7 +83,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Det_cases/cascade_rcnn_cascade_mask_rcnn_r50_vd_fpn_ssld_1x_coco/SIR_148.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Det_cases/cascade_rcnn_cascade_mask_rcnn_r50_vd_fpn_ssld_1x_coco/SIR_148.py
@@ -61,7 +61,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Det_cases/dcn_faster_rcnn_dcn_r101_vd_fpn_1x_coco/SIR_35.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Det_cases/dcn_faster_rcnn_dcn_r101_vd_fpn_1x_coco/SIR_35.py
@@ -122,7 +122,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Det_cases/dcn_faster_rcnn_dcn_r101_vd_fpn_1x_coco/SIR_56.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Det_cases/dcn_faster_rcnn_dcn_r101_vd_fpn_1x_coco/SIR_56.py
@@ -61,7 +61,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Det_cases/dcn_faster_rcnn_dcn_r50_vd_fpn_2x_coco/SIR_56.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Det_cases/dcn_faster_rcnn_dcn_r50_vd_fpn_2x_coco/SIR_56.py
@@ -61,7 +61,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Det_cases/faster_rcnn_faster_rcnn_r101_fpn_2x_coco/SIR_33.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Det_cases/faster_rcnn_faster_rcnn_r101_fpn_2x_coco/SIR_33.py
@@ -122,7 +122,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Det_cases/faster_rcnn_faster_rcnn_r101_fpn_2x_coco/SIR_54.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Det_cases/faster_rcnn_faster_rcnn_r101_fpn_2x_coco/SIR_54.py
@@ -61,7 +61,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Det_cases/faster_rcnn_faster_rcnn_r101_vd_fpn_1x_coco/SIR_35.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Det_cases/faster_rcnn_faster_rcnn_r101_vd_fpn_1x_coco/SIR_35.py
@@ -122,7 +122,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Det_cases/faster_rcnn_faster_rcnn_r101_vd_fpn_1x_coco/SIR_56.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Det_cases/faster_rcnn_faster_rcnn_r101_vd_fpn_1x_coco/SIR_56.py
@@ -61,7 +61,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Det_cases/faster_rcnn_faster_rcnn_r34_vd_fpn_1x_coco/SIR_33.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Det_cases/faster_rcnn_faster_rcnn_r34_vd_fpn_1x_coco/SIR_33.py
@@ -122,7 +122,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Det_cases/faster_rcnn_faster_rcnn_r50_vd_fpn_2x_coco/SIR_35.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Det_cases/faster_rcnn_faster_rcnn_r50_vd_fpn_2x_coco/SIR_35.py
@@ -122,7 +122,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Det_cases/faster_rcnn_faster_rcnn_r50_vd_fpn_2x_coco/SIR_56.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Det_cases/faster_rcnn_faster_rcnn_r50_vd_fpn_2x_coco/SIR_56.py
@@ -61,7 +61,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Det_cases/faster_rcnn_faster_rcnn_r50_vd_fpn_ssld_1x_coco/SIR_35.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Det_cases/faster_rcnn_faster_rcnn_r50_vd_fpn_ssld_1x_coco/SIR_35.py
@@ -122,7 +122,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Det_cases/faster_rcnn_faster_rcnn_r50_vd_fpn_ssld_1x_coco/SIR_56.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Det_cases/faster_rcnn_faster_rcnn_r50_vd_fpn_ssld_1x_coco/SIR_56.py
@@ -61,7 +61,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Det_cases/faster_rcnn_faster_rcnn_swin_tiny_fpn_1x_coco/SIR_85.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Det_cases/faster_rcnn_faster_rcnn_swin_tiny_fpn_1x_coco/SIR_85.py
@@ -122,7 +122,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Det_cases/faster_rcnn_faster_rcnn_swin_tiny_fpn_2x_coco/SIR_106.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Det_cases/faster_rcnn_faster_rcnn_swin_tiny_fpn_2x_coco/SIR_106.py
@@ -61,7 +61,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Det_cases/faster_rcnn_faster_rcnn_swin_tiny_fpn_2x_coco/SIR_85.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Det_cases/faster_rcnn_faster_rcnn_swin_tiny_fpn_2x_coco/SIR_85.py
@@ -122,7 +122,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Det_cases/fcos_fcos_r50_fpn_1x_coco/SIR_33.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Det_cases/fcos_fcos_r50_fpn_1x_coco/SIR_33.py
@@ -117,7 +117,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Det_cases/fcos_fcos_r50_fpn_iou_1x_coco/SIR_33.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Det_cases/fcos_fcos_r50_fpn_iou_1x_coco/SIR_33.py
@@ -117,7 +117,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Det_cases/fcos_fcos_r50_fpn_multiscale_2x_coco/SIR_33.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Det_cases/fcos_fcos_r50_fpn_multiscale_2x_coco/SIR_33.py
@@ -117,7 +117,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Det_cases/gfl_gfl_r101vd_fpn_mstrain_2x_coco/SIR_35.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Det_cases/gfl_gfl_r101vd_fpn_mstrain_2x_coco/SIR_35.py
@@ -117,7 +117,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Det_cases/gfl_gfl_r18vd_1x_coco/SIR_35.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Det_cases/gfl_gfl_r18vd_1x_coco/SIR_35.py
@@ -117,7 +117,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Det_cases/hrnet_faster_rcnn_hrnetv2p_w18_1x_coco/SIR_29.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Det_cases/hrnet_faster_rcnn_hrnetv2p_w18_1x_coco/SIR_29.py
@@ -81,7 +81,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Det_cases/hrnet_faster_rcnn_hrnetv2p_w18_1x_coco/SIR_50.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Det_cases/hrnet_faster_rcnn_hrnetv2p_w18_1x_coco/SIR_50.py
@@ -61,7 +61,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Det_cases/hrnet_faster_rcnn_hrnetv2p_w18_2x_coco/SIR_29.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Det_cases/hrnet_faster_rcnn_hrnetv2p_w18_2x_coco/SIR_29.py
@@ -81,7 +81,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Det_cases/hrnet_faster_rcnn_hrnetv2p_w18_2x_coco/SIR_60.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Det_cases/hrnet_faster_rcnn_hrnetv2p_w18_2x_coco/SIR_60.py
@@ -49,7 +49,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Det_cases/mask_rcnn_mask_rcnn_r50_fpn_1x_coco/SIR_54.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Det_cases/mask_rcnn_mask_rcnn_r50_fpn_1x_coco/SIR_54.py
@@ -61,7 +61,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Det_cases/mask_rcnn_mask_rcnn_r50_fpn_2x_coco/SIR_112.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Det_cases/mask_rcnn_mask_rcnn_r50_fpn_2x_coco/SIR_112.py
@@ -61,7 +61,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Det_cases/mask_rcnn_mask_rcnn_r50_vd_fpn_1x_coco/SIR_56.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Det_cases/mask_rcnn_mask_rcnn_r50_vd_fpn_1x_coco/SIR_56.py
@@ -61,7 +61,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Det_cases/mask_rcnn_mask_rcnn_x101_vd_64x4d_fpn_2x_coco/SIR_111.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Det_cases/mask_rcnn_mask_rcnn_x101_vd_64x4d_fpn_2x_coco/SIR_111.py
@@ -61,7 +61,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Det_cases/mask_rcnn_mask_rcnn_x101_vd_64x4d_fpn_2x_coco/SIR_35.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Det_cases/mask_rcnn_mask_rcnn_x101_vd_64x4d_fpn_2x_coco/SIR_35.py
@@ -122,7 +122,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Det_cases/mask_rcnn_mask_rcnn_x101_vd_64x4d_fpn_2x_coco/SIR_56.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Det_cases/mask_rcnn_mask_rcnn_x101_vd_64x4d_fpn_2x_coco/SIR_56.py
@@ -61,7 +61,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Det_cases/mot_jde_jde_darknet53_30e_1088x608/SIR_51.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Det_cases/mot_jde_jde_darknet53_30e_1088x608/SIR_51.py
@@ -67,7 +67,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Det_cases/mot_jde_jde_darknet53_30e_1088x608/SIR_63.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Det_cases/mot_jde_jde_darknet53_30e_1088x608/SIR_63.py
@@ -67,7 +67,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Det_cases/mot_jde_jde_darknet53_30e_576x320/SIR_51.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Det_cases/mot_jde_jde_darknet53_30e_576x320/SIR_51.py
@@ -67,7 +67,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Det_cases/mot_jde_jde_darknet53_30e_576x320/SIR_63.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Det_cases/mot_jde_jde_darknet53_30e_576x320/SIR_63.py
@@ -67,7 +67,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Det_cases/mot_jde_jde_darknet53_30e_864x480/SIR_51.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Det_cases/mot_jde_jde_darknet53_30e_864x480/SIR_51.py
@@ -67,7 +67,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Det_cases/mot_jde_jde_darknet53_30e_864x480/SIR_63.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Det_cases/mot_jde_jde_darknet53_30e_864x480/SIR_63.py
@@ -67,7 +67,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Det_cases/ppyolo_ppyolo_r50vd_dcn_1x_coco/SIR_52.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Det_cases/ppyolo_ppyolo_r50vd_dcn_1x_coco/SIR_52.py
@@ -67,7 +67,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Det_cases/ppyolo_ppyolo_r50vd_dcn_2x_coco/SIR_52.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Det_cases/ppyolo_ppyolo_r50vd_dcn_2x_coco/SIR_52.py
@@ -67,7 +67,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Det_cases/ppyolo_ppyolo_r50vd_dcn_voc/SIR_52.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Det_cases/ppyolo_ppyolo_r50vd_dcn_voc/SIR_52.py
@@ -67,7 +67,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Det_cases/ppyolo_ppyolov2_r101vd_dcn_365e_coco/SIR_69.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Det_cases/ppyolo_ppyolov2_r101vd_dcn_365e_coco/SIR_69.py
@@ -67,7 +67,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Det_cases/ppyolo_ppyolov2_r50vd_dcn_365e_coco/SIR_69.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Det_cases/ppyolo_ppyolov2_r50vd_dcn_365e_coco/SIR_69.py
@@ -67,7 +67,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Det_cases/rcnn_enhance_faster_rcnn_enhance_3x_coco/SIR_35.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Det_cases/rcnn_enhance_faster_rcnn_enhance_3x_coco/SIR_35.py
@@ -122,7 +122,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Det_cases/rcnn_enhance_faster_rcnn_enhance_3x_coco/SIR_56.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Det_cases/rcnn_enhance_faster_rcnn_enhance_3x_coco/SIR_56.py
@@ -61,7 +61,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Det_cases/res2net_mask_rcnn_res2net50_vd_26w_4s_fpn_2x_coco/SIR_135.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Det_cases/res2net_mask_rcnn_res2net50_vd_26w_4s_fpn_2x_coco/SIR_135.py
@@ -61,7 +61,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Det_cases/retinanet_retinanet_r101_fpn_2x_coco/SIR_33.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Det_cases/retinanet_retinanet_r101_fpn_2x_coco/SIR_33.py
@@ -117,7 +117,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Det_cases/retinanet_retinanet_r101_fpn_2x_coco/SIR_34.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Det_cases/retinanet_retinanet_r101_fpn_2x_coco/SIR_34.py
@@ -216,7 +216,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Det_cases/retinanet_retinanet_r50_fpn_1x_coco/SIR_33.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Det_cases/retinanet_retinanet_r50_fpn_1x_coco/SIR_33.py
@@ -117,7 +117,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Det_cases/retinanet_retinanet_r50_fpn_1x_coco/SIR_34.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Det_cases/retinanet_retinanet_r50_fpn_1x_coco/SIR_34.py
@@ -216,7 +216,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Det_cases/rotate_fcosr_fcosr_x50_3x_dota/SIR_33.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Det_cases/rotate_fcosr_fcosr_x50_3x_dota/SIR_33.py
@@ -117,7 +117,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Det_cases/rotate_ppyoloe_r_ppyoloe_r_crn_l_3x_dota/SIR_172.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Det_cases/rotate_ppyoloe_r_ppyoloe_r_crn_l_3x_dota/SIR_172.py
@@ -56,7 +56,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Det_cases/rotate_ppyoloe_r_ppyoloe_r_crn_l_3x_dota/SIR_177.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Det_cases/rotate_ppyoloe_r_ppyoloe_r_crn_l_3x_dota/SIR_177.py
@@ -56,7 +56,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Det_cases/rotate_ppyoloe_r_ppyoloe_r_crn_l_3x_dota/SIR_182.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Det_cases/rotate_ppyoloe_r_ppyoloe_r_crn_l_3x_dota/SIR_182.py
@@ -56,7 +56,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Det_cases/rotate_ppyoloe_r_ppyoloe_r_crn_m_3x_dota_ms/SIR_173.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Det_cases/rotate_ppyoloe_r_ppyoloe_r_crn_m_3x_dota_ms/SIR_173.py
@@ -56,7 +56,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Det_cases/rotate_ppyoloe_r_ppyoloe_r_crn_m_3x_dota_ms/SIR_178.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Det_cases/rotate_ppyoloe_r_ppyoloe_r_crn_m_3x_dota_ms/SIR_178.py
@@ -56,7 +56,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Det_cases/rotate_ppyoloe_r_ppyoloe_r_crn_m_3x_dota_ms/SIR_183.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Det_cases/rotate_ppyoloe_r_ppyoloe_r_crn_m_3x_dota_ms/SIR_183.py
@@ -56,7 +56,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Det_cases/rotate_ppyoloe_r_ppyoloe_r_crn_s_3x_dota/SIR_174.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Det_cases/rotate_ppyoloe_r_ppyoloe_r_crn_s_3x_dota/SIR_174.py
@@ -56,7 +56,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Det_cases/rotate_ppyoloe_r_ppyoloe_r_crn_s_3x_dota/SIR_179.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Det_cases/rotate_ppyoloe_r_ppyoloe_r_crn_s_3x_dota/SIR_179.py
@@ -56,7 +56,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Det_cases/rotate_ppyoloe_r_ppyoloe_r_crn_s_3x_dota/SIR_184.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Det_cases/rotate_ppyoloe_r_ppyoloe_r_crn_s_3x_dota/SIR_184.py
@@ -56,7 +56,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Det_cases/rotate_ppyoloe_r_ppyoloe_r_crn_x_3x_dota/SIR_172.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Det_cases/rotate_ppyoloe_r_ppyoloe_r_crn_x_3x_dota/SIR_172.py
@@ -56,7 +56,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Det_cases/rotate_ppyoloe_r_ppyoloe_r_crn_x_3x_dota/SIR_177.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Det_cases/rotate_ppyoloe_r_ppyoloe_r_crn_x_3x_dota/SIR_177.py
@@ -56,7 +56,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Det_cases/rotate_ppyoloe_r_ppyoloe_r_crn_x_3x_dota/SIR_182.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Det_cases/rotate_ppyoloe_r_ppyoloe_r_crn_x_3x_dota/SIR_182.py
@@ -56,7 +56,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Det_cases/rotate_s2anet_s2anet_conv_2x_dota/SIR_33.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Det_cases/rotate_s2anet_s2anet_conv_2x_dota/SIR_33.py
@@ -116,7 +116,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Det_cases/semi_det_baseline_fcos_r50_fpn_2x_coco_sup005/SIR_33.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Det_cases/semi_det_baseline_fcos_r50_fpn_2x_coco_sup005/SIR_33.py
@@ -117,7 +117,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Det_cases/semi_det_baseline_retinanet_r50_fpn_2x_coco_sup010/SIR_33.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Det_cases/semi_det_baseline_retinanet_r50_fpn_2x_coco_sup010/SIR_33.py
@@ -117,7 +117,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Det_cases/semi_det_baseline_retinanet_r50_fpn_2x_coco_sup010/SIR_34.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Det_cases/semi_det_baseline_retinanet_r50_fpn_2x_coco_sup010/SIR_34.py
@@ -216,7 +216,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Det_cases/sniper_faster_rcnn_r50_fpn_1x_sniper_visdrone/SIR_33.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Det_cases/sniper_faster_rcnn_r50_fpn_1x_sniper_visdrone/SIR_33.py
@@ -122,7 +122,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Det_cases/sniper_faster_rcnn_r50_fpn_1x_sniper_visdrone/SIR_54.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Det_cases/sniper_faster_rcnn_r50_fpn_1x_sniper_visdrone/SIR_54.py
@@ -61,7 +61,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Det_cases/sniper_faster_rcnn_r50_fpn_1x_visdrone/SIR_33.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Det_cases/sniper_faster_rcnn_r50_fpn_1x_visdrone/SIR_33.py
@@ -122,7 +122,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Det_cases/sniper_faster_rcnn_r50_fpn_1x_visdrone/SIR_54.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Det_cases/sniper_faster_rcnn_r50_fpn_1x_visdrone/SIR_54.py
@@ -61,7 +61,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Det_cases/solov2_solov2_r50_enhance_coco/SIR_34.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Det_cases/solov2_solov2_r50_enhance_coco/SIR_34.py
@@ -122,7 +122,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Det_cases/sparse_rcnn_sparse_rcnn_r50_fpn_3x_pro300_coco/SIR_33.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Det_cases/sparse_rcnn_sparse_rcnn_r50_fpn_3x_pro300_coco/SIR_33.py
@@ -122,7 +122,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Det_cases/ssd_ssd_vgg16_300_240e_voc/SIR_3.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Det_cases/ssd_ssd_vgg16_300_240e_voc/SIR_3.py
@@ -181,7 +181,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Det_cases/yolov3_yolov3_mobilenet_v1_roadsign/SIR_45.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Det_cases/yolov3_yolov3_mobilenet_v1_roadsign/SIR_45.py
@@ -67,7 +67,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Ocr_cases/det_ch_PP_OCRv3_ch_PP_OCRv3_det_cml/SIR_30.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Ocr_cases/det_ch_PP_OCRv3_ch_PP_OCRv3_det_cml/SIR_30.py
@@ -277,7 +277,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Ocr_cases/det_ch_PP_OCRv3_ch_PP_OCRv3_det_cml/SIR_43.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Ocr_cases/det_ch_PP_OCRv3_ch_PP_OCRv3_det_cml/SIR_43.py
@@ -131,7 +131,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Ocr_cases/det_ch_PP_OCRv3_ch_PP_OCRv3_det_cml/SIR_53.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Ocr_cases/det_ch_PP_OCRv3_ch_PP_OCRv3_det_cml/SIR_53.py
@@ -277,7 +277,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Ocr_cases/det_ch_PP_OCRv3_ch_PP_OCRv3_det_cml/SIR_56.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Ocr_cases/det_ch_PP_OCRv3_ch_PP_OCRv3_det_cml/SIR_56.py
@@ -131,7 +131,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Seg_cases/danet_danet_resnet50_os8_cityscapes_1024x512_80k/SIR_34.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Seg_cases/danet_danet_resnet50_os8_cityscapes_1024x512_80k/SIR_34.py
@@ -73,7 +73,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Seg_cases/danet_danet_resnet50_os8_voc12aug_512x512_40k/SIR_34.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Seg_cases/danet_danet_resnet50_os8_voc12aug_512x512_40k/SIR_34.py
@@ -73,7 +73,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Seg_cases/espnet_espnet_cityscapes_1024x512_120k/SIR_143.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Seg_cases/espnet_espnet_cityscapes_1024x512_120k/SIR_143.py
@@ -52,7 +52,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Seg_cases/mobileseg_mobileseg_litehrnet18_cityscapes_1024x512_80k/SIR_199.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Seg_cases/mobileseg_mobileseg_litehrnet18_cityscapes_1024x512_80k/SIR_199.py
@@ -139,7 +139,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Seg_cases/mobileseg_mobileseg_litehrnet18_cityscapes_1024x512_80k/SIR_284.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Seg_cases/mobileseg_mobileseg_litehrnet18_cityscapes_1024x512_80k/SIR_284.py
@@ -175,7 +175,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Seg_cases/mobileseg_mobileseg_litehrnet18_cityscapes_1024x512_80k/SIR_59.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Seg_cases/mobileseg_mobileseg_litehrnet18_cityscapes_1024x512_80k/SIR_59.py
@@ -103,7 +103,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Seg_cases/unet_plusplus_unet_plusplus_cityscapes_1024x512_160k/SIR_22.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer_search90plus/Seg_cases/unet_plusplus_unet_plusplus_cityscapes_1024x512_160k/SIR_22.py
@@ -83,7 +83,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer_search90plusplus/Det_cases/faster_rcnn_faster_rcnn_r101_fpn_2x_coco/SIR_33.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer_search90plusplus/Det_cases/faster_rcnn_faster_rcnn_r101_fpn_2x_coco/SIR_33.py
@@ -122,7 +122,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer_search90plusplus/Det_cases/faster_rcnn_faster_rcnn_r101_fpn_2x_coco/SIR_54.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer_search90plusplus/Det_cases/faster_rcnn_faster_rcnn_r101_fpn_2x_coco/SIR_54.py
@@ -61,7 +61,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer_search90plusplus/Det_cases/faster_rcnn_faster_rcnn_swin_tiny_fpn_1x_coco/SIR_85.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer_search90plusplus/Det_cases/faster_rcnn_faster_rcnn_swin_tiny_fpn_1x_coco/SIR_85.py
@@ -122,7 +122,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer_search90plusplus/Det_cases/faster_rcnn_faster_rcnn_swin_tiny_fpn_2x_coco/SIR_106.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer_search90plusplus/Det_cases/faster_rcnn_faster_rcnn_swin_tiny_fpn_2x_coco/SIR_106.py
@@ -61,7 +61,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer_search90plusplus/Det_cases/faster_rcnn_faster_rcnn_swin_tiny_fpn_2x_coco/SIR_85.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer_search90plusplus/Det_cases/faster_rcnn_faster_rcnn_swin_tiny_fpn_2x_coco/SIR_85.py
@@ -122,7 +122,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer_search90plusplus/Det_cases/hrnet_faster_rcnn_hrnetv2p_w18_2x_coco/SIR_29.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer_search90plusplus/Det_cases/hrnet_faster_rcnn_hrnetv2p_w18_2x_coco/SIR_29.py
@@ -81,7 +81,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer_search90plusplus/Det_cases/hrnet_faster_rcnn_hrnetv2p_w18_2x_coco/SIR_60.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer_search90plusplus/Det_cases/hrnet_faster_rcnn_hrnetv2p_w18_2x_coco/SIR_60.py
@@ -49,7 +49,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer_search90plusplus/Det_cases/mask_rcnn_mask_rcnn_x101_vd_64x4d_fpn_2x_coco/SIR_111.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer_search90plusplus/Det_cases/mask_rcnn_mask_rcnn_x101_vd_64x4d_fpn_2x_coco/SIR_111.py
@@ -61,7 +61,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer_search90plusplus/Det_cases/mask_rcnn_mask_rcnn_x101_vd_64x4d_fpn_2x_coco/SIR_35.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer_search90plusplus/Det_cases/mask_rcnn_mask_rcnn_x101_vd_64x4d_fpn_2x_coco/SIR_35.py
@@ -122,7 +122,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer_search90plusplus/Det_cases/mask_rcnn_mask_rcnn_x101_vd_64x4d_fpn_2x_coco/SIR_56.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer_search90plusplus/Det_cases/mask_rcnn_mask_rcnn_x101_vd_64x4d_fpn_2x_coco/SIR_56.py
@@ -61,7 +61,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer_search90plusplus/Det_cases/ppyolo_ppyolo_r50vd_dcn_voc/SIR_52.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer_search90plusplus/Det_cases/ppyolo_ppyolo_r50vd_dcn_voc/SIR_52.py
@@ -67,7 +67,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer_search90plusplus/Det_cases/rcnn_enhance_faster_rcnn_enhance_3x_coco/SIR_35.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer_search90plusplus/Det_cases/rcnn_enhance_faster_rcnn_enhance_3x_coco/SIR_35.py
@@ -122,7 +122,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer_search90plusplus/Det_cases/rcnn_enhance_faster_rcnn_enhance_3x_coco/SIR_56.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer_search90plusplus/Det_cases/rcnn_enhance_faster_rcnn_enhance_3x_coco/SIR_56.py
@@ -61,7 +61,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer_search90plusplus/Det_cases/retinanet_retinanet_r101_fpn_2x_coco/SIR_33.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer_search90plusplus/Det_cases/retinanet_retinanet_r101_fpn_2x_coco/SIR_33.py
@@ -117,7 +117,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer_search90plusplus/Det_cases/retinanet_retinanet_r101_fpn_2x_coco/SIR_34.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer_search90plusplus/Det_cases/retinanet_retinanet_r101_fpn_2x_coco/SIR_34.py
@@ -216,7 +216,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer_search90plusplus/Det_cases/retinanet_retinanet_r50_fpn_1x_coco/SIR_33.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer_search90plusplus/Det_cases/retinanet_retinanet_r50_fpn_1x_coco/SIR_33.py
@@ -117,7 +117,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer_search90plusplus/Det_cases/retinanet_retinanet_r50_fpn_1x_coco/SIR_34.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer_search90plusplus/Det_cases/retinanet_retinanet_r50_fpn_1x_coco/SIR_34.py
@@ -216,7 +216,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer_search90plusplus/Det_cases/rotate_s2anet_s2anet_conv_2x_dota/SIR_33.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer_search90plusplus/Det_cases/rotate_s2anet_s2anet_conv_2x_dota/SIR_33.py
@@ -116,7 +116,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer_search90plusplus/Det_cases/semi_det_baseline_retinanet_r50_fpn_2x_coco_sup010/SIR_33.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer_search90plusplus/Det_cases/semi_det_baseline_retinanet_r50_fpn_2x_coco_sup010/SIR_33.py
@@ -117,7 +117,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer_search90plusplus/Det_cases/semi_det_baseline_retinanet_r50_fpn_2x_coco_sup010/SIR_34.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer_search90plusplus/Det_cases/semi_det_baseline_retinanet_r50_fpn_2x_coco_sup010/SIR_34.py
@@ -216,7 +216,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer_search90plusplus/Det_cases/sniper_faster_rcnn_r50_fpn_1x_visdrone/SIR_33.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer_search90plusplus/Det_cases/sniper_faster_rcnn_r50_fpn_1x_visdrone/SIR_33.py
@@ -122,7 +122,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer_search90plusplus/Det_cases/sniper_faster_rcnn_r50_fpn_1x_visdrone/SIR_54.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer_search90plusplus/Det_cases/sniper_faster_rcnn_r50_fpn_1x_visdrone/SIR_54.py
@@ -61,7 +61,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer_search90plusplus/Det_cases/solov2_solov2_r50_enhance_coco/SIR_34.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer_search90plusplus/Det_cases/solov2_solov2_r50_enhance_coco/SIR_34.py
@@ -122,7 +122,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer_search90plusplus/Det_cases/sparse_rcnn_sparse_rcnn_r50_fpn_3x_pro300_coco/SIR_33.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer_search90plusplus/Det_cases/sparse_rcnn_sparse_rcnn_r50_fpn_3x_pro300_coco/SIR_33.py
@@ -122,7 +122,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer_search90plusplus/Ocr_cases/det_ch_PP_OCRv3_ch_PP_OCRv3_det_cml/SIR_30.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer_search90plusplus/Ocr_cases/det_ch_PP_OCRv3_ch_PP_OCRv3_det_cml/SIR_30.py
@@ -277,7 +277,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer_search90plusplus/Ocr_cases/det_ch_PP_OCRv3_ch_PP_OCRv3_det_cml/SIR_43.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer_search90plusplus/Ocr_cases/det_ch_PP_OCRv3_ch_PP_OCRv3_det_cml/SIR_43.py
@@ -131,7 +131,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer_search90plusplus/Ocr_cases/det_ch_PP_OCRv3_ch_PP_OCRv3_det_cml/SIR_53.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer_search90plusplus/Ocr_cases/det_ch_PP_OCRv3_ch_PP_OCRv3_det_cml/SIR_53.py
@@ -277,7 +277,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer_search90plusplus/Ocr_cases/det_ch_PP_OCRv3_ch_PP_OCRv3_det_cml/SIR_56.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer_search90plusplus/Ocr_cases/det_ch_PP_OCRv3_ch_PP_OCRv3_det_cml/SIR_56.py
@@ -131,7 +131,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer_search90plusplus/Seg_cases/danet_danet_resnet50_os8_cityscapes_1024x512_80k/SIR_34.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer_search90plusplus/Seg_cases/danet_danet_resnet50_os8_cityscapes_1024x512_80k/SIR_34.py
@@ -73,7 +73,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer_search90plusplus/Seg_cases/danet_danet_resnet50_os8_voc12aug_512x512_40k/SIR_34.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer_search90plusplus/Seg_cases/danet_danet_resnet50_os8_voc12aug_512x512_40k/SIR_34.py
@@ -73,7 +73,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer_search90plusplus/Seg_cases/espnet_espnet_cityscapes_1024x512_120k/SIR_143.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer_search90plusplus/Seg_cases/espnet_espnet_cityscapes_1024x512_120k/SIR_143.py
@@ -52,7 +52,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer_search90plusplus/Seg_cases/mobileseg_mobileseg_litehrnet18_cityscapes_1024x512_80k/SIR_199.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer_search90plusplus/Seg_cases/mobileseg_mobileseg_litehrnet18_cityscapes_1024x512_80k/SIR_199.py
@@ -139,7 +139,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer_search90plusplus/Seg_cases/mobileseg_mobileseg_litehrnet18_cityscapes_1024x512_80k/SIR_284.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer_search90plusplus/Seg_cases/mobileseg_mobileseg_litehrnet18_cityscapes_1024x512_80k/SIR_284.py
@@ -175,7 +175,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer_search90plusplus/Seg_cases/mobileseg_mobileseg_litehrnet18_cityscapes_1024x512_80k/SIR_59.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer_search90plusplus/Seg_cases/mobileseg_mobileseg_litehrnet18_cityscapes_1024x512_80k/SIR_59.py
@@ -103,7 +103,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)

--- a/framework/e2e/PaddleLT_new/layercase/sublayer_search90plusplus/Seg_cases/unet_plusplus_unet_plusplus_cityscapes_1024x512_160k/SIR_22.py
+++ b/framework/e2e/PaddleLT_new/layercase/sublayer_search90plusplus/Seg_cases/unet_plusplus_unet_plusplus_cityscapes_1024x512_160k/SIR_22.py
@@ -83,7 +83,7 @@ class TestLayer(unittest.TestCase):
         self.net = LayerCase()
     def train(self, net, to_static, with_prim=False, with_cinn=False):
         if to_static:
-            paddle.set_flags({'FLAGS_prim_all': with_prim})
+            paddle.base.core._set_prim_all_enabled(with_prim)
             if with_cinn:
                 assert with_prim, "with_cinn=True but with_prim=False is unsupported"
                 net = paddle.jit.to_static(net, backend="CINN", full_graph=True)


### PR DESCRIPTION
PaddlePaddle/Paddle#71837 重构了 prim flag 体系，删掉了 C++ flag `FLAGS_prim_all`，因此导致了 `set_flags({"FLAGS_prim_all": with_prim})` 形式不再被允许（但环境变量 `FLAGS_prim_all` 仍然有效，仅仅只是 `FLAGS_prim_all` 通过 `set_flags` 形式设置有问题而已）

本 PR 进行了如下两种转写：

使用 API 代替设置 flag：

```diff
-paddle.set_flags({'FLAGS_prim_all': with_prim})
+paddle.base.core._set_prim_all_enabled(with_prim)
```

将 `FLAGS_prim_all` 转发到 `FLAGS_prim_forward` 和 `FLAGS_prim_backward` 设置

```diff
 def SetEnvVar(env_var2value):
     for env_var, value in env_var2value.items():
         os.environ[env_var] = str(value)
+    if env_var2value.get("FLAGS_prim_all") is not None:
+        prim_all_value = env_var2value.pop("FLAGS_prim_all")
+        env_var2value["FLAGS_prim_forward"] = prim_all_value
+        env_var2value["FLAGS_prim_backward"] = prim_all_value
     paddle.set_flags({
         env_var:value
         for env_var, value in env_var2value.items()
         if env_var.startswith('FLAGS_')
     })
```

本 PR 需在 PaddlePaddle/Paddle#71837 前合入