### PR TITLE
Fix BosClient upload API compatibility

### DIFF
--- a/publish_scripts/PypiIndexUpdate.py
+++ b/publish_scripts/PypiIndexUpdate.py
@@ -15,6 +15,12 @@ from baidubce.auth.bce_credentials import BceCredentials
 from baidubce.services.bos.bos_client import BosClient
 
 
+def _get_put_super_object_from_file(bos_client):
+    """Return the multipart upload method supported by the installed BCE SDK."""
+    if hasattr(bos_client, "put_super_object_from_file"):
+        return bos_client.put_super_object_from_file
+    return bos_client.put_super_obejct_from_file
+
 
 def VersionVerification():
     """
@@ -94,7 +100,7 @@ def upload2bos(bucket_name, file_name):
     linux_path = path.as_posix()
     object_key = linux_path
 
-    result = bos_client.put_super_obejct_from_file(
+    result = _get_put_super_object_from_file(bos_client)(
         bucket_name, object_key, file_name, chunk_size=100, thread_num=multiprocessing.cpu_count()
     )
     if result:

--- a/tools/bos_tools.py
+++ b/tools/bos_tools.py
@@ -22,12 +22,21 @@ secret_access_key = os.getenv("SK")
 config = BceClientConfiguration(credentials=BceCredentials(access_key_id, secret_access_key), endpoint=bos_host)
 bos_client = BosClient(config)
 
+
+def _get_put_super_object_from_file(bos_client):
+    """Return the multipart upload method supported by the installed BCE SDK."""
+    if hasattr(bos_client, "put_super_object_from_file"):
+        return bos_client.put_super_object_from_file
+    return bos_client.put_super_obejct_from_file
+
+
 def bos_upload(bucket_name, object_key, file_name):
-    result = bos_client.put_super_obejct_from_file(
+    result = _get_put_super_object_from_file(bos_client)(
         bucket_name, object_key, file_name, chunk_size=100, thread_num=multiprocessing.cpu_count()
     )
     if result:
         print("Upload success!")
+
 
 def bos_download_url(bucket_name, object_key):
     # 建议使用0.9.29版本的bce-python-sdk

--- a/tools/bos_upload.py
+++ b/tools/bos_upload.py
@@ -16,6 +16,13 @@ from baidubce.services.bos import canned_acl
 from baidubce.services.bos.bos_client import BosClient
 
 
+def _get_put_super_object_from_file(bos_client):
+    """Return the multipart upload method supported by the installed BCE SDK."""
+    if hasattr(bos_client, "put_super_object_from_file"):
+        return bos_client.put_super_object_from_file
+    return bos_client.put_super_obejct_from_file
+
+
 # 设置BosClient的Host，Access Key ID和Secret Access Key
 bos_host = "bj.bcebos.com"
 access_key_id = os.getenv("AK")
@@ -37,7 +44,7 @@ if fsize < 200:
 else:
     chunk_size = 100
 
-result = bos_client.put_super_obejct_from_file(
+result = _get_put_super_object_from_file(bos_client)(
     bucket_name, object_key, file_name, chunk_size=100, thread_num=multiprocessing.cpu_count()
 )
 if result:


### PR DESCRIPTION
## Motivation

[Paddle Model-Benchmark 流水线](https://github.com/PaddlePaddle/Paddle/pull/79516#issuecomment-5024354359) 使用新版 `bce-python-sdk` 时，`BosClient` 只提供拼写正确的 `put_super_object_from_file`；但 PaddleTest 的部分 workflow 仍固定在只提供旧 typo API `put_super_obejct_from_file` 的版本。

因此上传脚本需要同时兼容两代 API。

## Changes

- 为 `tools/bos_tools.py`、`tools/bos_upload.py` 和 `publish_scripts/PypiIndexUpdate.py` 增加兼容方法解析。
- 优先调用正式 API `put_super_object_from_file`，缺失时回退到旧 API `put_super_obejct_from_file`。
- 保持现有上传参数及 SDK 版本约束不变。

## Validation

- `git diff --check`
- `python3 -m compileall -q tools/bos_tools.py tools/bos_upload.py publish_scripts/PypiIndexUpdate.py`
- 使用 fake old/new/dual clients 验证三个兼容 helper，包含“同时存在时优先正式 API”的场景。
- 使用 PyPI 官方 wheel 中的真实 `BosClient` 验证：
  - `bce-python-sdk==0.8.74`、`0.9.29` 解析到旧 typo API；
  - `bce-python-sdk==0.9.67`、`0.9.72` 解析到正式 API。

未执行真实 BOS 上传：该操作需要 AK/SK 凭据，并会产生外部写入。

## Related Issues

- https://github.com/PaddlePaddle/Paddle/pull/79516#issuecomment-5024354359
