### PR TITLE
delete error case in test_nonzero

### DIFF
--- a/framework/api/paddlebase/test_nonzero.py
+++ b/framework/api/paddlebase/test_nonzero.py
@@ -64,10 +64,12 @@ def test_nonzero2():
     x = paddle.to_tensor(np.array([[1.0, 1.0, 4.0], [0.0, 2.0, 0.0], [0.0, 0.0, 3.0]]).astype(np.float32))
     as_tuple_ = True
     outputs = paddle.nonzero(x, as_tuple_)
-    res = np.array([[[0], [0], [0], [1], [2]], [[0], [1], [2], [1], [2]]]).astype(np.int64)
-    for i in range(outputs.__len__()):
-        out = outputs[i].numpy()
-        npt.assert_allclose(out, res[i, :, :])
+    res = np.array([
+        [0, 0, 0, 1, 2],
+        [0, 1, 2, 1, 2]
+    ]).astype(np.int64)
+    outputs_np = np.stack([i.numpy() for i in outputs], axis=0)
+    npt.assert_allclose(outputs_np, res)
 
 
 @pytest.mark.api_base_nonzero_parameters
@@ -92,10 +94,9 @@ def test_nonzero4():
     x = paddle.to_tensor(np.array([2, 1, 0, 3]).astype(np.int32))
     as_tuple_ = True
     outputs = paddle.nonzero(x, as_tuple_)
-    res = np.array([[[0], [1], [3]]]).astype(np.int64)
-    for i in range(outputs.__len__()):
-        out = outputs[i].numpy()
-        npt.assert_allclose(out, res[i, :])
+    res = np.array([[0, 1, 3]]).astype(np.int64)
+    outputs_np = np.stack([i.numpy() for i in outputs], axis=0)
+    npt.assert_allclose(outputs_np, res)
 
 
 @pytest.mark.api_base_nonzero_parameters
@@ -153,12 +154,11 @@ def test_nonzero6():
     outputs = paddle.nonzero(x, as_tuple_)
     res = np.array(
         [
-            [[0.0], [0.0], [0.0], [0.0], [0.0], [1.0], [1.0], [1.0], [1.0], [1.0], [1.0], [2.0], [2.0], [2.0], [2.0]],
-            [[0.0], [0.0], [1.0], [1.0], [1.0], [0.0], [0.0], [0.0], [1.0], [1.0], [1.0], [0.0], [1.0], [1.0], [1.0]],
-            [[0.0], [0.0], [0.0], [1.0], [1.0], [0.0], [0.0], [1.0], [0.0], [1.0], [1.0], [0.0], [0.0], [1.0], [1.0]],
-            [[0.0], [1.0], [0.0], [0.0], [1.0], [0.0], [1.0], [1.0], [0.0], [0.0], [1.0], [0.0], [1.0], [0.0], [1.0]],
+            [0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2],
+            [0, 0, 1, 1, 1, 0, 0, 0, 1, 1, 1, 0, 1, 1, 1],
+            [0, 0, 0, 1, 1, 0, 0, 1, 0, 1, 1, 0, 0, 1, 1],
+            [0, 1, 0, 0, 1, 0, 1, 1, 0, 0, 1, 0, 1, 0, 1]
         ]
     ).astype(np.int64)
-    for i in range(outputs.__len__()):
-        out = outputs[i].numpy()
-        npt.assert_allclose(out, res[i, :, :])
+    outputs_np = np.stack([i.numpy() for i in outputs], axis=0)
+    npt.assert_allclose(outputs_np, res)


