### PR TITLE
Update test_ci_cache.py to handle prefix cache

### DIFF
--- a/framework/ServeTest/test_ci_cache.py
+++ b/framework/ServeTest/test_ci_cache.py
@@ -97,6 +97,9 @@ def test_prefix_cache_text():
     print("fastdeploy answer is :")
 
     try:
+        # prefix cache存在diff，跳过第一次请求
+        response = send_request(URL, payload)
+        chunks = get_stream_chunks(response)
         response = send_request(URL, payload)
         chunks = get_stream_chunks(response)
         # for idx, chunk in enumerate(chunks):
@@ -130,7 +133,7 @@ def test_prefix_cache_text():
         with open("/MODELDATA/baseline_cache_text.txt", "r", encoding="utf-8") as f:
             baseline = f.read()
         assert result == baseline, f"与baseline存在diff，result: {result}\n baseline: {baseline}"
-        # assert result_2 == baseline, f"与baseline存在diff，result: {result_2}\n baseline: {baseline}"
+        assert result_2 == baseline, f"与baseline存在diff，result: {result_2}\n baseline: {baseline}"
 
     prompt_tokens = chunks[-1]["usage"]["prompt_tokens"]
     cached_tokens = chunks[-1]["usage"]["prompt_tokens_details"]["cached_tokens"]


### PR DESCRIPTION
Added a comment to skip the first request when a prefix cache exists and corrected the assertion for result_2.