### PR TITLE
[Dy2St][CINN] Explicit set backend to None in pure dy2st test cases

### DIFF
--- a/framework/e2e/PaddleLT_new/engine/paddle_eval.py
+++ b/framework/e2e/PaddleLT_new/engine/paddle_eval.py
@@ -110,7 +110,7 @@ class LayerEval(object):
         """dy2st eval"""
         data = self._net_input()
         net = self._net_instant()
-        st_net = paddle.jit.to_static(net, full_graph=True)
+        st_net = paddle.jit.to_static(net, backend=None, full_graph=True)
         st_net.eval()
         logit = st_net(*data)
         if self.return_net_instance == "True":
@@ -123,7 +123,7 @@ class LayerEval(object):
         data, input_spec = self._net_input_and_spec()
         Logger("dy2st_eval_inputspec").get_log().info(f"待测动态InputSpec为: {input_spec}")
         net = self._net_instant()
-        st_net = paddle.jit.to_static(net, full_graph=True, input_spec=input_spec)
+        st_net = paddle.jit.to_static(net, backend=None, full_graph=True, input_spec=input_spec)
         st_net.eval()
         logit = st_net(*data)
         if self.return_net_instance == "True":
@@ -136,7 +136,7 @@ class LayerEval(object):
         data, input_spec = self._net_input_and_static_spec()
         Logger("dy2st_eval_static_inputspec").get_log().info(f"待测静态InputSpec为: {input_spec}")
         net = self._net_instant()
-        st_net = paddle.jit.to_static(net, full_graph=True, input_spec=input_spec)
+        st_net = paddle.jit.to_static(net, backend=None, full_graph=True, input_spec=input_spec)
         st_net.eval()
         logit = st_net(*data)
         if self.return_net_instance == "True":

--- a/framework/e2e/PaddleLT_new/engine/paddle_eval_bm.py
+++ b/framework/e2e/PaddleLT_new/engine/paddle_eval_bm.py
@@ -115,7 +115,7 @@ class LayerEvalBM(object):
     def dy2st_eval_perf(self):
         """dygraph eval"""
         net = self._net_instant()
-        st_net = paddle.jit.to_static(net, full_graph=True)
+        st_net = paddle.jit.to_static(net, backend=None, full_graph=True)
         st_net.eval()
 
         def _perf(input_data):

--- a/framework/e2e/PaddleLT_new/engine/paddle_export.py
+++ b/framework/e2e/PaddleLT_new/engine/paddle_export.py
@@ -76,7 +76,7 @@ class LayerExport(object):
 
     def jit_save(self):
         """jit.save(layer)"""
-        st_net = paddle.jit.to_static(self._net_instant())
+        st_net = paddle.jit.to_static(self._net_instant(), backend=None)
         st_net.eval()
         st_net(*self._net_input())
 
@@ -90,7 +90,7 @@ class LayerExport(object):
         Logger("jit_save_inputspec").get_log().info(f"待测动态InputSpec为: {input_spec}")
 
         net = self._net_instant()
-        st_net = paddle.jit.to_static(net, full_graph=True, input_spec=input_spec)
+        st_net = paddle.jit.to_static(net, backend=None, full_graph=True, input_spec=input_spec)
         st_net.eval()
         # st_net(*self._net_input())
 
@@ -104,7 +104,7 @@ class LayerExport(object):
         Logger("jit_save_static_inputspec").get_log().info(f"待测静态InputSpec为: {input_spec}")
 
         net = self._net_instant()
-        st_net = paddle.jit.to_static(net, full_graph=True, input_spec=input_spec)
+        st_net = paddle.jit.to_static(net, backend=None, full_graph=True, input_spec=input_spec)
         st_net.eval()
         # st_net(*self._net_input())
 
@@ -130,7 +130,7 @@ class LayerExport(object):
         Logger("jit_save_cinn_inputspec").get_log().info(f"待测动态InputSpec为: {input_spec}")
         net = self._net_instant()
 
-        cinn_net = paddle.jit.to_static(net, full_graph=True, input_spec=input_spec)
+        cinn_net = paddle.jit.to_static(net, backend="CINN", full_graph=True, input_spec=input_spec)
         cinn_net.eval()
         # cinn_net(*self._net_input())
 
@@ -144,7 +144,7 @@ class LayerExport(object):
         Logger("jit_save_cinn_static_inputspec").get_log().info(f"待测静态InputSpec为: {input_spec}")
         net = self._net_instant()
 
-        cinn_net = paddle.jit.to_static(net, full_graph=True, input_spec=input_spec)
+        cinn_net = paddle.jit.to_static(net, backend="CINN", full_graph=True, input_spec=input_spec)
         cinn_net.eval()
         # cinn_net(*self._net_input())
 

--- a/framework/e2e/PaddleLT_new/engine/paddle_train.py
+++ b/framework/e2e/PaddleLT_new/engine/paddle_train.py
@@ -228,7 +228,7 @@ class LayerTrain(object):
         loss = self._net_loss()
 
         net.train()
-        st_net = paddle.jit.to_static(net, full_graph=True)
+        st_net = paddle.jit.to_static(net, backend=None, full_graph=True)
 
         # 构建optimizer用于训练
         if st_net.parameters():
@@ -260,7 +260,7 @@ class LayerTrain(object):
         loss = self._net_loss()
 
         net.train()
-        st_net = paddle.jit.to_static(net, full_graph=True, input_spec=input_spec)
+        st_net = paddle.jit.to_static(net, backend=None, full_graph=True, input_spec=input_spec)
 
         # 构建optimizer用于训练
         if st_net.parameters():
@@ -292,7 +292,7 @@ class LayerTrain(object):
         loss = self._net_loss()
 
         net.train()
-        st_net = paddle.jit.to_static(net, full_graph=True, input_spec=input_spec)
+        st_net = paddle.jit.to_static(net, backend=None, full_graph=True, input_spec=input_spec)
 
         # 构建optimizer用于训练
         if st_net.parameters():

--- a/framework/e2e/PaddleLT_new/engine/paddle_train_bm.py
+++ b/framework/e2e/PaddleLT_new/engine/paddle_train_bm.py
@@ -153,7 +153,7 @@ class LayerTrainBM(object):
         loss = self._net_loss()
 
         net.train()
-        st_net = paddle.jit.to_static(net, full_graph=True)
+        st_net = paddle.jit.to_static(net, backend=None, full_graph=True)
 
         # 构建optimizer用于训练
         if st_net.parameters():


### PR DESCRIPTION
在 `to_static` test cases 中明确添加 `backend=None` 以确保后续 backend 默认值设为 `"CINN"` 后仍能正常工作