### PR TITLE
Update test_slogdet.py

### DIFF
--- a/framework/api/linalg/test_slogdet.py
+++ b/framework/api/linalg/test_slogdet.py
@@ -5,30 +5,47 @@
 test_slogdet
 """
 
-from apibase import APIBase
 import paddle
 import pytest
 import numpy as np
 
 
-class TestDet(APIBase):
+np.random.seed(22)
+paddle.seed(22)
+
+if paddle.is_compiled_with_cuda():
+    places = [paddle.CPUPlace(), paddle.CUDAPlace(0)]
+else:
+    places = [paddle.CPUPlace()]
+
+types = ["float32", "float64", "complex64", "complex128"]
+
+
+def cal_slogdet_api(x, dtype, place):
     """
-    test
+    calculate paddle.linalg.slogdet
     """
+    x = x.astype(dtype)
+    xp = paddle.to_tensor(x, dtype=dtype)
+    dynamic_res = paddle.linalg.slogdet(xp)
 
-    def hook(self):
-        """
-        implement
-        """
-        self.types = [np.float64, np.float32]
-        # self.debug = True
-        # self.static = True
-        # enable check grad
-        self.enable_backward = False
-        # self.delta = 1
+    paddle.enable_static()
+    main_program, startup_program = paddle.static.Program(), paddle.static.Program()
+    with paddle.utils.unique_name.guard():
+        with paddle.static.program_guard(main_program=main_program, startup_program=startup_program):
+            data0 = paddle.static.data(name="s0", shape=x.shape, dtype=dtype)
+            feed = {"s0": x}
+            out = paddle.linalg.slogdet(data0)
 
+            exe = paddle.static.Executor(place)
+            exe.run(startup_program)
+            static_res = exe.run(main_program, feed=feed, fetch_list=[out])
+    paddle.disable_static()
 
-obj = TestDet(paddle.linalg.slogdet)
+    assert np.allclose(dynamic_res[0].numpy(), static_res[0])
+    assert np.allclose(dynamic_res[1].numpy(), static_res[1])
+
+    return static_res
 
 
 @pytest.mark.api_linalg_slogdet_vartype
@@ -37,8 +54,13 @@ def test_slogdet_base():
     base
     """
     x = np.random.rand(14, 14) * 100
-    res = np.array(np.linalg.slogdet(x))
-    obj.base(res=res, x=x)
+    res = np.linalg.slogdet(x)
+
+    for place in places:
+        for dtype in types:
+            api_res = cal_slogdet_api(x, dtype, place)
+            assert np.allclose(res[0], api_res[0])
+            assert np.allclose(res[1], api_res[1])
 
 
 @pytest.mark.api_linalg_slogdet_parameters
@@ -47,8 +69,13 @@ def test_slogdet0():
     default
     """
     x = np.random.rand(4, 4)
-    res = np.array(np.linalg.slogdet(x))
-    obj.run(res=res, x=x)
+    res = np.linalg.slogdet(x)
+
+    for place in places:
+        for dtype in types:
+            api_res = cal_slogdet_api(x, dtype, place)
+            assert np.allclose(res[0], api_res[0])
+            assert np.allclose(res[1], api_res[1])
 
 
 @pytest.mark.api_linalg_slogdet_parameters
@@ -57,5 +84,10 @@ def test_slogdet1():
     multi_dim
     """
     x = np.random.rand(3, 4, 4)
-    res = np.array(np.linalg.slogdet(x))
-    obj.run(res=res, x=x)
+    res = np.linalg.slogdet(x)
+
+    for place in places:
+        for dtype in types:
+            api_res = cal_slogdet_api(x, dtype, place)
+            assert np.allclose(res[0], api_res[0])
+            assert np.allclose(res[1], api_res[1])


### PR DESCRIPTION
paddle.slogdet算子输出由 返回的是一个Tensor， Shape 为 [2, *]，到跟torch、numpy对齐，返回值为tuple(Tensor, Tensor)，即tuple(sign, logdet)。
相关PR：https://github.com/PaddlePaddle/Paddle/pull/72505

本地测试：
![image](https://github.com/user-attachments/assets/54873849-aeb3-4fe3-857d-f1c87c792e49)