### PR TITLE
Temporarily disable test_argmax10  and test_argmin10

### DIFF
--- a/framework/api/paddlebase/test_argmax.py
+++ b/framework/api/paddlebase/test_argmax.py
@@ -158,14 +158,14 @@ def test_argmax9():
     obj.exception(mode="c", etype="InvalidArgument", x=x, axis=axis)
 
 
-@pytest.mark.api_base_argmax_exception
-def test_argmax10():
-    """
-    axis = float
-    """
-    x = np.array([[-1], [2], [3]])
-    axis = float(1.0)
-    obj.exception(mode="python", etype=TypeError, x=x, axis=axis)
+# @pytest.mark.api_base_argmax_exception
+# def test_argmax10():
+#     """
+#     axis = float
+#     """
+#     x = np.array([[-1], [2], [3]])
+#     axis = float(1.0)
+#     obj.exception(mode="python", etype=TypeError, x=x, axis=axis)
 
 
 @pytest.mark.api_base_argmax_exception

--- a/framework/api/paddlebase/test_argmin.py
+++ b/framework/api/paddlebase/test_argmin.py
@@ -158,14 +158,14 @@ def test_argmin9():
     obj.exception(mode="c", etype="InvalidArgument", x=x, axis=axis)
 
 
-@pytest.mark.api_base_argmin_exception
-def test_argmin10():
-    """
-    axis = float
-    """
-    x = np.array([[-1], [2], [3]])
-    axis = float(1.0)
-    obj.exception(mode="python", etype=TypeError, x=x, axis=axis)
+# @pytest.mark.api_base_argmin_exception
+# def test_argmin10():
+#     """
+#     axis = float
+#     """
+#     x = np.array([[-1], [2], [3]])
+#     axis = float(1.0)
+#     obj.exception(mode="python", etype=TypeError, x=x, axis=axis)
 
 
 @pytest.mark.api_base_argmin_exception

--- a/framework/custom_device/paddlebase/test_argmax.py
+++ b/framework/custom_device/paddlebase/test_argmax.py
@@ -158,14 +158,14 @@ def test_argmax9():
     obj.exception(mode="c", etype="InvalidArgument", x=x, axis=axis)
 
 
-@pytest.mark.api_base_argmax_exception
-def test_argmax10():
-    """
-    axis = float
-    """
-    x = np.array([[-1], [2], [3]])
-    axis = float(1.0)
-    obj.exception(mode="python", etype=TypeError, x=x, axis=axis)
+# @pytest.mark.api_base_argmax_exception
+# def test_argmax10():
+#     """
+#     axis = float
+#     """
+#     x = np.array([[-1], [2], [3]])
+#     axis = float(1.0)
+#     obj.exception(mode="python", etype=TypeError, x=x, axis=axis)
 
 
 @pytest.mark.api_base_argmax_exception

--- a/framework/custom_device/paddlebase/test_argmin.py
+++ b/framework/custom_device/paddlebase/test_argmin.py
@@ -158,14 +158,14 @@ def test_argmin9():
     obj.exception(mode="c", etype="InvalidArgument", x=x, axis=axis)
 
 
-@pytest.mark.api_base_argmin_exception
-def test_argmin10():
-    """
-    axis = float
-    """
-    x = np.array([[-1], [2], [3]])
-    axis = float(1.0)
-    obj.exception(mode="python", etype=TypeError, x=x, axis=axis)
+# @pytest.mark.api_base_argmin_exception
+# def test_argmin10():
+#     """
+#     axis = float
+#     """
+#     x = np.array([[-1], [2], [3]])
+#     axis = float(1.0)
+#     obj.exception(mode="python", etype=TypeError, x=x, axis=axis)
 
 
 @pytest.mark.api_base_argmin_exception


### PR DESCRIPTION
paddle.argmax 和paddle.argmin下沉到C++实现。
原来python侧的一些错误检查也会下沉到C++，抛出的异常也由原来的TypeError变成了ValueError: (InvalidArgument)，因此临时禁用下[CE-Framework / Test]中有关TypeError的检查，等到下沉pr https://github.com/PaddlePaddle/Paddle/pull/74856 合入之后重新打开