### PR DESCRIPTION
```python
import paddle
import numpy as np
import torch
import numpy.testing as npt

def test1(outputs, res):
    for i in range(outputs.__len__()):
        out = outputs[i].numpy()
        npt.assert_allclose(out, res[i, :, :])

def test2(outputs, res):
    for i in range(outputs.__len__()):
        out = outputs[i].numpy()
        npt.assert_allclose(out, res[i, :])

def test3(outputs, res):
    for i in range(outputs.__len__()):
        out = outputs[i].numpy()
        npt.assert_allclose(out, res[i, :, :])

np_1 = np.array([[1.0, 1.0, 4.0], [0.0, 2.0, 0.0], [0.0, 0.0, 3.0]]).astype(np.float32)
np_2 = np.array([2, 1, 0, 3]).astype(np.int32)
np_3 = np.array(
        [
            [[[1.0, 2.0], [0.0, 0.0]], [[5.0, 0.0], [7.0, 8.0]]],
            [[[9.0, 10.0], [0.0, 12.0]], [[13.0, 0.0], [15.0, 16.0]]],
            [[[17.0, 0.0], [0.0, 0.0]], [[0.0, 22.0], [23.0, 24.0]]],
        ]
    ).astype(np.float64)

# 修改前的结果
expected_1 = np.array([[[0], [0], [0], [1], [2]], [[0], [1], [2], [1], [2]]]).astype(np.int64)
expected_2 = np.array([[[0], [1], [3]]]).astype(np.int64)
expected_3 = np.array(
    [
        [[0.0], [0.0], [0.0], [0.0], [0.0], [1.0], [1.0], [1.0], [1.0], [1.0], [1.0], [2.0], [2.0], [2.0], [2.0]],
        [[0.0], [0.0], [1.0], [1.0], [1.0], [0.0], [0.0], [0.0], [1.0], [1.0], [1.0], [0.0], [1.0], [1.0], [1.0]],
        [[0.0], [0.0], [0.0], [1.0], [1.0], [0.0], [0.0], [1.0], [0.0], [1.0], [1.0], [0.0], [0.0], [1.0], [1.0]],
        [[0.0], [1.0], [0.0], [0.0], [1.0], [0.0], [1.0], [1.0], [0.0], [0.0], [1.0], [0.0], [1.0], [0.0], [1.0]],
    ]
).astype(np.int64)

# 修改后的结果
res_1 = np.array([
    [0, 0, 0, 1, 2],
    [0, 1, 2, 1, 2]
]).astype(np.int64)
res_2 = np.array([[0, 1, 3]]).astype(np.int64)
res_3 = np.array(
    [
        [0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2],
        [0, 0, 1, 1, 1, 0, 0, 0, 1, 1, 1, 0, 1, 1, 1],
        [0, 0, 0, 1, 1, 0, 0, 1, 0, 1, 1, 0, 0, 1, 1],
        [0, 1, 0, 0, 1, 0, 1, 1, 0, 0, 1, 0, 1, 0, 1]
    ]
).astype(np.int64)


paddle_tensor_1 = paddle.to_tensor(np_1)
paddle_result_1 = paddle.nonzero(paddle_tensor_1, as_tuple=True)

paddle_tensor_2 = paddle.to_tensor(np_2)
paddle_result_2 = paddle.nonzero(paddle_tensor_2, as_tuple=True)

paddle_tensor_3 = paddle.to_tensor(np_3)
paddle_result_3 = paddle.nonzero(paddle_tensor_3, as_tuple=True)


torch_tensor_1 = torch.tensor(np_1)
torch_result_1 = torch.nonzero(torch_tensor_1, as_tuple=True)

torch_tensor_2 = torch.tensor(np_2)
torch_result_2 = torch.nonzero(torch_tensor_2, as_tuple=True)

torch_tensor_3 = torch.tensor(np_3)
torch_result_3 = torch.nonzero(torch_tensor_3, as_tuple=True)

# 修改前的情况 (PR #72003 合入前):
# 仅有paddle能对上expected结果（错误测试结果）
# test1(paddle_result_1, expected_1)
# test2(paddle_result_2, expected_2)
# test3(paddle_result_3, expected_3)
# test1(torch_tensor_1, expected_1)
# test2(torch_tensor_2, expected_2)
# test3(torch_tensor_3, expected_3)

# 修改后的情况 (PR #72003 合入后):
# paddle、torch都能对上res结果
paddle_result_np_1 = np.stack([x.numpy() for x in paddle_result_1], axis=0)
paddle_result_np_2 = np.stack([x.numpy() for x in paddle_result_2], axis=0)
paddle_result_np_3 = np.stack([x.numpy() for x in paddle_result_3], axis=0)
torch_result_np_1 = np.stack([x.numpy() for x in torch_result_1], axis=0)
torch_result_np_2 = np.stack([x.numpy() for x in torch_result_2], axis=0)
torch_result_np_3 = np.stack([x.numpy() for x in torch_result_3], axis=0)

npt.assert_allclose(torch_result_np_1, res_1)
npt.assert_allclose(torch_result_np_2, res_2)
npt.assert_allclose(torch_result_np_3, res_3)
npt.assert_allclose(paddle_result_np_1, res_1)
npt.assert_allclose(paddle_result_np_2, res_2)
npt.assert_allclose(paddle_result_np_3, res_3)
```

相关[72003](https://github.com/PaddlePaddle/Paddle/pull/72003)
### 修改前的情况 (PR #72003 合入前):
```
expected_1 = np.array([[[0], [0], [0], [1], [2]], [[0], [1], [2], [1], [2]]]).astype(np.int64)
expected_2 = np.array([[[0], [1], [3]]]).astype(np.int64)
expected_3 = np.array(
    [
        [[0.0], [0.0], [0.0], [0.0], [0.0], [1.0], [1.0], [1.0], [1.0], [1.0], [1.0], [2.0], [2.0], [2.0], [2.0]],
        [[0.0], [0.0], [1.0], [1.0], [1.0], [0.0], [0.0], [0.0], [1.0], [1.0], [1.0], [0.0], [1.0], [1.0], [1.0]],
        [[0.0], [0.0], [0.0], [1.0], [1.0], [0.0], [0.0], [1.0], [0.0], [1.0], [1.0], [0.0], [0.0], [1.0], [1.0]],
        [[0.0], [1.0], [0.0], [0.0], [1.0], [0.0], [1.0], [1.0], [0.0], [0.0], [1.0], [0.0], [1.0], [0.0], [1.0]],
    ]
).astype(np.int64)
```
仅有paddle能对上expected结果（错误测试结果）,torch跑不通 test_nonzero2、test_nonzero4、test_nonzero6。
### 修改后的情况 (PR #72003 合入后):
```
res_1 = np.array([
    [0, 0, 0, 1, 2],
    [0, 1, 2, 1, 2]
]).astype(np.int64)
res_2 = np.array([[0, 1, 3]]).astype(np.int64)
res_3 = np.array(
    [
        [0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2],
        [0, 0, 1, 1, 1, 0, 0, 0, 1, 1, 1, 0, 1, 1, 1],
        [0, 0, 0, 1, 1, 0, 0, 1, 0, 1, 1, 0, 0, 1, 1],
        [0, 1, 0, 0, 1, 0, 1, 1, 0, 0, 1, 0, 1, 0, 1]
    ]
).astype(np.int64)
```
torch、paddle都能对上res的结果。